### PR TITLE
Merge victim should take into account requested ID

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/equivalence/ApplicationEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/ApplicationEquivalentsMerger.java
@@ -3,9 +3,10 @@ package org.atlasapi.equivalence;
 import java.util.List;
 
 import org.atlasapi.application.ApplicationSources;
+import org.atlasapi.entity.Id;
 
 public interface ApplicationEquivalentsMerger<E extends Equivalable<E>> {
 
-    <T extends E> List<T> merge(Iterable<T> equivalents, ApplicationSources sources);
+    <T extends E> List<T> merge(Id id, Iterable<T> equivalents, ApplicationSources sources);
     
 }

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/DefaultMergingEquivalentsResolver.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/DefaultMergingEquivalentsResolver.java
@@ -30,6 +30,7 @@ public class DefaultMergingEquivalentsResolver<E extends Equivalable<E>>
             ApplicationSources sources, Set<Annotation> activeAnnotations) {
         ListenableFuture<ResolvedEquivalents<E>> unmerged
             = resolver.resolveIds(ids, sources.getEnabledReadSources(), activeAnnotations);
+        
         return Futures.transform(unmerged, mergeUsing(sources));
     }
 
@@ -38,16 +39,17 @@ public class DefaultMergingEquivalentsResolver<E extends Equivalable<E>>
         return new Function<ResolvedEquivalents<E>, ResolvedEquivalents<E>>() {
             @Override
             public ResolvedEquivalents<E> apply(ResolvedEquivalents<E> input) {
+                
                 ResolvedEquivalents.Builder<E> builder = ResolvedEquivalents.builder();
                 for (Map.Entry<Id, Collection<E>> entry : input.asMap().entrySet()) {
-                    builder.putEquivalents(entry.getKey(), merge(entry.getValue(), sources));
+                    builder.putEquivalents(entry.getKey(), merge(entry.getKey(), entry.getValue(), sources));
                 }
                 return builder.build();
             }
         };
     }
 
-    private Iterable<E> merge(Collection<E> equivs, ApplicationSources sources) {
-        return merger.merge(equivs, sources);
+    private Iterable<E> merge(Id id, Collection<E> equivs, ApplicationSources sources) {
+        return merger.merge(id, equivs, sources);
     }
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
@@ -15,6 +15,6 @@ public interface EquivalentsMergeStrategy<E extends Equivalable<E>> {
      * @param equivalents - a set of resources equivalent to chosen.
      * @return merged resources.
      */
-    <T extends E> T merge(T chosen, Iterable<T> equivalents, ApplicationSources sources);
+    <T extends E> T merge(T chosen, Iterable<? extends T> equivalents, ApplicationSources sources);
     
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -103,7 +103,7 @@ public class  OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Content> T merge(T chosen, final Iterable<T> equivalents, final ApplicationSources sources) {
+    public <T extends Content> T merge(T chosen, final Iterable<? extends T> equivalents, final ApplicationSources sources) {
         chosen.setId(lowestId(chosen));
         return chosen.accept(new ContentVisitorAdapter<T>() {
             

--- a/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
@@ -5,12 +5,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.atlasapi.application.ApplicationSources;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.Identifiable;
 import org.atlasapi.entity.Sourced;
 import org.atlasapi.entity.Sourceds;
 import org.atlasapi.equivalence.ApplicationEquivalentsMerger;
 import org.atlasapi.equivalence.Equivalable;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 
 public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
@@ -23,7 +28,7 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
     }
 
     @Override
-    public <T extends E> List<T> merge(Iterable<T> equivalents, ApplicationSources sources) {
+    public <T extends E> List<T> merge(final Id id, Iterable<T> equivalents, ApplicationSources sources) {
         if (!sources.isPrecedenceEnabled()) {
             return ImmutableList.copyOf(equivalents);
         }
@@ -33,9 +38,16 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
             return sortedEquivalents;
         }
         T chosen = sortedEquivalents.get(0);
-        ImmutableList<T> notChosen = sortedEquivalents.subList(1, sortedEquivalents.size());
+        T requested = Iterables.find(equivalents, idIs(id));
+        
+        if (chosen.getPublisher().equals(requested.getPublisher())) {
+            chosen = requested;
+        }
+        
+        Iterable<T> notChosen = Iterables.filter(sortedEquivalents, Predicates.not(idIs(chosen.getId())));
         return ImmutableList.of(strategy.merge(chosen, notChosen, sources));
     }
+    
 
     private boolean trivialMerge(ImmutableList<?> sortedEquivalents) {
         return sortedEquivalents.isEmpty() || sortedEquivalents.size() == 1;
@@ -43,6 +55,16 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
 
     private Ordering<Sourced> applicationEquivalentsOrdering(ApplicationSources sources) {
         return sources.publisherPrecedenceOrdering().onResultOf(Sourceds.toPublisher());
+    }
+    
+    private Predicate<Identifiable> idIs(final Id id) {
+        return new Predicate<Identifiable>() {
+
+            @Override
+            public boolean apply(Identifiable input) {
+                return input.getId().equals(id);
+            }
+        };
     }
 
 }


### PR DESCRIPTION
If the requested ID has the same source as the most precedent
piece of content, then requested ID content should be the
merge victim, such that its attributes are taken in preference
to other equivalent content in the set.