### PR TITLE
Sort ES hits according to publisher precedence using groovy script

### DIFF
--- a/atlas-elasticsearch/pom.xml
+++ b/atlas-elasticsearch/pom.xml
@@ -2,6 +2,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <groovy-all.version>2.3.5</groovy-all.version>
+    </properties>
     <parent>
         <groupId>org.atlasapi</groupId>
         <artifactId>atlas</artifactId>
@@ -29,6 +32,12 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>1.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy-all.version}</version>
+            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/ElasticSearchContentIndexModule.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/ElasticSearchContentIndexModule.java
@@ -58,13 +58,14 @@ public class ElasticSearchContentIndexModule implements IndexModule {
                 resolver,
                 channelGroupResolver,
                 equivContentIndex,
-                requestTimeout.intValue()
+                requestTimeout.intValue(),
+                EsUnequivalentContentIndex.SortPublishersScript.PRODUCTION
         );
         this.translator = new EsContentTranslator(
                 indexName,
                 esClient,
                 equivContentIndex,
-                requestTimeout.longValue(),
+                requestTimeout,
                 resolver
         );
 

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentSearcherV3CompatibilityTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentSearcherV3CompatibilityTest.java
@@ -69,7 +69,15 @@ public class EsContentSearcherV3CompatibilityTest {
     @Before
     public void setUp() throws Exception {
         ElasticSearchHelper.refresh(esClient.client());
-        indexer = new EsUnequivalentContentIndex(esClient.client(), EsSchema.CONTENT_INDEX, new NoOpContentResolver(), mock(ChannelGroupResolver.class), new NoOpSecondaryIndex(), 60000);
+        indexer = new EsUnequivalentContentIndex(
+                esClient.client(),
+                EsSchema.CONTENT_INDEX,
+                new NoOpContentResolver(),
+                mock(ChannelGroupResolver.class),
+                new NoOpSecondaryIndex(),
+                60000,
+                EsUnequivalentContentIndex.SortPublishersScript.TESTING
+        );
         indexer.startAsync().awaitRunning(10, TimeUnit.SECONDS);
         refresh(esClient.client());
     }

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentTitleSearcherTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentTitleSearcherTest.java
@@ -86,7 +86,15 @@ public class EsContentTitleSearcherTest {
         item2.setContainerRef(brand1.toRef());
         item3.setContainerRef(brand2.toRef());
 
-        EsUnequivalentContentIndex contentIndex = new EsUnequivalentContentIndex(esClient.client(), EsSchema.CONTENT_INDEX, new NoOpContentResolver(), mock(ChannelGroupResolver.class), new NoOpSecondaryIndex(), 60000);
+        EsUnequivalentContentIndex contentIndex = new EsUnequivalentContentIndex(
+                esClient.client(),
+                EsSchema.CONTENT_INDEX,
+                new NoOpContentResolver(),
+                mock(ChannelGroupResolver.class),
+                new NoOpSecondaryIndex(),
+                60000,
+                EsUnequivalentContentIndex.SortPublishersScript.TESTING
+        );
         contentIndex.startAsync().awaitRunning();
 
         EsContentTitleSearcher contentSearcher = new EsContentTitleSearcher(esClient.client());

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsUnequivalentContentIndexingTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsUnequivalentContentIndexingTest.java
@@ -63,7 +63,15 @@ public final class EsUnequivalentContentIndexingTest {
     @Before
     public void setup() throws TimeoutException {
         ElasticSearchHelper.refresh(esClient.client());
-        contentIndexer = new EsUnequivalentContentIndex(esClient.client(), EsSchema.CONTENT_INDEX, new NoOpContentResolver(), mock(ChannelGroupResolver.class), new NoOpSecondaryIndex(), 6000);
+        contentIndexer = new EsUnequivalentContentIndex(
+                esClient.client(),
+                EsSchema.CONTENT_INDEX,
+                new NoOpContentResolver(),
+                mock(ChannelGroupResolver.class),
+                new NoOpSecondaryIndex(),
+                6000,
+                EsUnequivalentContentIndex.SortPublishersScript.TESTING
+        );
         contentIndexer.startAsync().awaitRunning(25, TimeUnit.SECONDS);
     }
     

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
@@ -43,7 +43,8 @@ public class PseudoEquivalentContentIndexIT {
                 new NoOpContentResolver(),
                 mock(ChannelGroupResolver.class),
                 equivIndex,
-                60000
+                60000,
+                EsUnequivalentContentIndex.SortPublishersScript.TESTING
         );
         delegate.startAsync().awaitRunning();
         contentIndex = new PseudoEquivalentContentIndex(delegate, equivIndex);

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/topic/EsPopularTopicsIndexTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/topic/EsPopularTopicsIndexTest.java
@@ -41,7 +41,13 @@ public class EsPopularTopicsIndexTest {
 
     private final Node esClient = ElasticSearchHelper.testNode();
     private final EsUnequivalentContentIndex index = new EsUnequivalentContentIndex(
-            esClient.client(), EsSchema.CONTENT_INDEX, new NoOpContentResolver(), mock(ChannelGroupResolver.class), new NoOpSecondaryIndex(), 60
+            esClient.client(),
+            EsSchema.CONTENT_INDEX,
+            new NoOpContentResolver(),
+            mock(ChannelGroupResolver.class),
+            new NoOpSecondaryIndex(),
+            60,
+            EsUnequivalentContentIndex.SortPublishersScript.TESTING
     );
 
     @BeforeClass

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/util/ElasticSearchHelper.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/util/ElasticSearchHelper.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.admin.indices.status.IndicesStatusResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 
@@ -19,8 +20,13 @@ public class ElasticSearchHelper {
     
     public static Node testNode() {
         return NodeBuilder.nodeBuilder()
-            .local(true).clusterName(UUID.randomUUID().toString())
-            .build().start();
+                .local(true)
+                .clusterName(UUID.randomUUID().toString())
+                .settings(ImmutableSettings.settingsBuilder()
+                        .put("script.engine.groovy.inline.search", "on")
+                        .build())
+                .build()
+                .start();
     }
     
     public static void clearIndices(Client esClient) {


### PR DESCRIPTION
- Currently due to an issue we can't inline groovy scripts to
requests made to the production cluster so we have to operate in two
modes. We inline the script for integration tests and reference a
script saved on the servers for production
- When ordering is requested and there is no fuzzy search which
requires score sorting we will also sort according to publisher
precedence to ensure that when deduping we are more likely to sort
according the value that will be displayed to the user