### PR TITLE
Change users of MessageSender to specify partition key

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/CassandraPersistenceModule.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/CassandraPersistenceModule.java
@@ -130,6 +130,9 @@ public class CassandraPersistenceModule extends AbstractIdleService implements P
             public void sendMessage(T resourceUpdatedMessage) throws MessagingException { }
 
             @Override
+            public void sendMessage(T message, byte[] partitionKey) throws MessagingException { }
+
+            @Override
             public void close() throws Exception { }
         };
     }
@@ -212,6 +215,14 @@ public class CassandraPersistenceModule extends AbstractIdleService implements P
             public void sendMessage(M message) throws MessagingException {
                 Timer.Context time = timer.time();
                 delegate.sendMessage(message);
+                time.stop();
+            }
+
+            @Override
+            public void sendMessage(M message, byte[] partitionKey)
+                    throws MessagingException {
+                Timer.Context time = timer.time();
+                delegate.sendMessage(message, partitionKey);
                 time.stop();
             }
 

--- a/atlas-cassandra/src/test/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStoreIT.java
@@ -32,6 +32,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.persistence.cassandra.DatastaxCassandraService;
 import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.queue.MessagingException;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.Keyspace;
@@ -53,8 +54,15 @@ public class CassandraEquivalenceGraphStoreIT {
         }
 
         @Override
+        public void sendMessage(EquivalenceGraphUpdateMessage message,
+                byte[] partitionKey)
+                throws MessagingException {
+            //no-op
+        }
+
+        @Override
         public void close() throws Exception {
-            
+            //no-op
         }
     };
     private static AstyanaxContext<Keyspace> context;

--- a/atlas-cassandra/src/test/java/org/atlasapi/schedule/CassandraScheduleStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/schedule/CassandraScheduleStoreIT.java
@@ -43,6 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 
 import com.datastax.driver.core.Session;
