### PR TITLE
Log when a messaging worker is processing message

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/messaging/ContentEquivalenceUpdatingWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/ContentEquivalenceUpdatingWorker.java
@@ -4,21 +4,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.annotation.Nullable;
 
-import com.codahale.metrics.Meter;
-import com.metabroadcast.common.queue.RecoverableException;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraphStore;
-
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.metabroadcast.common.queue.Worker;
 import org.atlasapi.system.bootstrap.workers.DirectAndExplicitEquivalenceMigrator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
+import com.metabroadcast.common.queue.Worker;
+
 public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAssertionMessage> {
 
-    private final Logger log = LoggerFactory.getLogger(ContentEquivalenceUpdatingWorker.class);
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ContentEquivalenceUpdatingWorker.class);
 
     private final EquivalenceGraphStore graphStore;
     private final DirectAndExplicitEquivalenceMigrator equivMigrator;
@@ -39,6 +40,9 @@ public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAsser
 
     @Override
     public void process(EquivalenceAssertionMessage message) throws RecoverableException {
+        LOG.debug("Processing message on id {}, message: {}", message.getSubject().getId(),
+                message);
+
         try {
             if (messageTimer != null) {
                 Timer.Context timer = messageTimer.time();
@@ -51,11 +55,11 @@ public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAsser
                         message.getPublishers());
                 equivMigrator.migrateEquivalence(message.getSubject());
             }
-            log.debug("Successfully processed message {}", message.toString());
+            LOG.debug("Successfully processed message {}", message.toString());
         } catch (WriteException e) {
             throw new RecoverableException("update failed for " + message.toString(), e);
         } catch (Exception e) {
-            log.warn("Error while processing EquivalenceAssertionMessage {}", message.toString(), e);
+            LOG.warn("Error while processing EquivalenceAssertionMessage {}", message.toString(), e);
             if (meter != null) {
                 meter.mark();
             }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorker.java
@@ -27,7 +27,8 @@ public class EquivalentContentIndexingContentWorker implements Worker<Equivalent
 
     private static final String METRICS_TIMER = "EquivalentContentIndexingContentWorker";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentContentIndexingContentWorker.class);
 
     private final ContentResolver contentResolver;
     private final ContentIndex contentIndex;
