### PR TITLE
Merge broadcasts where start times are slightly different

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -40,6 +40,7 @@ import org.atlasapi.equivalence.EquivalenceRef;
 import org.atlasapi.equivalence.SeriesOrder;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.segment.SegmentEvent;
+import org.joda.time.Duration;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -58,6 +59,8 @@ import com.google.common.collect.Sets;
 public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     private static final Ordering<Episode> SERIES_ORDER = Ordering.from(new SeriesOrder());
+
+    private static final long BROADCAST_START_TIME_TOLERANCE_IN_MS = Duration.standardMinutes(5).getMillis();
 
     private EquivalentSetContentHierarchyChooser hierarchyChooser;
 
@@ -384,7 +387,8 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 @Override
                 public boolean apply(Broadcast input) {
                     return chosenBroadcast.getChannelId().equals(input.getChannelId())
-                            && chosenBroadcast.getTransmissionTime().equals(input.getTransmissionTime());
+                            && Math.abs(chosenBroadcast.getTransmissionTime().getMillis() - 
+                                        input.getTransmissionTime().getMillis()) <= BROADCAST_START_TIME_TOLERANCE_IN_MS;
                 }
              });
             if (matched.isPresent()) {

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -12,6 +12,7 @@ import org.atlasapi.application.ApplicationSources;
 import org.atlasapi.application.SourceReadEntry;
 import org.atlasapi.application.SourceStatus;
 import org.atlasapi.content.Brand;
+import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.BroadcastRef;
 import org.atlasapi.content.Certificate;
 import org.atlasapi.content.Container;
@@ -32,7 +33,9 @@ import org.atlasapi.segment.SegmentEvent;
 import org.atlasapi.util.ImmutableCollectors;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.junit.Test;
 
@@ -462,6 +465,33 @@ public class OutputContentMergerTest {
         
         Brand merged = merger.merge(bbcBrand, ImmutableList.of(paBrand), sources);
         assertThat(merged.getItemRefs(), is(equalTo(bbcEpisodes)));   
+    }
+    
+    @Test
+    public void testMergesBroadcastsWithSimilarStartTimes() {
+        
+        ApplicationSources sources = sourcesWithPrecedence(false, Publisher.BBC, Publisher.PA)
+                .copy()
+                .withContentHierarchyPrecedence(ImmutableList.of(Publisher.BBC, Publisher.PA))
+                .build();
+        
+        DateTime b1StartTime = new DateTime(2015, DateTimeConstants.JANUARY, 1, 1, 20, 0, 0);
+        
+        Item item1 = item(4L, "item1", Publisher.BBC);
+        Broadcast b1 = new Broadcast(Id.valueOf(1), new Interval(b1StartTime, b1StartTime.plusMinutes(10)));
+        b1.addAlias(new Alias("ns1", "v1"));
+        item1.setBroadcasts(ImmutableSet.of(b1));
+        
+        Item item2 = item(5L, "item2", Publisher.PA);
+        DateTime b2StartTime = b1StartTime.plusMinutes(1);
+        
+        Broadcast b2 = new Broadcast(Id.valueOf(1), new Interval(b2StartTime, b2StartTime.plusMinutes(10)));
+        item2.setBroadcasts(ImmutableSet.of(b2));
+        b2.addAlias(new Alias("ns2", "v2"));
+        
+        Item merged = (Item) merger.merge(item1,  ImmutableList.of(item2), sources);
+        assertThat(Iterables.getOnlyElement(merged.getBroadcasts()).getAliases().size(), is(2));
+
     }
 
     private Brand brand(long id, String uri, Publisher source) {


### PR DESCRIPTION
We have a tolerance in equivalence, but did not have one for
broadcast merging on output. We will now match broadcasts
between equivalent items if they have a start date within
five minutes of each other.