### PR TITLE
Choose container with hiearchy during output merging

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -22,6 +22,9 @@ import org.atlasapi.content.Content;
 import org.atlasapi.content.MergingEquivalentsResolverBackedContainerSummaryResolver;
 import org.atlasapi.equivalence.DefaultMergingEquivalentsResolver;
 import org.atlasapi.equivalence.MergingEquivalentsResolver;
+import org.atlasapi.output.EquivalentSetContentHierarchyChooser;
+import org.atlasapi.output.FirstHierarchyContentHierarchyChooser;
+import org.atlasapi.output.MostPrecidentWithChildrenContentHierarchyChooser;
 import org.atlasapi.output.OutputContentMerger;
 import org.atlasapi.output.StrategyBackedEquivalentsMerger;
 import org.atlasapi.query.common.ContextualQueryExecutor;
@@ -82,7 +85,11 @@ public class QueryModule {
     }
 
     private StrategyBackedEquivalentsMerger<Content> equivalentsMerger() {
-        return new StrategyBackedEquivalentsMerger<Content>(new OutputContentMerger());
+        return new StrategyBackedEquivalentsMerger<Content>(new OutputContentMerger(contentHierarchyChooser()));
+    }
+    
+    private EquivalentSetContentHierarchyChooser contentHierarchyChooser() {
+        return new FirstHierarchyContentHierarchyChooser(new MostPrecidentWithChildrenContentHierarchyChooser());
     }
     
     @Qualifier("store")

--- a/atlas-core/src/main/java/org/atlasapi/output/EquivalentSetContentHierarchyChooser.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/EquivalentSetContentHierarchyChooser.java
@@ -1,0 +1,22 @@
+package org.atlasapi.output;
+
+import org.atlasapi.content.Container;
+
+import com.google.common.base.Optional;
+
+/**
+ * Strategy for selecting which container in an equivalent set should
+ * be used for series and items
+ *
+ */
+public interface EquivalentSetContentHierarchyChooser {
+
+    /**
+     * Select {@link Container} whose children should be used. 
+     * 
+     * @param containers    Containers in the equivalent set, ordered 
+     *                      by precedence
+     * @return              Chosen container, if one is suitable.
+     */
+    Optional<Container> chooseBestHierarchy(Iterable<Container> containers);
+}

--- a/atlas-core/src/main/java/org/atlasapi/output/FirstHierarchyContentHierarchyChooser.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/FirstHierarchyContentHierarchyChooser.java
@@ -1,0 +1,65 @@
+package org.atlasapi.output;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.atlasapi.content.Brand;
+import org.atlasapi.content.Container;
+import org.atlasapi.content.Series;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Iterables;
+
+/**
+ * A {@link EquivalentSetContentHierarchyChooser} that chooses the first 
+ * {@link Container} with a true brand/series/episode (or series/episode
+ * in the case of top-level series) hierarchy. If none is found, the order
+ * will be delegated to the provided fall-back
+ * {@link EquivalentSetContentHierarchyChooser}
+ *
+ */
+public class FirstHierarchyContentHierarchyChooser implements EquivalentSetContentHierarchyChooser {
+
+    private final EquivalentSetContentHierarchyChooser fallback;
+
+    public FirstHierarchyContentHierarchyChooser(EquivalentSetContentHierarchyChooser fallback) {
+        this.fallback = checkNotNull(fallback);
+    }
+    
+    @Override
+    public Optional<Container> chooseBestHierarchy(Iterable<Container> containers) {
+        Optional<Container> best = Iterables.tryFind(containers, HAS_HIERARCHY);
+        
+        if (best.isPresent()) {
+            return best;
+        }
+        
+        return fallback.chooseBestHierarchy(containers);
+    }
+    
+    private static final Predicate<Container> HAS_HIERARCHY = new Predicate<Container>() {
+
+        @Override
+        public boolean apply(Container input) {
+            if (input == null) {
+                return false;
+            }
+            if (input instanceof Series) {
+                Series series = (Series) input;
+                return series.getItemRefs() != null 
+                        && !series.getItemRefs().isEmpty();
+            }
+            if (input instanceof Brand) {
+                Brand brand = (Brand) input;
+                return brand.getSeriesRefs() != null 
+                        && !brand.getSeriesRefs().isEmpty();
+            }
+            throw new IllegalArgumentException("Container of type " + input.getClass().getName() + " needs to be supported");
+        }
+        
+    };
+
+}

