### PR TITLE
Separate precedence for hierarchies

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/model/translators/ApplicationModelTranslator.java
+++ b/atlas-core/src/main/java/org/atlasapi/model/translators/ApplicationModelTranslator.java
@@ -60,6 +60,7 @@ public class ApplicationModelTranslator implements Function<org.atlasapi.applica
                 .withPrecedence(input.precedenceEnabled())
                 .withReadableSources(reads)
                 .withWritableSources(input.writableSources().asList())
+                .withContentHierarchyPrecedence(input.contentHierarchyPrecedence().orNull())
                 .build()
                 .copyWithMissingSourcesPopulated();
     }
@@ -103,6 +104,8 @@ public class ApplicationModelTranslator implements Function<org.atlasapi.applica
             configuration = configuration.copyWithPrecedence(precedence);
         }
         configuration = configuration.copyWithWritableSources(input.getWrites());
+        configuration = configuration.copyWithContentHierarchyPrecedence(input.contentHierarchyPrecedence().orNull());
+        configuration = configuration.copyWithImagePrecedenceEnabled(input.imagePrecedenceEnabled());
         return configuration;
     }
     

--- a/atlas-core/src/main/java/org/atlasapi/util/ImmutableCollectors.java
+++ b/atlas-core/src/main/java/org/atlasapi/util/ImmutableCollectors.java
@@ -12,7 +12,7 @@ public class ImmutableCollectors {
                 ImmutableList.Builder::new,
                 ImmutableList.Builder::add,
                 (b1, b2) -> b1.addAll(b2.build()),
-                ImmutableList.Builder::build
+                (builder) -> builder.build()
         );
     }
 


### PR DESCRIPTION
Allow precedence ordering for merging of containers'
contents to be specified separately from the overall precedence
ordering.