### PR TITLE
Split off MetricsRegistry to MetricsModule to eliminate circ dep

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/AtlasApiModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/AtlasApiModule.java
@@ -4,6 +4,7 @@ import org.atlasapi.application.ApplicationModule;
 import org.atlasapi.messaging.KafkaMessagingModule;
 import org.atlasapi.query.QueryWebModule;
 import org.atlasapi.system.HealthModule;
+import org.atlasapi.system.MetricsModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -12,11 +13,12 @@ import com.metabroadcast.common.webapp.properties.ContextConfigurer;
 
 @Configuration
 @Import({
-    HealthModule.class,
-    AtlasPersistenceModule.class,
-    KafkaMessagingModule.class,
-    ApplicationModule.class,
-    QueryWebModule.class
+        HealthModule.class,
+        MetricsModule.class,
+        AtlasPersistenceModule.class,
+        KafkaMessagingModule.class,
+        ApplicationModule.class,
+        QueryWebModule.class
 })
 public class AtlasApiModule {
 
@@ -26,5 +28,4 @@ public class AtlasApiModule {
         c.init();
         return c;
     }
-
 }

--- a/atlas-api/src/main/java/org/atlasapi/AtlasApiModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/AtlasApiModule.java
@@ -3,8 +3,8 @@ package org.atlasapi;
 import org.atlasapi.application.ApplicationModule;
 import org.atlasapi.messaging.KafkaMessagingModule;
 import org.atlasapi.query.QueryWebModule;
+import org.atlasapi.system.ApiMetricsModule;
 import org.atlasapi.system.HealthModule;