--- a/atlas-core/src/main/java/org/atlasapi/output/MostPrecidentWithChildrenContentHierarchyChooser.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/MostPrecidentWithChildrenContentHierarchyChooser.java
@@ -1,0 +1,27 @@
+package org.atlasapi.output;
+
+import org.atlasapi.content.Container;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+
+/**
+ * A {@link EquivalentSetContentHierarchyChooser} that chooses the first 
+ * {@link Container}, according to the order provided, with children will 
+ * be chosen.
+ *
+ */
+public class MostPrecidentWithChildrenContentHierarchyChooser implements EquivalentSetContentHierarchyChooser {
+
+    @Override
+    public Optional<Container> chooseBestHierarchy(Iterable<Container> containers) {
+        return Iterables.tryFind(containers,
+                                 Predicates.and(
+                                         Predicates.notNull(),
+                                         (Container input) -> input.getItemRefs() != null &&
+                                                              !input.getItemRefs().isEmpty())
+                                );
+    }
+
+}

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -21,7 +21,8 @@ import com.google.common.collect.Iterables;
 
 public class BroadcastMergingTest {
 
-    private final OutputContentMerger executor = new OutputContentMerger();
+    //TODO mock hierarchy chooser
+    private final OutputContentMerger executor = new OutputContentMerger(new MostPrecidentWithChildrenContentHierarchyChooser());
     private final ApplicationSources sources = ApplicationSources.defaults()
             .copy().withPrecedence(true)
             .withReadableSources(ImmutableList.of(

--- a/atlas-core/src/test/java/org/atlasapi/output/FirstHierarchyContentHierarchyChooserTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/FirstHierarchyContentHierarchyChooserTest.java
@@ -1,0 +1,84 @@
+package org.atlasapi.output;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.atlasapi.content.Brand;
+import org.atlasapi.content.Container;
+import org.atlasapi.content.ItemRef;
+import org.atlasapi.content.Series;
+import org.atlasapi.content.SeriesRef;
+import org.atlasapi.entity.Id;
+import org.atlasapi.media.entity.Publisher;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FirstHierarchyContentHierarchyChooserTest {
+
+    @Mock
+    private EquivalentSetContentHierarchyChooser fallback;
+    
+    @InjectMocks
+    private FirstHierarchyContentHierarchyChooser underTest;
+    
+    @Test
+    public void testFirstBrandWithHierarchyChosen() {
+        Brand mostPrecedentWithoutSeries = brand(123L);
+        
+        Brand lessPrecedentWithSeries = brand(456L);
+        lessPrecedentWithSeries.setSeriesRefs(ImmutableSet.of(seriesRef(4L)));
+        
+        Optional<Container> chosen = underTest.chooseBestHierarchy(ImmutableList.of(mostPrecedentWithoutSeries, lessPrecedentWithSeries));
+        
+        assertThat(chosen.get(), is(lessPrecedentWithSeries));
+    }
+    
+    @Test
+    public void testFallbackUsedIfNoHiearchyFound() {
+        Brand mostPrecedentWithoutSeries = brand(123L);
+        Brand lessPrecedentWithoutSeries = brand(456L);
+        
+        ImmutableList<Container> containers = ImmutableList.of(mostPrecedentWithoutSeries, lessPrecedentWithoutSeries);
+        underTest.chooseBestHierarchy(containers);
+        
+        verify(fallback).chooseBestHierarchy(containers);
+    }
+    
+    @Test
+    public void testFirstSeriesWithChildrenChosen() {
+        Series series = series(123L);
+        series.setItemRefs(ImmutableSet.of(itemRef(789L)));
+        Brand lessPrecedentBrand = brand(456L);
+        
+        Optional<Container> chosen = underTest.chooseBestHierarchy(ImmutableList.of(series, lessPrecedentBrand));
+        
+        assertThat(chosen.get(), is(series));
+    }
+
+    private Brand brand(long id) {
+        return new Brand(Id.valueOf(id), Publisher.METABROADCAST);
+    }
+    
+    private Series series(long id) {
+        return new Series(Id.valueOf(id), Publisher.METABROADCAST);
+    }
+    
+    private SeriesRef seriesRef(long id) {
+        return new SeriesRef(Id.valueOf(id), Publisher.METABROADCAST, "", 1, DateTime.now());
+    }
+    
+    private ItemRef itemRef(long id) {
+        return new ItemRef(Id.valueOf(id), Publisher.METABROADCAST, "1", DateTime.now());
+    }
+    
+}

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -48,7 +48,8 @@ import com.metabroadcast.common.intl.Countries;
 
 public class OutputContentMergerTest {
 
-    private final OutputContentMerger merger = new OutputContentMerger();
+    //TODO mock hierarchy chooser
+    private final OutputContentMerger merger = new OutputContentMerger(new MostPrecidentWithChildrenContentHierarchyChooser());
 
     @Test
     public void testSortOfCommonSourceContentIsStable() {


### PR DESCRIPTION
From an equivalent set of containers, choose the first
one that has a true hierarchy (brand/series/episode),
if there is one, in preference to flat (brand/episode)
structure.