@@ -133,7 +134,7 @@ public abstract class CassandraScheduleStoreIT {
         DateTime middle = new DateTime(2013,05,31,23,0,0,0,DateTimeZones.LONDON);
         DateTime end = new DateTime(2013,06,01,14,0,0,0,DateTimeZones.LONDON);
         
-        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.<ScheduleHierarchy>of(
+        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(itemAndBroadcast(null, "one", source, channel, start, middle)), 
             ScheduleHierarchy.itemOnly(itemAndBroadcast(null, "two", source, channel, middle, end))
         );
@@ -167,7 +168,7 @@ public abstract class CassandraScheduleStoreIT {
         ItemAndBroadcast episode1 = itemAndBroadcast(null, "one", source, channel, start, middle);
         ItemAndBroadcast episode2 = itemAndBroadcast(null, "two", source, channel, middle, end);
 
-        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.<ScheduleHierarchy>of(
+        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1),
             ScheduleHierarchy.itemOnly(episode2)
         );
@@ -187,7 +188,7 @@ public abstract class CassandraScheduleStoreIT {
 
         episode1 = itemAndBroadcast(null, "one", source, channel, start, newMiddle);
         ItemAndBroadcast episode3 = itemAndBroadcast(null, "three", source, channel, newMiddle, end);
-        hiers = ImmutableList.<ScheduleHierarchy>of(
+        hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1),
             ScheduleHierarchy.itemOnly(episode3)
         );
@@ -256,14 +257,14 @@ public abstract class CassandraScheduleStoreIT {
 
 
         ItemAndBroadcast episode4 = itemAndBroadcast(null, "four", source, channel, newMiddle, end);
-        hiers = ImmutableList.<ScheduleHierarchy>of(
+        hiers = ImmutableList.of(
                 ScheduleHierarchy.itemOnly(episode1),
                 ScheduleHierarchy.itemOnly(episode4)
         );
         store.writeSchedule(hiers, channel, writtenInterval);
 
         ArgumentCaptor<ScheduleUpdateMessage> captor = ArgumentCaptor.forClass(ScheduleUpdateMessage.class);
-        verify(scheduleUpdateSender, times(3)).sendMessage(captor.capture());
+        verify(scheduleUpdateSender, times(3)).sendMessage(captor.capture(), Matchers.any());
 
         assertThat(
                 captor.getAllValues().get(2).getScheduleUpdate().getStaleBroadcasts(),
@@ -344,7 +345,7 @@ public abstract class CassandraScheduleStoreIT {
         ItemAndBroadcast episode1 = itemAndBroadcast(null, "one", source, channel, start, middle);
         ItemAndBroadcast episode2 = itemAndBroadcast(null, "two", source, channel, middle, end);
         
-        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.<ScheduleHierarchy>of(
+        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1), 
             ScheduleHierarchy.itemOnly(episode2)
         );
@@ -364,7 +365,7 @@ public abstract class CassandraScheduleStoreIT {
         
         episode1 = itemAndBroadcast(null, "one", source, channel, start, middle);
         ItemAndBroadcast episode3 = itemAndBroadcast(null, "three", source, channel, middle, newEnd);
-        hiers = ImmutableList.<ScheduleHierarchy>of(
+        hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1), 
             ScheduleHierarchy.itemOnly(episode3)
         );
@@ -420,7 +421,7 @@ public abstract class CassandraScheduleStoreIT {
         
         ItemAndBroadcast iab1 = new ItemAndBroadcast(item1, broadcast1);
         ItemAndBroadcast iab2 = new ItemAndBroadcast(item1.copy(), broadcast2);
-        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.<ScheduleHierarchy>of(
+        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(iab1), 
             ScheduleHierarchy.itemOnly(iab2)
         );
@@ -466,7 +467,7 @@ public abstract class CassandraScheduleStoreIT {
         ItemAndBroadcast episode1 = itemAndBroadcast(null, "one", source, channel, start, middle);
         ItemAndBroadcast episode2 = itemAndBroadcast(null, "two", source, channel, middle, end);
         
-        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.<ScheduleHierarchy>of(
+        ImmutableList<ScheduleHierarchy> hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1), 
             ScheduleHierarchy.itemOnly(episode2)
         );
@@ -486,7 +487,7 @@ public abstract class CassandraScheduleStoreIT {
         
         episode1 = itemAndBroadcast(null, "one", source, channel, start, middle);
         ItemAndBroadcast episode3 = itemAndBroadcast(null, "three", source, channel, middle, newEnd);
-        hiers = ImmutableList.<ScheduleHierarchy>of(
+        hiers = ImmutableList.of(
             ScheduleHierarchy.itemOnly(episode1), 
             ScheduleHierarchy.itemOnly(episode3)
         );

--- a/atlas-cassandra/src/test/java/org/atlasapi/util/TestCassandraPersistenceModule.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/util/TestCassandraPersistenceModule.java
@@ -59,6 +59,11 @@ public class TestCassandraPersistenceModule extends AbstractIdleService implemen
                 @Override
                 public void sendMessage(M message) throws MessagingException {
                 }
+
+                @Override
+                public void sendMessage(M message, byte[] partitionKey)
+                        throws MessagingException {
+                }
             };
         }
         

--- a/atlas-core/src/main/java/org/atlasapi/content/AbstractContentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/AbstractContentStore.java
@@ -6,8 +6,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.MissingResourceException;
@@ -21,7 +19,10 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.Clock;
@@ -319,7 +320,8 @@ public abstract class AbstractContentStore implements ContentStore {
                 itemRef
         );
         try {
-            sender.sendMessage(message);
+            Id resourceId = message.getUpdatedResource().getId();
+            sender.sendMessage(message, Longs.toByteArray(resourceId.longValue()));
         } catch (Exception e) {
             log.error("Failed to send message " + message.getUpdatedResource().toString(), e);
         }
@@ -329,7 +331,8 @@ public abstract class AbstractContentStore implements ContentStore {
         Iterable<ResourceUpdatedMessage> messages = createEntityUpdatedMessages(result);
         for (ResourceUpdatedMessage message : messages) {
             try {
-                sender.sendMessage(message);
+                Id resourceId = message.getUpdatedResource().getId();
+                sender.sendMessage(message, Longs.toByteArray(resourceId.longValue()));
             } catch (Exception e) {
                 log.error("Failed to send message " + message.getUpdatedResource().toString(), e);
             }

--- a/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.collect.OptionalMap;
@@ -143,7 +144,8 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
                         Timestamp.of(DateTime.now(DateTimeZone.UTC)),
                         graph.getId().longValue(),
                         content.toRef()
-                )
+                ),
+                Longs.toByteArray(graph.getId().longValue())
         );
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStore.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.collect.MoreSets;
@@ -141,11 +142,14 @@ public abstract class AbstractEquivalenceGraphStore implements EquivalenceGraphS
 
     private void sendUpdateMessage(ResourceRef subject, Optional<EquivalenceGraphUpdate> updated)  {
         try {
-            messageSender.sendMessage(new EquivalenceGraphUpdateMessage(
-                UUID.randomUUID().toString(),
-                Timestamp.of(DateTime.now(DateTimeZones.UTC)),
-                updated.get()
-            ));
+            messageSender.sendMessage(
+                    new EquivalenceGraphUpdateMessage(
+                        UUID.randomUUID().toString(),
+                        Timestamp.of(DateTime.now(DateTimeZones.UTC)),
+                        updated.get()
+                    ),
+                    Longs.toByteArray(updated.get().getUpdated().getId().longValue())
+            );
         } catch (MessagingException e) {
             log().warn("messaging failed for equivalence update of " + subject, e);
         }

--- a/atlas-core/src/main/java/org/atlasapi/event/ConcreteEventStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/event/ConcreteEventStore.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.queue.MessageSender;
@@ -122,7 +123,8 @@ public class ConcreteEventStore implements EventStore {
     private void sendResourceUpdatedMessage(WriteResult<Event, Event> result) {
         ResourceUpdatedMessage message = createEntityUpdatedMessages(result);
         try {
-            sender.sendMessage(message);
+            Id resourceId = message.getUpdatedResource().getId();
+            sender.sendMessage(message, Longs.toByteArray(resourceId.longValue()));
         } catch (Exception e) {
             log.error("Failed to send message " + message.getUpdatedResource().toString(), e);
         }

--- a/atlas-core/src/main/java/org/atlasapi/segment/AbstractSegmentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/segment/AbstractSegmentStore.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Optional;
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.queue.MessagingException;
@@ -73,7 +74,8 @@ abstract public class AbstractSegmentStore implements SegmentStore {
     private void writeMessage(WriteResult<Segment, Segment> result) {
         ResourceUpdatedMessage msg = createEntityUpdatedMessage(result);
         try {
-            sender.sendMessage(msg);
+            Id resourceId = msg.getUpdatedResource().getId();
+            sender.sendMessage(msg, Longs.toByteArray(resourceId.longValue()));
         } catch (MessagingException e) {
             log.error("Failed to send resource update message [{}] - {}",
                     msg.getUpdatedResource().toString(), e.toString());

--- a/atlas-core/src/main/java/org/atlasapi/topic/AbstractTopicStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/topic/AbstractTopicStore.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Equivalence;
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.Clock;
@@ -73,7 +74,8 @@ public abstract class AbstractTopicStore implements TopicStore {
     private void writeMessage(final WriteResult<Topic, Topic> result) {
         ResourceUpdatedMessage message = createEntityUpdatedMessage(result);
         try {
-            sender.sendMessage(message);
+            Id resourceId = message.getUpdatedResource().getId();
+            sender.sendMessage(message, Longs.toByteArray(resourceId.longValue()));
         } catch (Exception e) {
             log.error(message.getUpdatedResource().toString(), e);
         }

--- a/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
@@ -59,6 +59,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.queue.MessagingException;
 import com.metabroadcast.common.time.DateTimeZones;
 
 public class AbstractEquivalenceGraphStoreTest {
@@ -593,6 +594,13 @@ public class AbstractEquivalenceGraphStoreTest {
                 @Override
                 public void sendMessage(EquivalenceGraphUpdateMessage message)  {
                     // no-op
+                }
+
+                @Override
+                public void sendMessage(EquivalenceGraphUpdateMessage message,
+                        byte[] partitionKey)
+                        throws MessagingException {
+
                 }
 
                 @Override


### PR DESCRIPTION
- This is intended to ensure messages about the same resource always
go the same partition and that therefore we have ordering guarantees
about those messages. This is irrelevant when it comes to idempotent
messages, but it is required to ensure correctness when it comes to
non-idempotent ones like EquivalenceGraphUpdateMessage