### PR TITLE
Mbst 13222 adding separate score reasons

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
@@ -125,12 +125,18 @@ final class ContentDeserializationVisitor implements ContentVisitor<Content> {
             described.setSpecialization(Specialization.valueOf(msg.getSpecialization().toUpperCase()));
         }
         if (msg.hasPriority()) {
-            Priority priority = new Priority(msg.getPriority(), ImmutableList.of("Legacy priority"));
+            Priority priority = new Priority(msg.getPriority(), new PriorityScoreReasons(
+                    ImmutableList.of("Legacy priority"),
+                    ImmutableList.of("Legacy priority")
+            ));
             described.setPriority(priority);
         }
         if (msg.hasPriorities()) {
             ContentProtos.Priority priorities = msg.getPriorities();
-            Priority priority = new Priority(priorities.getScore(), priorities.getReasonsList());
+            Priority priority = new Priority(priorities.getScore(), new PriorityScoreReasons(
+                    priorities.getPositiveReasonsList(),
+                    priorities.getNegativeReasonsList()
+            ));
             described.setPriority(priority);
         }
         if(msg.hasActivelyPublished()) {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -133,18 +133,19 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
         for (RelatedLink relatedLink : content.getRelatedLinks()) {
             builder.addRelatedLink(relatedLinkSerializer.serialize(relatedLink));
         }
-        if (content.getPriority() != null) {
+        Priority priority = content.getPriority();
+        if (priority != null) {
             ContentProtos.Priority.Builder priorityBuilder = ContentProtos.Priority.newBuilder();
-            Priority priority = content.getPriority();
             if (priority.getPriority() != null) {
                 priorityBuilder.setScore(priority.getPriority());
-                if (priority.getReasons() != null) {
-                    if (priority.getReasons().getPositive() != null) {
-                        priorityBuilder.addAllPositiveReasons(priority.getReasons().getPositive());
-                    }
-                    if (priority.getReasons().getNegative() != null) {
-                        priorityBuilder.addAllNegativeReasons(priority.getReasons().getNegative());
-                    }
+            }
+            PriorityScoreReasons scoreReasons = priority.getReasons();
+            if (scoreReasons != null) {
+                if (scoreReasons.getPositive() != null) {
+                    priorityBuilder.addAllPositiveReasons(scoreReasons.getPositive());
+                }
+                if (scoreReasons.getNegative() != null) {
+                    priorityBuilder.addAllNegativeReasons(scoreReasons.getNegative());
                 }
             }
             builder.setPriorities(priorityBuilder.build());

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -137,10 +137,15 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
             ContentProtos.Priority.Builder priorityBuilder = ContentProtos.Priority.newBuilder();
             Priority priority = content.getPriority();
             if (priority.getPriority() != null) {
-                priorityBuilder.addAllReasons(priority.getReasons());
-            }
-            if (priority.getPriority() != null) {
                 priorityBuilder.setScore(priority.getPriority());
+                if (priority.getReasons() != null) {
+                    if (priority.getReasons().getPositive() != null) {
+                        priorityBuilder.addAllPositiveReasons(priority.getReasons().getPositive());
+                    }
+                    if (priority.getReasons().getNegative() != null) {
+                        priorityBuilder.addAllNegativeReasons(priority.getReasons().getNegative());
+                    }
+                }
             }
             builder.setPriorities(priorityBuilder.build());
         }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/PrioritySerializer.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/PrioritySerializer.java
@@ -10,8 +10,15 @@ public class PrioritySerializer implements Serializer<Priority, CommonProtos.Pri
         CommonProtos.Priority.Builder builder = CommonProtos.Priority.newBuilder();
 
         if(source.getReasons() != null) {
-            for (String reason : source.getReasons()) {
-                builder.addReason(reason);
+            if (source.getReasons().getPositive() != null) {
+                for (String reason : source.getReasons().getPositive()) {
+                    builder.addPositiveReasons(reason);
+                }
+            }
+            if (source.getReasons().getNegative() != null) {
+                for (String reason : source.getReasons().getNegative()) {
+                    builder.addNegativeReasons(reason);
+                }
             }
         }
         if(source.getPriority() != null) {
@@ -28,7 +35,10 @@ public class PrioritySerializer implements Serializer<Priority, CommonProtos.Pri
         if(serialized.hasPriority()) {
             target.setPriority(serialized.getPriority());
         }
-        target.setReasons(serialized.getReasonList());
+        target.setReasons(new PriorityScoreReasons(
+                serialized.getPositiveReasonsList(),
+                serialized.getNegativeReasonsList()
+        ));
 
         return target;
     }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/PrioritySerializer.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/PrioritySerializer.java
@@ -9,14 +9,15 @@ public class PrioritySerializer implements Serializer<Priority, CommonProtos.Pri
     public CommonProtos.Priority serialize(Priority source) {
         CommonProtos.Priority.Builder builder = CommonProtos.Priority.newBuilder();
 
-        if(source.getReasons() != null) {
-            if (source.getReasons().getPositive() != null) {
-                for (String reason : source.getReasons().getPositive()) {
+        PriorityScoreReasons scoreReasons = source.getReasons();
+        if(scoreReasons != null) {
+            if (scoreReasons.getPositive() != null) {
+                for (String reason : scoreReasons.getPositive()) {
                     builder.addPositiveReasons(reason);
                 }
             }
-            if (source.getReasons().getNegative() != null) {
-                for (String reason : source.getReasons().getNegative()) {
+            if (scoreReasons.getNegative() != null) {
+                for (String reason : scoreReasons.getNegative()) {
                     builder.addNegativeReasons(reason);
                 }
             }

--- a/atlas-cassandra/src/main/protobuf/common.proto
+++ b/atlas-cassandra/src/main/protobuf/common.proto
@@ -118,9 +118,10 @@ message Synopses {
 }
 
 message Priority {
-    repeated string positive_reasons = 1;
+    repeated string reason = 1 [deprecated = true];
     optional double priority = 2;
-    repeated string negative_reasons = 3;
+    repeated string positive_reasons = 3;
+    repeated string negative_reasons = 4;
 }
 
 message Image {

--- a/atlas-cassandra/src/main/protobuf/common.proto
+++ b/atlas-cassandra/src/main/protobuf/common.proto
@@ -118,8 +118,9 @@ message Synopses {
 }
 
 message Priority {
-    repeated string reason = 1;
+    repeated string positive_reasons = 1;
     optional double priority = 2;
+    repeated string negative_reasons = 3;
 }
 
 message Image {

--- a/atlas-cassandra/src/main/protobuf/content.proto
+++ b/atlas-cassandra/src/main/protobuf/content.proto
@@ -119,8 +119,9 @@ message Restriction {
 
 message Priority {
     optional double score = 1;
-    repeated string positive_reasons = 2;
-    repeated string negative_reasons = 3;
+    repeated string reasons = 2 [deprecated = true];
+    repeated string positive_reasons = 3;
+    repeated string negative_reasons = 4;
 }
 
 message Summary {

--- a/atlas-cassandra/src/main/protobuf/content.proto
+++ b/atlas-cassandra/src/main/protobuf/content.proto
@@ -119,7 +119,8 @@ message Restriction {
 
 message Priority {
     optional double score = 1;
-    repeated string reasons = 2;
+    repeated string positive_reasons = 2;
+    repeated string negative_reasons = 3;
 }
 
 message Summary {

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/PrioritySerializerTest.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/PrioritySerializerTest.java
@@ -20,7 +20,10 @@ public class PrioritySerializerTest {
 
     @Test
     public void testSerialization() throws Exception {
-        Priority expected = new Priority(0.0, Lists.newArrayList("reason"));
+        Priority expected = new Priority(0.0, new PriorityScoreReasons(
+                Lists.newArrayList("Positive reason"),
+                Lists.newArrayList("Negative reason")
+        ));
 
         CommonProtos.Priority serialized = serializer.serialize(expected);
 
@@ -28,6 +31,8 @@ public class PrioritySerializerTest {
 
         assertThat(actual.getPriority(), is(expected.getPriority()));
         assertThat(actual.getReasons(), is(expected.getReasons()));
+        assertThat(actual.getReasons().getPositive(), is(expected.getReasons().getPositive()));
+        assertThat(actual.getReasons().getNegative(), is(expected.getReasons().getNegative()));
     }
 
     @Test
@@ -38,7 +43,7 @@ public class PrioritySerializerTest {
 
         Priority actual = serializer.deserialize(serialized);
 
-        expected.setReasons(Lists.newArrayList());
+        expected.setReasons(new PriorityScoreReasons(Lists.newArrayList(), Lists.newArrayList()));
         assertThat(actual.getPriority(), is(expected.getPriority()));
         assertThat(actual.getReasons(), is(expected.getReasons()));
     }


### PR DESCRIPTION
Added changes to common.proto and content.proto to have two separate list for Priority score reasons.
Furthermore updated following classes for serialisation and deserialisation:
PrioritySerializer
ContentSerializationVisitor
ContentDeserializationVisitor
Updated tests:
PrioritySerializer