### PR TITLE
Update 'graph' in 'equivalent_content' with value from 'equivalent_conte...

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/writers/SeriesSummaryWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/SeriesSummaryWriter.java
@@ -20,7 +20,6 @@ public class SeriesSummaryWriter implements EntityWriter<Episode> {
     private final NumberToShortStringCodec idCodec;
     private final ContainerSummaryResolver containerSummaryResolver;
 
-
     public SeriesSummaryWriter(NumberToShortStringCodec idCodec, ContainerSummaryResolver containerSummaryResolver) {
         this.idCodec = checkNotNull(idCodec);
         this.containerSummaryResolver = checkNotNull(containerSummaryResolver);

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -276,7 +276,8 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
         return update(EQUIVALENT_CONTENT_TABLE)
                 .where(eq(SET_ID_KEY, graph.getId().longValue()))
                 .and(eq(CONTENT_ID_KEY, content.getId().longValue()))
-            .with(set(DATA_KEY, serialize(content)));
+                .with(set(DATA_KEY, serialize(content)))
+                .and(set(GRAPH_KEY, graphSerializer.serialize(graph)));
     }
 
     private ByteBuffer serialize(Content content) {


### PR DESCRIPTION
This is to make sure that the EquivalenceGraphs in equivalent content are consitent with the ones from equivalent_content_graph Cassandra table.
Assumes that equivalent_content_graph is the correct version of the graph.