### PR TITLE
Added endpoint for deactivating third party credentials

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
@@ -63,7 +63,7 @@ public class UsersController {
             NumberToShortStringCodec idCodec,
             UserFetcher userFetcher,
             UserStore userStore,
-            MongoDBCredentialsStore credentialsStore,
+            CredentialsStore credentialsStore,
             Clock clock) {
         this.requestParser = requestParser;
         this.queryExecutor = queryExecutor;
@@ -73,7 +73,7 @@ public class UsersController {
         this.userFetcher = userFetcher;
         this.userStore = userStore;
         this.clock = clock;
-        this.credentialsStore = credentialsStore;
+        this.credentialsStore = (MongoDBCredentialsStore) credentialsStore;
     }
 
     @RequestMapping({ "/4/users/{uid}.*", "/4/users.*" })
@@ -163,6 +163,7 @@ public class UsersController {
         ResponseWriter writer = null;
         try {
             User editingUser = userFetcher.userFor(request).get();
+
             if (!editingUser.is(Role.ADMIN)) {
                 throw new ResourceForbiddenException();
             }

--- a/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
@@ -63,7 +63,7 @@ public class UsersController {
             NumberToShortStringCodec idCodec,
             UserFetcher userFetcher,
             UserStore userStore,
-            CredentialsStore credentialsStore,
+            MongoDBCredentialsStore credentialsStore,
             Clock clock) {
         this.requestParser = requestParser;
         this.queryExecutor = queryExecutor;
@@ -73,7 +73,7 @@ public class UsersController {
         this.userFetcher = userFetcher;
         this.userStore = userStore;
         this.clock = clock;
-        this.credentialsStore = (MongoDBCredentialsStore) credentialsStore;
+        this.credentialsStore = credentialsStore;
     }
 
     @RequestMapping({ "/4/users/{uid}.*", "/4/users.*" })

--- a/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
@@ -27,13 +27,19 @@ import org.atlasapi.query.common.useraware.UserAwareQueryExecutor;
 import org.atlasapi.query.common.useraware.UserAwareQueryParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.google.common.base.Optional;
+import com.metabroadcast.common.base.Maybe;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.social.auth.credentials.Credentials;
+import com.metabroadcast.common.social.auth.credentials.CredentialsStore;
+import com.metabroadcast.common.social.auth.credentials.MongoDBCredentialsStore;
+import com.metabroadcast.common.social.model.UserRef;
 import com.metabroadcast.common.time.Clock;
 
 @Controller
@@ -47,6 +53,7 @@ public class UsersController {
     private final NumberToShortStringCodec idCodec;
     private final UserFetcher userFetcher;
     private final UserStore userStore;
+    private final MongoDBCredentialsStore credentialsStore;
     private final Clock clock;
     
     public UsersController(UserAwareQueryParser<User> requestParser,
@@ -56,6 +63,7 @@ public class UsersController {
             NumberToShortStringCodec idCodec,
             UserFetcher userFetcher,
             UserStore userStore,
+            CredentialsStore credentialsStore,
             Clock clock) {
         this.requestParser = requestParser;
         this.queryExecutor = queryExecutor;
@@ -65,6 +73,7 @@ public class UsersController {
         this.userFetcher = userFetcher;
         this.userStore = userStore;
         this.clock = clock;
+        this.credentialsStore = (MongoDBCredentialsStore) credentialsStore;
     }
 
     @RequestMapping({ "/4/users/{uid}.*", "/4/users.*" })
@@ -145,6 +154,33 @@ public class UsersController {
             ErrorSummary summary = ErrorSummary.forException(e);
             new ErrorResultWriter().write(summary, writer, request, response);
         }
+    }
+
+    @RequestMapping(value = "/4/users/deactivate/{uid}.*", method = RequestMethod.POST)
+    public void deactivateUser(HttpServletRequest request,
+            HttpServletResponse response,
+            @PathVariable String uid) throws IOException {
+        ResponseWriter writer = null;
+        try {
+            User editingUser = userFetcher.userFor(request).get();
+            if (!editingUser.is(Role.ADMIN)) {
+                throw new ResourceForbiddenException();
+            }
+            Id userId = Id.valueOf(idCodec.decode(uid));
+            Optional<User> user = userStore.userForId(userId);
+            if (user.isPresent()) {
+                UserRef userRef = user.get().getUserRef();
+                Credentials credentialsMaybe = credentialsStore.find(userRef).requireValue();
+                Credentials credentials = credentialsMaybe;
+                credentialsStore.expired(credentials.authToken());
+            } else {
+                throw new NotFoundException(userId);
+            }
+        } catch (Exception e) {
+            log.error("Request exception " + request.getRequestURI(), e);
+            ErrorSummary summary = ErrorSummary.forException(e);
+            new ErrorResultWriter().write(summary, writer, request, response);
+            }
     }
     
     private boolean isUserRoleChanged(User posted, User existing) {

--- a/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
@@ -170,8 +170,7 @@ public class UsersController {
             Optional<User> user = userStore.userForId(userId);
             if (user.isPresent()) {
                 UserRef userRef = user.get().getUserRef();
-                Credentials credentialsMaybe = credentialsStore.find(userRef).requireValue();
-                Credentials credentials = credentialsMaybe;
+                Credentials credentials = credentialsStore.find(userRef).requireValue();
                 credentialsStore.expired(credentials.authToken());
             } else {
                 throw new NotFoundException(userId);

--- a/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/users/UsersController.java
@@ -166,6 +166,7 @@ public class UsersController {
             if (!editingUser.is(Role.ADMIN)) {
                 throw new ResourceForbiddenException();
             }
+
             Id userId = Id.valueOf(idCodec.decode(uid));
             Optional<User> user = userStore.userForId(userId);
             if (user.isPresent()) {
@@ -179,7 +180,7 @@ public class UsersController {
             log.error("Request exception " + request.getRequestURI(), e);
             ErrorSummary summary = ErrorSummary.forException(e);
             new ErrorResultWriter().write(summary, writer, request, response);
-            }
+        }
     }
     
     private boolean isUserRoleChanged(User posted, User existing) {

--- a/atlas-api/src/main/java/org/atlasapi/application/www/ApplicationWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/www/ApplicationWebModule.java
@@ -282,6 +282,7 @@ public class ApplicationWebModule {
                 idCodec,
                 userFetcher(),
                 appPersistence.userStore(),
+                appPersistence.credentialsStore(),
                 new SystemClock());
     }
     


### PR DESCRIPTION
We need an endpoint that we can `POST` to which will deactivate a users third-party (Google/Github/Twitter) account from atlas admin.