### PR TITLE
Feature/equivalent content store graph

### DIFF
--- a/atlas-cassandra/src/main/resources/atlas.schema
+++ b/atlas-cassandra/src/main/resources/atlas.schema
@@ -66,7 +66,7 @@ CREATE TABLE equivalent_content (
   set_id bigint,
   content_id bigint,
   data blob,
-  graph blob,
+  graph blob static,
   PRIMARY KEY (set_id, content_id)
 ) WITH
   bloom_filter_fp_chance=0.010000 AND

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/CassandraEquivalentContentStoreRowIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/CassandraEquivalentContentStoreRowIT.java
@@ -3,6 +3,10 @@ package org.atlasapi.content;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static org.atlasapi.content.CassandraEquivalentContentStore.CONTENT_ID_KEY;
+import static org.atlasapi.content.CassandraEquivalentContentStore.EQUIVALENT_CONTENT_TABLE;
+import static org.atlasapi.content.CassandraEquivalentContentStore.GRAPH_KEY;
+import static org.atlasapi.content.CassandraEquivalentContentStore.SET_ID_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -130,9 +134,9 @@ public class CassandraEquivalentContentStoreRowIT {
         persistenceModule.equivalentContentStore().updateContent(c1);
 
         persistenceModule.getCassandraSession().execute(
-                QueryBuilder.update("equivalent_content")
-                        .where(eq("set_id", c1.getId().longValue()))
-                        .with(set("graph", null))
+                QueryBuilder.update(EQUIVALENT_CONTENT_TABLE)
+                        .where(eq(SET_ID_KEY, c1.getId().longValue()))
+                        .with(set(GRAPH_KEY, null))
         );
 
         resolved(c1, c1);
@@ -188,9 +192,9 @@ public class CassandraEquivalentContentStoreRowIT {
         makeEquivalent(c1, c2);
 
         persistenceModule.getCassandraSession().execute(
-                QueryBuilder.update("equivalent_content")
-                        .where(eq("set_id", c1.getId().longValue()))
-                        .with(set("graph", null))
+                QueryBuilder.update(EQUIVALENT_CONTENT_TABLE)
+                        .where(eq(SET_ID_KEY, c1.getId().longValue()))
+                        .with(set(GRAPH_KEY, null))
         );
 
         resolvedSet(c1.getId(), c1, c2);
@@ -205,18 +209,18 @@ public class CassandraEquivalentContentStoreRowIT {
         persistenceModule.equivalentContentStore().updateContent(c2);
 
         ResultSet result = persistenceModule.getCassandraSession().execute(
-                QueryBuilder.select("graph").from("equivalent_content")
-                        .where(eq("set_id", c1.getId().longValue()))
+                QueryBuilder.select(GRAPH_KEY).from(EQUIVALENT_CONTENT_TABLE)
+                        .where(eq(SET_ID_KEY, c1.getId().longValue()))
         );
 
         makeEquivalent(c1, c2);
 
-        ByteBuffer oldGraph = result.iterator().next().getBytes("graph");
+        ByteBuffer oldGraph = result.iterator().next().getBytes(GRAPH_KEY);
 
         persistenceModule.getCassandraSession().execute(
-                QueryBuilder.update("equivalent_content")
-                        .where(eq("set_id", c1.getId().longValue()))
-                        .with(set("graph", oldGraph))
+                QueryBuilder.update(EQUIVALENT_CONTENT_TABLE)
+                        .where(eq(SET_ID_KEY, c1.getId().longValue()))
+                        .with(set(GRAPH_KEY, oldGraph))
         );
 
         resolvedSet(c1.getId(), c1);
@@ -224,9 +228,9 @@ public class CassandraEquivalentContentStoreRowIT {
 
     private void assertNoRowsWithIds(Id setId, Id contentId) {
         Session session = persistenceModule.getCassandraSession();
-        Statement rowsForIdQuery = select().all().from("equivalent_content")
-                .where(eq("set_id", setId.longValue()))
-                .and(eq("content_id", contentId.longValue()));
+        Statement rowsForIdQuery = select().all().from(EQUIVALENT_CONTENT_TABLE)
+                .where(eq(SET_ID_KEY, setId.longValue()))
+                .and(eq(CONTENT_ID_KEY, contentId.longValue()));
         ResultSet rows = session.execute(rowsForIdQuery);
         boolean exhausted = rows.isExhausted();
         assertTrue(String.format("Expected 0 rows for %s-%s, got %s", setId, contentId, rows.all().size()), exhausted);
@@ -234,7 +238,7 @@ public class CassandraEquivalentContentStoreRowIT {
 
     private void assertNoRowsWithSetId(Id setId) {
         Session session = persistenceModule.getCassandraSession();
-        Statement rowsForIdQuery = select().all().from("equivalent_content").where(eq("set_id", setId.longValue()));
+        Statement rowsForIdQuery = select().all().from(EQUIVALENT_CONTENT_TABLE).where(eq(SET_ID_KEY, setId.longValue()));
         ResultSet rows = session.execute(rowsForIdQuery);
         boolean exhausted = rows.isExhausted();
         assertTrue(String.format("Expected 0 rows for %s, got %s", setId, rows.all().size()), exhausted);

--- a/atlas-cassandra/src/test/java/org/atlasapi/util/CassandraInit.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/util/CassandraInit.java
@@ -56,7 +56,7 @@ public class CassandraInit {
         session.execute("CREATE TABLE equivalence_graph_index (resource_id bigint, graph_id bigint, PRIMARY KEY (resource_id));");
         session.execute("CREATE TABLE equivalence_graph (graph_id bigint, graph blob, PRIMARY KEY (graph_id));");
         session.execute("CREATE TABLE equivalent_content_index (key bigint, value bigint, PRIMARY KEY (key));");
-        session.execute("CREATE TABLE equivalent_content (set_id bigint, content_id bigint, graph blob, data blob, PRIMARY KEY (set_id,content_id));");
+        session.execute("CREATE TABLE equivalent_content (set_id bigint, content_id bigint, graph blob static, data blob, PRIMARY KEY (set_id,content_id));");
         session.execute("CREATE TABLE equivalent_schedule (source text, channel bigint, day timestamp, broadcast_id text, broadcast_start timestamp, broadcast blob, graph blob, content_count bigint, content blob, schedule_update timestamp, equiv_update timestamp, PRIMARY KEY ((source, channel, day), broadcast_id)) ");
 
         /*


### PR DESCRIPTION
Currently if the equivalent_content store reaches an inconsistent
state where rows exist for a set that should not be part of the set
according to the equivalence graph store we will serve stale content
as part of the set. To resolve this we will store the equivalence
graph as a static field on equivalent_content and use it to check
every returned row is actually part of that set