### PR TITLE
Allow schedule and all equivalent content to be bootstrapped

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/BootstrapModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/BootstrapModule.java
@@ -55,6 +55,7 @@ public class BootstrapModule {
     @Autowired private SchedulerModule scheduler;
     @Autowired private ElasticSearchContentIndexModule search;
     @Autowired private MetricRegistry metrics;
+    @Autowired private DirectAndExplicitEquivalenceMigrator explicitEquivalenceMigrator;
 
     @Bean
     BootstrapController bootstrapController() {
@@ -87,7 +88,7 @@ public class BootstrapModule {
                 persistence.nullMessageSendingContentStore(),
                 search.equivContentIndex(),
                 persistence,
-                explicitEquivalenceMigrator(),
+                explicitEquivalenceMigrator,
                 NUMBER_OF_SOURCE_BOOTSTRAP_TRHEADS,
                 progressStore(),
                 metrics
@@ -97,14 +98,6 @@ public class BootstrapModule {
     @Bean
     public ProgressStore progressStore() {
         return new MongoProgressStore(persistence.databasedWriteMongo());
-    }
-
-    public DirectAndExplicitEquivalenceMigrator explicitEquivalenceMigrator() {
-        return new DirectAndExplicitEquivalenceMigrator(
-                legacy.legacyContentResolver(),
-                legacy.legacyEquivalenceStore(),
-                persistence.nullMessageSendingGraphStore()
-        );
     }
 
     @Bean

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ChannelIntervalScheduleBootstrapTaskFactory.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ChannelIntervalScheduleBootstrapTaskFactory.java
@@ -3,11 +3,14 @@ package org.atlasapi.system.bootstrap;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.atlasapi.content.ContentStore;
+import org.atlasapi.content.ContentVisitor;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.schedule.ScheduleResolver;
 import org.atlasapi.schedule.ScheduleWriter;
 import org.joda.time.Interval;
+
+import com.google.common.base.Optional;
 
 public class ChannelIntervalScheduleBootstrapTaskFactory
         implements SourceChannelIntervalFactory<ChannelIntervalScheduleBootstrapTask> {
@@ -32,7 +35,8 @@ public class ChannelIntervalScheduleBootstrapTaskFactory
                 contentStore,
                 source,
                 channel,
-                interval);
+                interval, 
+                Optional.<ContentVisitor<?>>absent());
     }
     
 }

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ScheduleBootstrapWithContentMigrationTaskFactory.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ScheduleBootstrapWithContentMigrationTaskFactory.java
@@ -1,0 +1,60 @@
+package org.atlasapi.system.bootstrap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.atlasapi.AtlasPersistenceModule;
+import org.atlasapi.PersistenceModule;
+import org.atlasapi.channel.Channel;
+import org.atlasapi.content.ContentIndex;
+import org.atlasapi.content.ContentStore;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.schedule.ScheduleResolver;
+import org.atlasapi.schedule.ScheduleWriter;
+import org.atlasapi.system.bootstrap.workers.DirectAndExplicitEquivalenceMigrator;
+import org.joda.time.Interval;
+
+import com.google.common.base.Optional;
+
+
+/**
+ * A schedule bootstrapper that also migrates schedule content, including its
+ * equivalent set. This is generally not required in normal operations, but useful
+ * to force consistency between Owl and Deer content in the schedule.
+ *
+ */
+public class ScheduleBootstrapWithContentMigrationTaskFactory 
+            implements SourceChannelIntervalFactory<ChannelIntervalScheduleBootstrapTask> {
+
+    private final ScheduleResolver scheduleResolver;
+    private final ScheduleWriter scheduleWriter;
+    private final ContentStore contentStore;
+    private ContentBootstrapListener contentAndEquivalentsBoostrapListener;
+
+    public ScheduleBootstrapWithContentMigrationTaskFactory(ScheduleResolver scheduleResolver,
+            ScheduleWriter scheduleWriter, ContentStore contentStore, ContentIndex contentIndex,
+            DirectAndExplicitEquivalenceMigrator equivalenceMigrator, AtlasPersistenceModule persistence) {
+        this.scheduleResolver = checkNotNull(scheduleResolver);
+        this.scheduleWriter = checkNotNull(scheduleWriter);
+        this.contentStore = checkNotNull(contentStore);
+        this.contentAndEquivalentsBoostrapListener = ContentBootstrapListener.builder()
+                .withContentWriter(contentStore)
+                .withEquivalenceMigrator(equivalenceMigrator)
+                .withEquivalentContentStore(persistence.nullMessageSendingEquivalentContentStore())
+                .withContentIndex(contentIndex)
+                .withMigrateEquivalents(persistence.nullMessageSendingEquivalenceGraphStore())
+                .build();
+    }
+
+    @Override
+    public ChannelIntervalScheduleBootstrapTask create(Publisher source, Channel channel,
+            Interval interval) {
+        return new ChannelIntervalScheduleBootstrapTask(
+                scheduleResolver,
+                scheduleWriter,
+                contentStore,
+                source,
+                channel,
+                interval,
+                Optional.of(contentAndEquivalentsBoostrapListener));
+    }
+}

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ScheduleBootstrapper.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ScheduleBootstrapper.java
@@ -32,17 +32,21 @@ public class ScheduleBootstrapper {
     private final AtomicInteger total = new AtomicInteger(0);
     private final ListeningExecutorService executor;
     private final ChannelIntervalScheduleBootstrapTaskFactory taskFactory;
+    private final ScheduleBootstrapWithContentMigrationTaskFactory bootstrapWithMigrationTaskFactory;
 
     public ScheduleBootstrapper(
             ListeningExecutorService executor,
-            ChannelIntervalScheduleBootstrapTaskFactory taskFactory
+            ChannelIntervalScheduleBootstrapTaskFactory taskFactory,
+            ScheduleBootstrapWithContentMigrationTaskFactory bootstrapWithMigrationTaskFactory
     ) {
         this.executor = checkNotNull(executor);
         this.taskFactory = checkNotNull(taskFactory);
+        this.bootstrapWithMigrationTaskFactory = checkNotNull(bootstrapWithMigrationTaskFactory);
     }
 
 
-    public boolean bootstrapSchedules(Iterable<Channel> channels, Interval interval, Publisher source) {
+    public boolean bootstrapSchedules(Iterable<Channel> channels, Interval interval, Publisher source,
+            boolean migrateContent) {
         if (!bootstrapLock.tryLock()) {
             return false;
         }
@@ -60,7 +64,7 @@ public class ScheduleBootstrapper {
         );
         try {
             for (Channel channel : channels) {
-                futures.add(bootstrapChannel(channel, interval, source));
+                futures.add(bootstrapChannel(channel, interval, source, migrateContent));
             }
             Futures.get(Futures.allAsList(futures), Exception.class);
         } catch (Exception e) {
@@ -72,11 +76,16 @@ public class ScheduleBootstrapper {
         return true;
     }
 
-    private ListenableFuture<UpdateProgress> bootstrapChannel(final Channel channel, Interval interval, Publisher source) {
+    private ListenableFuture<UpdateProgress> bootstrapChannel(final Channel channel, Interval interval, 
+            Publisher source, boolean migrateContent) {
         log.info("Bootstrapping channel {}/{}", channel.getId(), channel.getTitle());
-        ListenableFuture<UpdateProgress> updateFuture = executor.submit(
-                taskFactory.create(source, channel, interval)
-        );
+        ChannelIntervalScheduleBootstrapTask task;
+        if (migrateContent) {
+            task = bootstrapWithMigrationTaskFactory.create(source, channel, interval);
+        } else {
+            task = taskFactory.create(source, channel, interval);
+        }
+        ListenableFuture<UpdateProgress> updateFuture = executor.submit(task);
         Futures.addCallback(updateFuture, new FutureCallback<UpdateProgress>() {
             @Override
             public void onSuccess(UpdateProgress result) {


### PR DESCRIPTION
By adding the migrateContent=true URI parameter to the existing