-import org.atlasapi.system.MetricsModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -14,7 +14,7 @@ import com.metabroadcast.common.webapp.properties.ContextConfigurer;
 @Configuration
 @Import({
         HealthModule.class,
-        MetricsModule.class,
+        ApiMetricsModule.class,
         AtlasPersistenceModule.class,
         KafkaMessagingModule.class,
         ApplicationModule.class,

--- a/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
@@ -42,7 +42,7 @@ import org.atlasapi.schedule.EquivalentScheduleStore;
 import org.atlasapi.schedule.ScheduleStore;
 import org.atlasapi.schedule.ScheduleWriter;
 import org.atlasapi.segment.SegmentStore;
-import org.atlasapi.system.HealthModule;
+import org.atlasapi.system.MetricsModule;
 import org.atlasapi.system.legacy.LegacyChannelGroupResolver;
 import org.atlasapi.system.legacy.LegacyChannelGroupTransformer;
 import org.atlasapi.system.legacy.LegacyChannelResolver;
@@ -113,8 +113,8 @@ public class AtlasPersistenceModule {
 
     private String equivalentContentChanges = Configurer.get("messaging.destination.equivalent.content.changes").get();
 
-    @Autowired MessagingModule messaging;
-    @Autowired HealthModule health;
+    private @Autowired MessagingModule messaging;
+    private @Autowired MetricsModule metricsModule;
 
 
     @PostConstruct
@@ -128,7 +128,7 @@ public class AtlasPersistenceModule {
         ConfiguredAstyanaxContext contextSupplier = new ConfiguredAstyanaxContext(cassandraCluster, cassandraKeyspace,
                 seeds, Integer.parseInt(cassandraPort),
                 Integer.parseInt(cassandraClientThreads), Integer.parseInt(cassandraConnectionTimeout),
-                health.metrics());
+                metricsModule.metrics());
         AstyanaxContext<Keyspace> context = contextSupplier.get();
         context.start();
 
@@ -150,7 +150,7 @@ public class AtlasPersistenceModule {
                 content -> UUID.randomUUID().toString(),
                 event -> UUID.randomUUID().toString(),
                 seeds,
-                health.metrics()
+                metricsModule.metrics()
         );
     }
     
@@ -244,7 +244,7 @@ public class AtlasPersistenceModule {
                         esIndex,
                         Long.parseLong(esRequestTimeout),
                         persistenceModule().contentStore(),
-                        health.metrics(),
+                        metricsModule.metrics(),
                         channelGroupResolver(),
                         new CassandraSecondaryIndex(
                                 persistenceModule().getSession(),

--- a/atlas-api/src/main/java/org/atlasapi/MonitoringWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/MonitoringWebModule.java
@@ -5,9 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
 
+import org.atlasapi.system.ApiMetricsModule;
 import org.atlasapi.system.HealthModule;
 import org.atlasapi.system.JettyHealthProbe;
-import org.atlasapi.system.MetricsModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +16,8 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({
         HealthModule.class,
-        MetricsModule.class
+        ApiMetricsModule.class,
+        AtlasPersistenceModule.class
 })
 public class MonitoringWebModule {
 

--- a/atlas-api/src/main/java/org/atlasapi/MonitoringWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/MonitoringWebModule.java
@@ -7,31 +7,19 @@ import javax.servlet.ServletContext;
 
 import org.atlasapi.system.HealthModule;
 import org.atlasapi.system.JettyHealthProbe;
+import org.atlasapi.system.MetricsModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({HealthModule.class})
+@Import({
+        HealthModule.class,
+        MetricsModule.class
+})
 public class MonitoringWebModule {
-//
-//    private static final Function<Class<?>, String> TO_FQN = new Function<Class<?>, String>() {
-//
-//        @Override
-//        public String apply(Class<?> clazz) {
-//            return clazz.getCanonicalName();
-//        }
-//    };
-//
-//    @Override
-//    public final void setConfigLocation(String location) {
-//        super.setConfigLocations( Lists.transform(ImmutableList.of(
-//                JettyHealthProbe.class, 
-//                HealthModule.class
-//            ), TO_FQN).toArray(new String[0]));
-//    }
-    
+
     @Autowired
     private ServletContext servletContext;
     

--- a/atlas-api/src/main/java/org/atlasapi/system/ApiMetricsModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/ApiMetricsModule.java
@@ -1,0 +1,14 @@
+package org.atlasapi.system;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+@Configuration
+public class ApiMetricsModule implements MetricsModule {
+
+    @Override public @Bean MetricRegistry metrics() {
+        return new MetricRegistry();
+    }
+}

--- a/atlas-api/src/main/java/org/atlasapi/system/HealthModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/HealthModule.java
@@ -4,26 +4,25 @@ import java.util.Collection;
 
 import javax.annotation.PostConstruct;
 
+import org.atlasapi.AtlasPersistenceModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.metabroadcast.common.health.HealthProbe;
 import com.metabroadcast.common.health.probes.MemoryInfoProbe;
+import com.metabroadcast.common.persistence.cassandra.health.CassandraProbe;
 import com.metabroadcast.common.webapp.health.HealthController;
 import com.metabroadcast.common.webapp.health.probes.MetricsProbe;
 
 @Configuration
 public class HealthModule {
 
-    private static final MetricRegistry metrics = new MetricRegistry();
-
     private @Autowired Collection<HealthProbe> probes;
     private @Autowired HealthController healthController;
-    // TODO There is a circular dependency here. Extract metrics to their own modules
-    // private @Autowired AtlasPersistenceModule persistenceModule;
+    private @Autowired MetricsModule metricsModule;
+    private @Autowired AtlasPersistenceModule persistenceModule;
 
     public @Bean HealthController healthController() {
         return new HealthController(ImmutableList.of(
@@ -32,22 +31,19 @@ public class HealthModule {
     }
 
     public @Bean org.atlasapi.system.HealthController threadController() {
-        return new org.atlasapi.system.HealthController(null);
-    }
-
-    public @Bean HealthProbe metricsProbe() {
-        return new MetricsProbe("Metrics", metrics());
-    }
-
-    public @Bean MetricRegistry metrics() {
-        return metrics;
+        return new org.atlasapi.system.HealthController(
+                persistenceModule.persistenceModule().getSession()
+        );
     }
 
     @PostConstruct
     public void addProbes() {
-//        healthController.addProbes(ImmutableList.of(
-//                new CassandraProbe(persistenceModule.persistenceModule().getSession())
-//        ));
+        healthController.addProbes(ImmutableList.of(
+                new CassandraProbe(persistenceModule.persistenceModule().getSession())
+        ));
         healthController.addProbes(probes);
+        healthController.addProbes(ImmutableList.of(
+                new MetricsProbe("Metrics", metricsModule.metrics())
+        ));
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/system/HealthModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/HealthModule.java
@@ -21,7 +21,7 @@ public class HealthModule {
 
     private @Autowired Collection<HealthProbe> probes;
     private @Autowired HealthController healthController;
-    private @Autowired MetricsModule metricsModule;
+    private @Autowired ApiMetricsModule metricsModule;
     private @Autowired AtlasPersistenceModule persistenceModule;
 
     public @Bean HealthController healthController() {

--- a/atlas-api/src/main/java/org/atlasapi/system/MetricsModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/MetricsModule.java
@@ -1,14 +1,10 @@
 package org.atlasapi.system;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import com.codahale.metrics.MetricRegistry;
 
-@Configuration
-public class MetricsModule {
+public interface MetricsModule {
 
-    public @Bean MetricRegistry metrics() {
-        return new MetricRegistry();
-    }
+    @Bean MetricRegistry metrics();
 }

--- a/atlas-api/src/main/java/org/atlasapi/system/MetricsModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/MetricsModule.java
@@ -1,0 +1,14 @@
+package org.atlasapi.system;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+@Configuration
+public class MetricsModule {
+
+    public @Bean MetricRegistry metrics() {
+        return new MetricRegistry();
+    }
+}

--- a/atlas-processing/src/main/java/org/atlasapi/AtlasProcessingModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/AtlasProcessingModule.java
@@ -3,6 +3,7 @@ package org.atlasapi;
 import org.atlasapi.messaging.KafkaMessagingModule;
 import org.atlasapi.messaging.WorkersModule;
 import org.atlasapi.system.ProcessingHealthModule;
+import org.atlasapi.system.ProcessingMetricsModule;
 import org.atlasapi.system.bootstrap.BootstrapModule;
 import org.atlasapi.system.debug.DebugModule;
 import org.springframework.context.annotation.Bean;
@@ -13,12 +14,13 @@ import com.metabroadcast.common.webapp.properties.ContextConfigurer;
 
 @Configuration
 @Import({
-    ProcessingHealthModule.class,
-    KafkaMessagingModule.class,
-    AtlasPersistenceModule.class,
-    WorkersModule.class,
-    BootstrapModule.class,
-    DebugModule.class
+        ProcessingHealthModule.class,
+        ProcessingMetricsModule.class,
+        KafkaMessagingModule.class,
+        AtlasPersistenceModule.class,
+        WorkersModule.class,
+        BootstrapModule.class,
+        DebugModule.class
 })
 public class AtlasProcessingModule {
 

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
@@ -10,6 +10,7 @@ import org.atlasapi.AtlasPersistenceModule;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
 import org.atlasapi.schedule.ScheduleUpdateMessage;
 import org.atlasapi.system.ProcessingHealthModule;
+import org.atlasapi.system.ProcessingMetricsModule;
 import org.atlasapi.system.bootstrap.workers.ContentEquivalenceAssertionLegacyMessageSerializer;
 import org.atlasapi.system.bootstrap.workers.DirectAndExplicitEquivalenceMigrator;
 import org.atlasapi.system.bootstrap.workers.LegacyRetryingContentResolver;
@@ -68,7 +69,7 @@ public class WorkersModule {
     @Autowired
     private AtlasPersistenceModule persistence;
     @Autowired
-    private ProcessingHealthModule health;
+    private ProcessingMetricsModule metricsModule;
     private ServiceManager consumerManager;
 
     private <M extends Message> MessageSerializer<M> serializer(Class<M> cls) {
@@ -78,7 +79,8 @@ public class WorkersModule {
     @Bean
     @Lazy(true)
     public Worker<ResourceUpdatedMessage> topicIndexingWorker() {
-        return new TopicIndexingWorker(persistence.topicStore(), persistence.topicIndex(), health.metrics());
+        return new TopicIndexingWorker(persistence.topicStore(), persistence.topicIndex(), metricsModule
+                .metrics());
     }
 
     @Bean
@@ -94,7 +96,8 @@ public class WorkersModule {
     @Bean
     @Lazy(true)
     public Worker<EquivalenceGraphUpdateMessage> equivalentContentStoreGraphUpdateWorker() {
-        return new EquivalentContentStoreGraphUpdateWorker(persistence.getEquivalentContentStore(), health.metrics());
+        return new EquivalentContentStoreGraphUpdateWorker(persistence.getEquivalentContentStore(), metricsModule
+                .metrics());
     }
 
     @Bean
@@ -118,7 +121,7 @@ public class WorkersModule {
                         persistence.legacyContentResolver(),
                         persistence.nullMessageSendingContentStore()
                 ),
-                health.metrics()
+                metricsModule.metrics()
         );
     }
 
@@ -136,7 +139,8 @@ public class WorkersModule {
     @Bean
     @Lazy(true)
     public Worker<EquivalenceGraphUpdateMessage> equivalentScheduletStoreGraphUpdateWorker() {
-        return new EquivalentScheduleStoreGraphUpdateWorker(persistence.getEquivalentScheduleStore(), health.metrics());
+        return new EquivalentScheduleStoreGraphUpdateWorker(persistence.getEquivalentScheduleStore(), metricsModule
+                .metrics());
     }
 
     @Bean
@@ -145,7 +149,7 @@ public class WorkersModule {
         return new EquivalentScheduleStoreContentUpdateWorker(
                 persistence.getEquivalentContentStore(),
                 persistence.getEquivalentScheduleStore(),
-                health.metrics()
+                metricsModule.metrics()
         );
     }
 
@@ -174,7 +178,8 @@ public class WorkersModule {
     @Bean
     @Lazy(true)
     public Worker<ScheduleUpdateMessage> equivalentScheduleStoreScheduleUpdateWorker() {
-        return new EquivalentScheduleStoreScheduleUpdateWorker(persistence.getEquivalentScheduleStore(), health.metrics());
+        return new EquivalentScheduleStoreScheduleUpdateWorker(persistence.getEquivalentScheduleStore(), metricsModule
+                .metrics());
     }
 
     @Bean
@@ -192,7 +197,7 @@ public class WorkersModule {
     public Worker<EquivalenceAssertionMessage> contentEquivalenceUpdater() {
         return new ContentEquivalenceUpdatingWorker(
                 persistence.getContentEquivalenceGraphStore(),
-                health.metrics(),
+                metricsModule.metrics(),
                 explicitEquivalenceMigrator()
         );
     }
@@ -212,7 +217,7 @@ public class WorkersModule {
     @Lazy(true)
     public EquivalentContentIndexingContentWorker equivalentContentIndexingWorker() {
         return new EquivalentContentIndexingContentWorker(
-                persistence.contentStore(), persistence.contentIndex(), health.metrics()
+                persistence.contentStore(), persistence.contentIndex(), metricsModule.metrics()
         );
     }
 
@@ -235,7 +240,7 @@ public class WorkersModule {
     @Bean
     @Lazy(true)
     public EquivalentContentIndexingGraphWorker equivalentContentIndexingGraphWorker() {
-        return new EquivalentContentIndexingGraphWorker(persistence.contentIndex(), health.metrics());
+        return new EquivalentContentIndexingGraphWorker(persistence.contentIndex(), metricsModule.metrics());
     }
 
     @Bean

--- a/atlas-processing/src/main/java/org/atlasapi/system/ProcessingHealthModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/ProcessingHealthModule.java
@@ -1,44 +1,29 @@
 package org.atlasapi.system;
 
 import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
 import org.atlasapi.AtlasPersistenceModule;
+import org.atlasapi.system.health.AstyanaxProbe;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.graphite.GraphiteReporter;
-import com.codahale.metrics.graphite.GraphiteUDP;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
-import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.common.collect.ImmutableList;
 import com.metabroadcast.common.health.HealthProbe;
-import com.metabroadcast.common.health.ProbeResult;
 import com.metabroadcast.common.health.probes.MemoryInfoProbe;
 import com.metabroadcast.common.persistence.cassandra.health.CassandraProbe;
-import com.metabroadcast.common.properties.Configurer;
 import com.metabroadcast.common.webapp.health.HealthController;
 import com.metabroadcast.common.webapp.health.probes.MetricsProbe;
-import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
 
 @Configuration
 public class ProcessingHealthModule extends HealthModule {
 
     private @Autowired Collection<HealthProbe> probes;
     private @Autowired HealthController healthController;
+    private @Autowired ProcessingMetricsModule metricsModule;
     private @Autowired AtlasPersistenceModule persistenceModule;
-    private final String environmentPrefix =  Configurer.get("metrics.environment.prefix").get();
-    private final String graphiteHost =  Configurer.get("metrics.graphite.host").get();
-    private final int graphitePort =  Configurer.get("metrics.graphite.port").toInt();
 
     public @Bean HealthController healthController() {
         return new HealthController(ImmutableList.of(
@@ -50,64 +35,12 @@ public class ProcessingHealthModule extends HealthModule {
         return new org.atlasapi.system.HealthController(persistenceModule.persistenceModule().getSession());
     }
 
-    public GraphiteReporter graphiteReporterFor(MetricRegistry metrics) {
-        GraphiteReporter reporter = GraphiteReporter.forRegistry(metrics)
-                .prefixedWith("atlas.deer." + environmentPrefix + ".")
-                .withClock(new Clock.UserTimeClock())
-                .build(new GraphiteUDP(graphiteHost, graphitePort));
-        reporter.start(1, TimeUnit.MINUTES);
-        return reporter;
-    }
-
-    public @Bean HealthProbe metricsProbe() {
-        return new MetricsProbe("Metrics", metrics());
-    }
-
-    public @Bean HealthProbe astyanaxProbe() {
-        return new HealthProbe() {
-
-            @Override public ProbeResult probe() throws Exception {
-                ProbeResult result = new ProbeResult(title());
-                ConnectionPoolMonitor pool = persistenceModule.persistenceModule()
-                        .getContext().getConnectionPoolMonitor();
-                result.addInfo("Socket timeouts", Long.toString(pool.getSocketTimeoutCount()));
-                result.addInfo("Transport errors", Long.toString(pool.getTransportErrorCount()));
-                result.addInfo("Pool-exhausted timeouts", Long.toString(pool.getPoolExhaustedTimeoutCount()));
-                result.addInfo("Connections opened", Long.toString(pool.getConnectionCreatedCount()));
-                result.addInfo("Connections closed", Long.toString(pool.getConnectionClosedCount()));
-                return result;
-            }
-
-            @Override public String title() {
-                return "Astyanax";
-            }
-
-            @Override public String slug() {
-                return "astyanax";
-            }
-        };
-    }
-
-    public @Bean MetricRegistry metrics() {
-        MetricRegistry metrics = new MetricRegistry();
-        registerMetrics("gc.", new GarbageCollectorMetricSet(), metrics);
-        registerMetrics("memory.", new MemoryUsageGaugeSet(), metrics);
-        registerMetrics("threads.", new ThreadStatesGaugeSet(), metrics);
-        graphiteReporterFor(metrics);
-        return metrics;
-    }
-
     @PostConstruct
     public void addProbes() {
         healthController.addProbes(ImmutableList.of(
                 new CassandraProbe(persistenceModule.persistenceModule().getSession()),
-                metricsProbe()
+                new AstyanaxProbe(persistenceModule.persistenceModule().getContext()),
+                new MetricsProbe("Metrics", metricsModule.metrics())
         ));
-    }
-
-    private void registerMetrics(String prefix, MetricSet metrics, MetricRegistry registry) {
-        for (Map.Entry<String, Metric> metric : metrics.getMetrics().entrySet()) {
-            registry.register(prefix.concat(metric.getKey()), metric.getValue());
-        }
     }
 }

--- a/atlas-processing/src/main/java/org/atlasapi/system/ProcessingMetricsModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/ProcessingMetricsModule.java
@@ -17,7 +17,7 @@ import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.metabroadcast.common.properties.Configurer;
 
 @Configuration
-public class ProcessingMetricsModule extends MetricsModule {
+public class ProcessingMetricsModule implements MetricsModule {
 
     private final String environmentPrefix = Configurer.get("metrics.environment.prefix").get();
     private final String graphiteHost = Configurer.get("metrics.graphite.host").get();

--- a/atlas-processing/src/main/java/org/atlasapi/system/ProcessingMetricsModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/ProcessingMetricsModule.java
@@ -1,0 +1,50 @@
+package org.atlasapi.system;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.GraphiteUDP;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.metabroadcast.common.properties.Configurer;
+
+@Configuration
+public class ProcessingMetricsModule extends MetricsModule {
+
+    private final String environmentPrefix = Configurer.get("metrics.environment.prefix").get();
+    private final String graphiteHost = Configurer.get("metrics.graphite.host").get();
+    private final int graphitePort = Configurer.get("metrics.graphite.port").toInt();
+
+    @Override
+    public MetricRegistry metrics() {
+        MetricRegistry metrics = new MetricRegistry();
+        registerMetrics("gc.", new GarbageCollectorMetricSet(), metrics);
+        registerMetrics("memory.", new MemoryUsageGaugeSet(), metrics);
+        registerMetrics("threads.", new ThreadStatesGaugeSet(), metrics);
+        graphiteReporterFor(metrics);
+        return metrics;
+    }
+
+    private void registerMetrics(String prefix, MetricSet metrics, MetricRegistry registry) {
+        for (Map.Entry<String, Metric> metric : metrics.getMetrics().entrySet()) {
+            registry.register(prefix.concat(metric.getKey()), metric.getValue());
+        }
+    }
+
+    private GraphiteReporter graphiteReporterFor(MetricRegistry metrics) {
+        GraphiteReporter reporter = GraphiteReporter.forRegistry(metrics)
+                .prefixedWith("atlas.deer." + environmentPrefix + ".")
+                .withClock(new Clock.UserTimeClock())
+                .build(new GraphiteUDP(graphiteHost, graphitePort));
+        reporter.start(1, TimeUnit.MINUTES);
+        return reporter;
+    }
+}

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
@@ -18,6 +18,7 @@ import org.atlasapi.messaging.ResourceUpdatedMessage;
 import org.atlasapi.messaging.v3.JacksonMessageSerializer;
 import org.atlasapi.messaging.v3.ScheduleUpdateMessage;
 import org.atlasapi.system.ProcessingHealthModule;
+import org.atlasapi.system.ProcessingMetricsModule;
 import org.atlasapi.system.bootstrap.ChannelIntervalScheduleBootstrapTaskFactory;
 import org.atlasapi.system.bootstrap.ScheduleBootstrapWithContentMigrationTaskFactory;
 import org.atlasapi.system.legacy.LegacyPersistenceModule;
@@ -78,7 +79,7 @@ public class BootstrapWorkersModule {
     @Autowired
     private KafkaMessagingModule messaging;
     @Autowired
-    private ProcessingHealthModule health;
+    private ProcessingMetricsModule metricsModule;
     @Autowired
     private ElasticSearchContentIndexModule search;
 
@@ -97,7 +98,7 @@ public class BootstrapWorkersModule {
         ContentBootstrapWorker worker = new ContentBootstrapWorker(
                 legacyResolver,
                 persistence.contentStore(),
-                health.metrics()
+                metricsModule.metrics()
         );
         MessageSerializer<ResourceUpdatedMessage> serializer =
                 new EntityUpdatedLegacyMessageSerializer();

--- a/atlas-processing/src/main/java/org/atlasapi/system/health/AstyanaxProbe.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/health/AstyanaxProbe.java
@@ -1,0 +1,40 @@
+package org.atlasapi.system.health;
+
+import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
+
+import com.metabroadcast.common.health.HealthProbe;
+import com.metabroadcast.common.health.ProbeResult;
+import com.netflix.astyanax.AstyanaxContext;
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.connectionpool.ConnectionPoolMonitor;
+
+public class AstyanaxProbe implements HealthProbe {
+
+    private final AstyanaxContext<Keyspace> context;
+
+    public AstyanaxProbe(AstyanaxContext<Keyspace> context) {
+        this.context = checkNotNull(context);
+    }
+
+    @Override
+    public ProbeResult probe() throws Exception {
+        ProbeResult result = new ProbeResult(title());
+        ConnectionPoolMonitor pool = context.getConnectionPoolMonitor();
+        result.addInfo("Socket timeouts", Long.toString(pool.getSocketTimeoutCount()));
+        result.addInfo("Transport errors", Long.toString(pool.getTransportErrorCount()));
+        result.addInfo("Pool-exhausted timeouts", Long.toString(pool.getPoolExhaustedTimeoutCount()));
+        result.addInfo("Connections opened", Long.toString(pool.getConnectionCreatedCount()));
+        result.addInfo("Connections closed", Long.toString(pool.getConnectionClosedCount()));
+        return result;
+    }
+
+    @Override
+    public String title() {
+        return "Astyanax";
+    }
+
+    @Override
+    public String slug() {
+        return "astyanax";
+    }
+}


### PR DESCRIPTION
- Reenable cassandra probe on HealthModule
- Split off MetricsRegistry to MetricsModule
- Delete commented out code from MonitoringWebModule
- Extract AstyanaxProbe to its own class for readability and
separation of concerns. This can't be moved to common-persistence
because we don't have the astyanax driver there