### PR TITLE
Clamp location availability start/end to deal with Year 2038 bug

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/writers/time/UnixMillenniumBugFixer.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/time/UnixMillenniumBugFixer.java
@@ -1,0 +1,38 @@
+package org.atlasapi.output.writers.time;
+
+import java.time.Month;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+/**
+ * This class attempts to fix the Unix Millennium Bug for 32-bit clients by changing any date time
+ * that is greater than 2038-01-01T00:00:00.0 to that.
+ * <p>
+ * This was needed because some Android devices are 32-bit and we ingest from content providers
+ * that sometimes give us dates higher than the max that can be represented in signed 32-bit.
+ * <p>
+ * It is a temporary solution and it is set to be automatically disabled on 2016-03-05T08:00:00.0Z.
+ * There is a unit test that will fail on that date time to alert us to remove this.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Year_2038_problem">Year 2038 problem</a>
+ */
+public class UnixMillenniumBugFixer {
+
+    public static final DateTime FIX_DISABLE_DATE_TIME =
+            new DateTime(2016, Month.MARCH.getValue(), 5, 8, 0, 0, 0, DateTimeZone.UTC);
+
+    public static final DateTime MAX_ALLOWED_DATE_TIME =
+            new DateTime(2038, Month.JANUARY.getValue(), 1, 0, 0, 0, 0, DateTimeZone.UTC);
+
+    public DateTime clampDateTime(DateTime dateTime) {
+        if (DateTime.now().withZone(DateTimeZone.UTC).isAfter(FIX_DISABLE_DATE_TIME)) {
+            return dateTime;
+        }
+
+        if (dateTime.isAfter(MAX_ALLOWED_DATE_TIME)) {
+            return MAX_ALLOWED_DATE_TIME.withZone(dateTime.getZone());
+        }
+        return dateTime;
+    }
+}

--- a/atlas-api/src/test/java/org/atlasapi/output/writers/time/UnixMillenniumBugFixerTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/writers/time/UnixMillenniumBugFixerTest.java
@@ -1,0 +1,53 @@
+package org.atlasapi.output.writers.time;
+
+import static org.atlasapi.output.writers.time.UnixMillenniumBugFixer.FIX_DISABLE_DATE_TIME;
+import static org.atlasapi.output.writers.time.UnixMillenniumBugFixer.MAX_ALLOWED_DATE_TIME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UnixMillenniumBugFixerTest {
+
+    private UnixMillenniumBugFixer fixer;
+    private DateTimeZone alternativeZone;
+
+    @Before
+    public void setUp() throws Exception {
+        fixer = new UnixMillenniumBugFixer();
+        alternativeZone = DateTimeZone.forOffsetHours(1);
+    }
+
+    @Test
+    public void testDateTimeGreaterThanMax32BitUnixTimeIsModified() throws Exception {
+        DateTime requestedDateTime = new DateTime(2038, 2, 1, 0, 0, 0, DateTimeZone.UTC);
+        DateTime dateTime = fixer.clampDateTime(requestedDateTime);
+
+        assertThat(dateTime, is(MAX_ALLOWED_DATE_TIME));
+    }
+
+    @Test
+    public void testDateTimeGreaterThanMax32BitUnixTimeIsModifiedButPreservesZone()
+            throws Exception {
+        DateTime requestedDateTime = new DateTime(2038, 2, 1, 0, 0, 0, alternativeZone);
+        DateTime dateTime = fixer.clampDateTime(requestedDateTime);
+
+        assertThat(dateTime, is(MAX_ALLOWED_DATE_TIME.withZone(alternativeZone)));
+    }
+
+    @Test
+    public void testDateTimeLessThatMax32BitUnixTimeIsNotModified() throws Exception {
+        DateTime requestedDateTime = new DateTime(2037, 2, 1, 0, 0, 0, alternativeZone);
+        DateTime dateTime = fixer.clampDateTime(requestedDateTime);
+
+        assertThat(dateTime, is(requestedDateTime));
+    }
+
+    @Test
+    public void testFixExpirationDateHasNotPassed() throws Exception {
+        assertThat(FIX_DISABLE_DATE_TIME.isAfterNow(), is(true));
+    }
+}


### PR DESCRIPTION
- This attempts to fix the Unix Millennium Bug for 32-bit clients by
changing any date time that is greater than 2038-01-01T00:00:00.0 to
that value
- This was needed because some Android devices are 32-bit and we
ingest from content providers that sometimes give us dates in the
year 3000
- This "fix" is set to be disabled automatically on
2016-03-05T08:00:00.0Z and there is a unit test set to fail then to
alert us to remove this