@@ -42,9 +43,9 @@ public class EquivalentContentIndexingContentWorker implements Worker<Equivalent
 
     @Override
     public void process(EquivalentContentUpdatedMessage message) throws RecoverableException {
-        log.debug("Processing message {}", message.toString());
-
         Id contentId = getContentId(message);
+
+        LOG.debug("Processing message on id {}, message: {}", contentId, message);
 
         Timer.Context time = timer.time();
         try {
@@ -67,7 +68,7 @@ public class EquivalentContentIndexingContentWorker implements Worker<Equivalent
 
         if (contentOptional.isPresent()) {
             Content content = contentOptional.get();
-            log.debug("Indexing message {}", content);
+            LOG.debug("Indexing message {}", content);
             contentIndex.index(content);
         }
     }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
@@ -1,34 +1,25 @@
 package org.atlasapi.messaging;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.metabroadcast.common.queue.RecoverableException;
-import com.metabroadcast.common.queue.Worker;
-import org.atlasapi.content.Content;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.atlasapi.content.ContentIndex;
-import org.atlasapi.content.ContentResolver;
-import org.atlasapi.content.IndexException;
-import org.atlasapi.entity.Id;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
+import org.atlasapi.util.ImmutableCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
+import com.metabroadcast.common.queue.Worker;
 
 public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceGraphUpdateMessage> {
 
     private static final String METRICS_TIMER = "EquivalentContentIndexingGraphWorker";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentContentIndexingContentWorker.class);
 
     private final ContentIndex contentIndex;
     private final Timer timer;
@@ -40,7 +31,14 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
 
     @Override
     public void process(EquivalenceGraphUpdateMessage message) throws RecoverableException {
-        log.debug("Processing message {}", message.toString());
+        LOG.debug(
+                "Processing message on ids {}, message: {}",
+                message.getGraphUpdate().getAllGraphs().stream()
+                        .map(EquivalenceGraph::getId)
+                        .collect(ImmutableCollectors.toList()),
+                message
+        );
+
         Timer.Context time = timer.time();
         try {
             for (EquivalenceGraph graph : message.getGraphUpdate().getAllGraphs()) {

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
@@ -20,7 +20,8 @@ import com.metabroadcast.common.queue.Worker;
 
 public class EquivalentContentStoreContentUpdateWorker implements Worker<ResourceUpdatedMessage> {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentContentStoreContentUpdateWorker.class);
 
     private final ContentResolver contentResolver;
 
@@ -39,6 +40,9 @@ public class EquivalentContentStoreContentUpdateWorker implements Worker<Resourc
 
     @Override
     public void process(ResourceUpdatedMessage message) throws RecoverableException {
+        LOG.debug("Processing message on id {}, message: {}",
+                message.getUpdatedResource().getId(), message);
+
         try {
             Timer.Context timer = messageTimer.time();
             ListenableFuture<Resolved<Content>> contentFuture = contentResolver.resolveIds(

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
@@ -4,20 +4,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.annotation.Nullable;
 
-import com.metabroadcast.common.queue.RecoverableException;
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.entity.util.WriteException;
+import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
+import org.atlasapi.util.ImmutableCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 
 public class EquivalentContentStoreGraphUpdateWorker implements Worker<EquivalenceGraphUpdateMessage> {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentContentStoreGraphUpdateWorker.class);
     
     private final EquivalentContentStore equivalentContentStore;
     private final Timer messageTimer;
@@ -30,6 +33,14 @@ public class EquivalentContentStoreGraphUpdateWorker implements Worker<Equivalen
 
     @Override
     public void process(EquivalenceGraphUpdateMessage message) throws RecoverableException {
+        LOG.debug(
+                "Processing message on ids {}, message: {}",
+                message.getGraphUpdate().getAllGraphs().stream()
+                        .map(EquivalenceGraph::getId)
+                        .collect(ImmutableCollectors.toList()),
+                message
+        );
+
         try {
             if (messageTimer != null) {
                 Timer.Context timer = messageTimer.time();

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorker.java
@@ -11,6 +11,8 @@ import org.atlasapi.content.Item;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
 import org.atlasapi.util.ImmutableCollectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -20,10 +22,12 @@ import com.metabroadcast.common.queue.Worker;
 
 public class EquivalentScheduleStoreContentUpdateWorker  implements Worker<EquivalentContentUpdatedMessage> {
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentScheduleStoreContentUpdateWorker.class);
+
     private final EquivalentContentStore contentStore;
     private final EquivalentScheduleWriter scheduleWriter;
     private final Timer messageTimer;
-
 
     public EquivalentScheduleStoreContentUpdateWorker(
             EquivalentContentStore contentStore,
@@ -37,6 +41,9 @@ public class EquivalentScheduleStoreContentUpdateWorker  implements Worker<Equiv
 
     @Override
     public void process(EquivalentContentUpdatedMessage message) throws RecoverableException {
+        LOG.debug("Processing message on id {}, message: {}",
+                message.getEquivalentSetId(), message);
+
         Set<Content> content = Futures.get(
                 contentStore.resolveEquivalentSet(message.getEquivalentSetId()),
                 RecoverableException.class

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreGraphUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreGraphUpdateWorker.java
@@ -2,22 +2,25 @@ package org.atlasapi.messaging;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.metabroadcast.common.queue.RecoverableException;
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.util.WriteException;
+import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
+import org.atlasapi.util.ImmutableCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
-
-import javax.annotation.Nullable;
 
 public class EquivalentScheduleStoreGraphUpdateWorker implements Worker<EquivalenceGraphUpdateMessage> {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentScheduleStoreGraphUpdateWorker.class);
 
     private final EquivalentScheduleWriter scheduleWriter;
     private final Timer messageTimer;
@@ -30,6 +33,14 @@ public class EquivalentScheduleStoreGraphUpdateWorker implements Worker<Equivale
 
     @Override
     public void process(EquivalenceGraphUpdateMessage message) throws RecoverableException {
+        LOG.debug(
+                "Processing message on ids {}, message: {}",
+                message.getGraphUpdate().getAllGraphs().stream()
+                        .map(EquivalenceGraph::getId)
+                        .collect(ImmutableCollectors.toList()),
+                message
+        );
+
         try {
             Timer.Context timer = null;
             if (messageTimer != null) {

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
@@ -2,23 +2,24 @@ package org.atlasapi.messaging;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.metabroadcast.common.queue.RecoverableException;
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
 import org.atlasapi.schedule.ScheduleUpdateMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
-
-import javax.annotation.Nullable;
 
 
 public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<ScheduleUpdateMessage>{
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOG =
+            LoggerFactory.getLogger(EquivalentScheduleStoreScheduleUpdateWorker.class);
     
     private final EquivalentScheduleWriter scheduleWriter;
     private final Timer messageTimer;
@@ -31,6 +32,9 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
 
     @Override
     public void process(ScheduleUpdateMessage message) throws RecoverableException {
+        LOG.debug("Processing message on id {}, message: {}",
+                message.getScheduleUpdate().getSchedule().getChannel(), message);
+
         try {
             Timer.Context timer = null;
             if (messageTimer != null) {

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/EventReadWriteWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/EventReadWriteWorker.java
@@ -22,7 +22,7 @@ import com.metabroadcast.common.queue.Worker;
 
 public class EventReadWriteWorker implements Worker<ResourceUpdatedMessage> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(EventReadWriteWorker.class);
 
     private final EventResolver resolver;
     private final EventWriter writer;
@@ -35,6 +35,9 @@ public class EventReadWriteWorker implements Worker<ResourceUpdatedMessage> {
     @Override
     public void process(ResourceUpdatedMessage message)
             throws RecoverableException {
+        LOG.debug("Processing message on id {}, message: {}",
+                message.getUpdatedResource().getId(), message);
+
         ImmutableList<Id> ids = ImmutableList.of(message.getUpdatedResource().getId());
         process(ids);
     }
@@ -49,7 +52,7 @@ public class EventReadWriteWorker implements Worker<ResourceUpdatedMessage> {
                     try {
                         writer.write(event);
                     } catch (WriteException e) {
-                        log.warn("Failed to write event " + event.getId());
+                        LOG.warn("Failed to write event " + event.getId());
                     }
                 }
             }

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/TopicReadWriteWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/TopicReadWriteWorker.java
@@ -8,6 +8,8 @@ import org.atlasapi.messaging.ResourceUpdatedMessage;
 import org.atlasapi.topic.Topic;
 import org.atlasapi.topic.TopicResolver;
 import org.atlasapi.topic.TopicWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -19,6 +21,8 @@ import com.metabroadcast.common.queue.Worker;
 
 public class TopicReadWriteWorker implements Worker<ResourceUpdatedMessage> {
 
+    public static final Logger LOG = LoggerFactory.getLogger(TopicReadWriteWorker.class);
+
     private final TopicResolver resolver;
     private final TopicWriter writer;
 
@@ -29,6 +33,9 @@ public class TopicReadWriteWorker implements Worker<ResourceUpdatedMessage> {
     
     @Override
     public void process(ResourceUpdatedMessage message) {
+        LOG.debug("Processing message on id {}, message: {}",
+                message.getUpdatedResource().getId(), message);
+
         ImmutableList<Id> ids = ImmutableList.of(message.getUpdatedResource().getId());
         ListenableFuture<Resolved<Topic>> read = resolver.resolveIds(ids);
         Futures.addCallback(read, new FutureCallback<Resolved<Topic>>() {


### PR DESCRIPTION
- Log the IDs included in the message to allow seeing when a piece of
content has been processed
- Change all loggers to be static as per code style