### PR TITLE
Bug/missed graph creation handling

### DIFF
--- a/atlas-cassandra/src/test/java/org/atlasapi/content/CassandraEquivalentContentStoreRowIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/CassandraEquivalentContentStoreRowIT.java
@@ -7,6 +7,7 @@ import static org.atlasapi.content.CassandraEquivalentContentStore.CONTENT_ID_KE
 import static org.atlasapi.content.CassandraEquivalentContentStore.EQUIVALENT_CONTENT_TABLE;
 import static org.atlasapi.content.CassandraEquivalentContentStore.GRAPH_KEY;
 import static org.atlasapi.content.CassandraEquivalentContentStore.SET_ID_KEY;
+import static org.atlasapi.media.entity.Publisher.METABROADCAST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -64,19 +65,19 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testRemovesOldRows() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
-        Content c3 = createAndWriteItem(Id.valueOf(31), Publisher.METABROADCAST);
-        Content c4 = createAndWriteItem(Id.valueOf(41), Publisher.METABROADCAST);
-        Content c5 = createAndWriteItem(Id.valueOf(51), Publisher.METABROADCAST);
-        Content c6 = createAndWriteItem(Id.valueOf(61), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
+        Content c3 = createAndWriteItem(Id.valueOf(31), METABROADCAST);
+        Content c4 = createAndWriteItem(Id.valueOf(41), METABROADCAST);
+        Content c5 = createAndWriteItem(Id.valueOf(51), METABROADCAST);
+        Content c6 = createAndWriteItem(Id.valueOf(61), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
-        persistenceModule.equivalentContentStore().updateContent(c3);
-        persistenceModule.equivalentContentStore().updateContent(c4);
-        persistenceModule.equivalentContentStore().updateContent(c5);
-        persistenceModule.equivalentContentStore().updateContent(c6);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
+        persistenceModule.equivalentContentStore().updateContent(c3.getId());
+        persistenceModule.equivalentContentStore().updateContent(c4.getId());
+        persistenceModule.equivalentContentStore().updateContent(c5.getId());
+        persistenceModule.equivalentContentStore().updateContent(c6.getId());
         
         makeEquivalent(c2, c4);
         makeEquivalent(c3, c5);
@@ -120,18 +121,18 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testResolveSingleContent() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
 
         resolved(c1, c1);
     }
 
     @Test
     public void testResolveSingleContentWithNoGraph() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
 
         persistenceModule.getCassandraSession().execute(
                 QueryBuilder.update(EQUIVALENT_CONTENT_TABLE)
@@ -144,11 +145,11 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testResolveAllContentInSet() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
 
         makeEquivalent(c1, c2);
 
@@ -157,11 +158,11 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testResolveAllContentInSetWithNoGraph() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
 
         makeEquivalent(c1, c2);
 
@@ -170,11 +171,11 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testResolveSet() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
 
         makeEquivalent(c1, c2);
 
@@ -183,11 +184,11 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testResolveSetWithNoGraph() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
 
         makeEquivalent(c1, c2);
 
@@ -202,11 +203,11 @@ public class CassandraEquivalentContentStoreRowIT {
 
     @Test
     public void testDoNotResolveContentThatIsNotInGraph() throws Exception {
-        Content c1 = createAndWriteItem(Id.valueOf(11), Publisher.METABROADCAST);
-        Content c2 = createAndWriteItem(Id.valueOf(21), Publisher.METABROADCAST);
+        Content c1 = createAndWriteItem(Id.valueOf(11), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(21), METABROADCAST);
 
-        persistenceModule.equivalentContentStore().updateContent(c1);
-        persistenceModule.equivalentContentStore().updateContent(c2);
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
 
         ResultSet result = persistenceModule.getCassandraSession().execute(
                 QueryBuilder.select(GRAPH_KEY).from(EQUIVALENT_CONTENT_TABLE)
@@ -224,6 +225,40 @@ public class CassandraEquivalentContentStoreRowIT {
         );
 
         resolvedSet(c1.getId(), c1);
+    }
+
+    @Test
+    public void testDeletingGraphUpdatesStaleContent() throws Exception {
+        Content c1 = createAndWriteItem(Id.valueOf(1), METABROADCAST);
+        Content c2 = createAndWriteItem(Id.valueOf(2), METABROADCAST);
+        Content c3 = createAndWriteItem(Id.valueOf(3), METABROADCAST);
+
+        persistenceModule.equivalentContentStore().updateContent(c1.getId());
+        persistenceModule.equivalentContentStore().updateContent(c2.getId());
+        persistenceModule.equivalentContentStore().updateContent(c3.getId());
+
+        makeEquivalent(c2, c3);
+
+        // This is the message that should have split off c3 into its own graph, but the message
+        // was not processed by the equivalent content store thus leaving c3 in the original set
+        // as stale content
+        persistenceModule.contentEquivalenceGraphStore().updateEquivalences(
+                c2.toRef(), ImmutableSet.of(), ImmutableSet.of(METABROADCAST)
+        );
+
+        // This adds a content with a smaller ID to the set thus causing the canonical ID to change
+        // and effectively causing the deletion of the old graph. c3 is no longer in the graph
+        // as far as equivalence graph knows so it's not mentioned anywhere in this update
+        Optional<EquivalenceGraphUpdate> updateOptional = persistenceModule
+                .contentEquivalenceGraphStore()
+                .updateEquivalences(
+                        c1.toRef(), ImmutableSet.of(c2.toRef()), ImmutableSet.of(METABROADCAST)
+                );
+
+        persistenceModule.equivalentContentStore().updateEquivalences(updateOptional.get());
+
+        resolvedSet(c1.getId(), c1, c2);
+        resolvedSet(c3.getId(), c3);
     }
 
     private void assertNoRowsWithIds(Id setId, Id contentId) {
@@ -247,7 +282,7 @@ public class CassandraEquivalentContentStoreRowIT {
     private void resolved(Content c, Content... cs) throws Exception {
         ResolvedEquivalents<Content> resolved
             = get(persistenceModule.equivalentContentStore().resolveIds(ImmutableList.of(c.getId()), 
-                    ImmutableSet.of(Publisher.METABROADCAST), Annotation.all()));
+                    ImmutableSet.of(METABROADCAST), Annotation.all()));
         ImmutableSet<Content> idContent = resolved.get(c.getId());
         assertEquals(ImmutableSet.copyOf(cs), idContent);
     }
@@ -269,7 +304,7 @@ public class CassandraEquivalentContentStoreRowIT {
        
         Optional<EquivalenceGraphUpdate> graphs
             = persistenceModule.contentEquivalenceGraphStore().updateEquivalences(c.toRef(), csRefs, 
-                ImmutableSet.of(Publisher.METABROADCAST, Publisher.BBC));
+                ImmutableSet.of(METABROADCAST, Publisher.BBC));
         
         persistenceModule.equivalentContentStore().updateEquivalences(graphs.get());
         

--- a/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
@@ -13,6 +13,7 @@ import org.atlasapi.equivalence.EquivalenceGraphStore;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.messaging.EquivalentContentUpdatedMessage;
 import org.atlasapi.util.GroupLock;
+import org.atlasapi.util.ImmutableCollectors;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -59,14 +60,25 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
         Set<Id> ids = idsOf(update);
         try {
             lock.lock(ids);
-            ImmutableSetMultimap.Builder<EquivalenceGraph, Content> graphsAndContent
+
+            ImmutableSetMultimap.Builder<EquivalenceGraph, Content> graphsAndContentBuilder
                 = ImmutableSetMultimap.builder();
             Function<Id, Optional<Content>> toContent = Functions.forMap(resolveIds(ids));
+
             for (EquivalenceGraph graph : graphsOf(update)) {
-                Iterable<Optional<Content>> content = Collections2.transform(graph.getEquivalenceSet(), toContent);
-                graphsAndContent.putAll(graph, Optional.presentInstances(content));
+                Iterable<Optional<Content>> content =
+                        Collections2.transform(graph.getEquivalenceSet(), toContent);
+                graphsAndContentBuilder.putAll(graph, Optional.presentInstances(content));
             }
-            updateEquivalences(graphsAndContent.build(), update);
+
+            ImmutableSetMultimap<EquivalenceGraph, Content> graphsAndContent =
+                    graphsAndContentBuilder.build();
+
+            // This has to run before we process the update so we can still resolve the set(s)
+            // that are going to be deleted
+            updateStaleContent(update, graphsAndContent);
+
+            update(graphsAndContent, update);
         } catch (InterruptedException e) {
             throw new WriteException("Updating " + ids, e);
         } finally {
@@ -75,10 +87,13 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
     }
 
     @Override
-    public final void updateContent(Content content) throws WriteException {
+    public final void updateContent(Id contentId) throws WriteException {
         try {
-            lock.lock(content.getId());
-            ImmutableList<Id> ids = ImmutableList.of(content.getId());
+            lock.lock(contentId);
+
+            Content content = resolveId(contentId);
+
+            ImmutableList<Id> ids = ImmutableList.of(contentId);
 
             ListenableFuture<OptionalMap<Id, EquivalenceGraph>> graphs = graphStore.resolveIds(ids);
             Optional<EquivalenceGraph> possibleGraph = get(graphs).get(content.getId());
@@ -86,26 +101,27 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
             EquivalenceGraph graph;
             if (possibleGraph.isPresent()) {
                 graph = possibleGraph.get();
-                updateInSet(graph, content);
-
+                update(graph, content);
             } else {
                 graph = EquivalenceGraph.valueOf(content.toRef());
-                updateEquivalences(ImmutableSetMultimap.of(graph, content),
-                        EquivalenceGraphUpdate.builder(graph).build());
+                update(graph, content);
             }
 
             sendEquivalentContentChangedMessage(content, graph);
         } catch (MessagingException | InterruptedException e) {
-            throw new WriteException("Updating " + content.getId(), e);
+            throw new WriteException("Updating " + contentId, e);
         } finally {
-            lock.unlock(content.getId());
+            lock.unlock(contentId);
         }
     }
 
-    protected abstract void updateInSet(EquivalenceGraph graph, Content content);
+    protected abstract void update(EquivalenceGraph graph, Content content);
 
-    protected abstract void updateEquivalences(ImmutableSetMultimap<EquivalenceGraph, Content> graphsAndContent,
+    protected abstract void update(ImmutableSetMultimap<EquivalenceGraph, Content> graphsAndContent,
             EquivalenceGraphUpdate update);
+
+    protected abstract ListenableFuture<Set<Content>> resolveEquivalentSetIncludingStaleContent(
+            Long equivalentSetId);
 
     protected ContentResolver getContentResolver() {
         return contentResolver;
@@ -126,6 +142,15 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
                 )))
                 .addAll(update.getDeleted())
                 .build();
+    }
+
+    private Content resolveId(Id contentId) throws WriteException {
+        Optional<Content> contentOptional = resolveIds(ImmutableList.of(contentId)).get(contentId);
+
+        if (contentOptional.isPresent()) {
+            return contentOptional.get();
+        }
+        throw new WriteException("Failed to resolve content " + contentId);
     }
 
     private OptionalMap<Id, Content> resolveIds(Iterable<Id> ids) throws WriteException {
@@ -149,4 +174,46 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
         );
     }
 
+    // This will resolve all content in the graphs that are about to be deleted and then check
+    // if that content appears in the updated or created graphs. If not it could be stale content
+    // so we are forcing an update
+    private void updateStaleContent(EquivalenceGraphUpdate update,
+            ImmutableSetMultimap<EquivalenceGraph, Content> graphsAndContent) {
+        ImmutableSet<Id> staleContentIds = getStaleContent(update.getDeleted(), graphsAndContent);
+
+        staleContentIds.stream()
+                .forEach(contentId -> {
+                    try {
+                        updateContent(contentId);
+                    } catch (WriteException e) {
+                        LOG.warn("Failed to update stale content {}", contentId, e);
+                    }
+                });
+    }
+
+    private ImmutableSet<Id> getStaleContent(ImmutableSet<Id> deletedGraphIds,
+            ImmutableSetMultimap<EquivalenceGraph, Content> graphsAndContent) {
+        ImmutableSet<Id> idsOfContentToBeUpdated = graphsAndContent.values().stream()
+                .map(Content::getId)
+                .collect(ImmutableCollectors.toSet());
+
+        return deletedGraphIds.stream()
+                .flatMap(graphId -> getStaleContent(graphId, idsOfContentToBeUpdated).stream())
+                .collect(ImmutableCollectors.toSet());
+    }
+
+    private ImmutableSet<Id> getStaleContent(Id deletedGraphId,
+            ImmutableSet<Id> contentIdsToBeUpdated) {
+        try {
+            return get(resolveEquivalentSetIncludingStaleContent(deletedGraphId.longValue()))
+                            .stream()
+                            .map(Content::getId)
+                            .filter(id -> !contentIdsToBeUpdated.contains(id))
+                            .collect(ImmutableCollectors.toSet());
+
+        } catch (WriteException e) {
+            LOG.warn("Failed to resolve equivalent set {}", deletedGraphId, e);
+        }
+        return ImmutableSet.of();
+    }
 }

--- a/atlas-core/src/main/java/org/atlasapi/content/EquivalentContentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/EquivalentContentStore.java
@@ -2,6 +2,7 @@ package org.atlasapi.content;
 
 import java.util.Set;
 
+import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.EquivalentsResolver;
@@ -16,26 +17,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 //TODO Given there's already EquivalentsResolver have EquivalentsWriter too as super-interfaces?
 public interface EquivalentContentStore extends EquivalentsResolver<Content> {
 
-    /**
-     * Update equivalence sets as represented by the changes in the provided update.
-     * @param update
-     * @throws WriteException
-     */
     void updateEquivalences(EquivalenceGraphUpdate update) throws WriteException;
     
-    /**
-     * Update piece of content.
-     * @param content - reference to the resource which has changed.
-     * @throws WriteException - if the update fails.
-     */
-    void updateContent(Content content) throws WriteException;
+    void updateContent(Id contentId) throws WriteException;
 
-
-    /**
-     * Resolves whole equivalejnt set
-     * @param equivalentSetId
-     * @return
-     */
     ListenableFuture<Set<Content>> resolveEquivalentSet(Long equivalentSetId);
-    
 }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
@@ -2,19 +2,14 @@ package org.atlasapi.messaging;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.atlasapi.content.Content;
 import org.atlasapi.content.ContentResolver;
 import org.atlasapi.content.EquivalentContentStore;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.entity.util.WriteException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 
@@ -45,17 +40,7 @@ public class EquivalentContentStoreContentUpdateWorker implements Worker<Resourc
 
         try {
             Timer.Context timer = messageTimer.time();
-            ListenableFuture<Resolved<Content>> contentFuture = contentResolver.resolveIds(
-                    ImmutableList.of(message.getUpdatedResource().getId())
-            );
-            //this should never be empty, as the message here has been sent for existing content
-            Content content = Futures.get(
-                    contentFuture,
-                    RecoverableException.class)
-                    .getResources()
-                    .first()
-                    .get();
-            equivalentContentStore.updateContent(content);
+            equivalentContentStore.updateContent(message.getUpdatedResource().getId());
             timer.stop();
         } catch (WriteException e) {
             throw new RecoverableException("update failed for content " + message.getUpdatedResource(), e);

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
@@ -160,7 +160,7 @@ public class ContentBootstrapListener extends ContentVisitorAdapter<
             Instant graphUpdateEnd = Instant.now();
             resultBuilder.success("Migrated equivalence graph");
 
-            equivalentContentStore.updateContent(content);
+            equivalentContentStore.updateContent(content.getId());
 
             if(graphUpdate.isPresent()) {
                 equivalentContentStore.updateEquivalences(graphUpdate.get());

--- a/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
@@ -19,7 +19,6 @@ import org.atlasapi.content.Container;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.ContentIndex;
 import org.atlasapi.content.ContentStore;
-import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.content.EsContent;
 import org.atlasapi.content.EsContentTranslator;
 import org.atlasapi.content.Item;
@@ -165,13 +164,8 @@ public class ContentDebugController {
     private void updateEquivalentContentStore(@PathVariable("id") String id,
                                    final HttpServletResponse response) throws IOException {
         try {
-            ContentStore contentStore = persistence.contentStore();
-            Resolved<Content> resolved = Futures.get(
-                    contentStore.resolveIds(ImmutableList.of(Id.valueOf(lowercase.decode(id)))), IOException.class
-            );
-            Content content = Iterables.getOnlyElement(resolved.getResources());
-            EquivalentContentStore equivContentStore = persistence.getEquivalentContentStore();
-            equivContentStore.updateContent(content);
+            Id contentId = Id.valueOf(lowercase.decode(id));
+            persistence.getEquivalentContentStore().updateContent(contentId);
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ContentBootstrapListenerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ContentBootstrapListenerTest.java
@@ -199,7 +199,7 @@ public class ContentBootstrapListenerTest {
             EquivalenceGraphUpdate graphUpdate) throws Exception {
         verify(contentWriter).writeContent(content);
         verify(equivalenceMigrator).migrateEquivalence(contentRef);
-        verify(equivalentContentStore).updateContent(content);
+        verify(equivalentContentStore).updateContent(content.getId());
         verify(equivalentContentStore).updateEquivalences(graphUpdate);
         verify(contentIndex).index(content);
     }

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ScheduleBootstrapperTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ScheduleBootstrapperTest.java
@@ -1,37 +1,44 @@
 package org.atlasapi.system.bootstrap;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.atlasapi.channel.Channel;
+import org.atlasapi.media.entity.Publisher;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.metabroadcast.common.scheduling.UpdateProgress;
 
-import org.atlasapi.channel.Channel;
-import org.atlasapi.media.entity.Publisher;
-import org.elasticsearch.common.base.Optional;
-import org.joda.time.Interval;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ScheduleBootstrapperTest {
 
+    private @Mock ListeningExecutorService executorService;
+    private @Mock ChannelIntervalScheduleBootstrapTaskFactory taskFactory;
+    private @Mock ScheduleBootstrapWithContentMigrationTaskFactory bootstrapWithMigrationTaskFactory;
+    private @Mock EquivalenceWritingChannelIntervalScheduleBootstrapTaskFactory equivTaskFactory;
 
-    @Mock
-    ListeningExecutorService executorService;
-    @Mock
-    ChannelIntervalScheduleBootstrapTaskFactory taskFactory;
+    private ScheduleBootstrapper objectUnderTest;
 
+    @Before
+    public void setUp() throws Exception {
+        objectUnderTest = new ScheduleBootstrapper(
+                executorService,
+                taskFactory,
+                bootstrapWithMigrationTaskFactory,
+                equivTaskFactory
+        );
+    }
 
-    @InjectMocks
-    ScheduleBootstrapper objectUnderTest;
     @Test
     public void testBootstrapSchedules() throws Exception {
         Channel channel1 = mock(Channel.class);

--- a/atlas-testlib/src/main/java/org/atlasapi/content/EquivalentContentStoreTester.java
+++ b/atlas-testlib/src/main/java/org/atlasapi/content/EquivalentContentStoreTester.java
@@ -36,7 +36,7 @@ public final class EquivalentContentStoreTester extends AbstractTester<Equivalen
         WriteResult<Content, Content> result = getSubjectGenerator().getContentStore().writeContent(content);
         assertTrue("Failed to write " + content, result.written());
         
-        getSubjectGenerator().getEquivalentContentStore().updateContent(content);
+        getSubjectGenerator().getEquivalentContentStore().updateContent(content.getId());
         
         ResolvedEquivalents<Content> resolved
             = get(getSubjectGenerator().getEquivalentContentStore().resolveIds(ImmutableList.of(content.getId()), ImmutableSet.of(Publisher.METABROADCAST), Annotation.all()));
@@ -100,7 +100,7 @@ public final class EquivalentContentStoreTester extends AbstractTester<Equivalen
         WriteResult<Content, Content> result = getSubjectGenerator().getContentStore().writeContent(content1);
         assertTrue("Failed to write " + content1, result.written());
         
-        getSubjectGenerator().getEquivalentContentStore().updateContent(content1);
+        getSubjectGenerator().getEquivalentContentStore().updateContent(content1.getId());
         
         ResolvedEquivalents<Content> resolved
             = get(getSubjectGenerator().getEquivalentContentStore().resolveIds(ImmutableList.of(content1.getId()), ImmutableSet.of(Publisher.METABROADCAST), Annotation.all()));
@@ -143,7 +143,7 @@ public final class EquivalentContentStoreTester extends AbstractTester<Equivalen
         WriteResult<Content, Content> result = getSubjectGenerator().getContentStore().writeContent(content);
         assertTrue("Failed to write " + content, result.written());
         
-        getSubjectGenerator().getEquivalentContentStore().updateContent(content);
+        getSubjectGenerator().getEquivalentContentStore().updateContent(content.getId());
         
         ResolvedEquivalents<Content> resolved
             = get(getSubjectGenerator().getEquivalentContentStore().resolveIds(ImmutableList.of(Id.valueOf(2)), ImmutableSet.of(Publisher.METABROADCAST), Annotation.all()));
@@ -158,7 +158,7 @@ public final class EquivalentContentStoreTester extends AbstractTester<Equivalen
         WriteResult<Content, Content> result = getSubjectGenerator().getContentStore().writeContent(content);
         assertTrue("Failed to write " + content, result.written());
         
-        getSubjectGenerator().getEquivalentContentStore().updateContent(content);
+        getSubjectGenerator().getEquivalentContentStore().updateContent(content.getId());
         
         ResolvedEquivalents<Content> resolved
             = get(getSubjectGenerator().getEquivalentContentStore().resolveIds(ImmutableList.of(Id.valueOf(1)), ImmutableSet.of(Publisher.BBC), Annotation.all()));
@@ -200,7 +200,7 @@ public final class EquivalentContentStoreTester extends AbstractTester<Equivalen
         WriteResult<Content, Content> result = getSubjectGenerator().getContentStore().writeContent(content);
         assertTrue("Failed to write " + content, result.written());
         
-        getSubjectGenerator().getEquivalentContentStore().updateContent(content);
+        getSubjectGenerator().getEquivalentContentStore().updateContent(content.getId());
         
         ResolvedEquivalents<Content> resolved
             = get(getSubjectGenerator().getEquivalentContentStore().resolveIds(ImmutableList.of(content.getId(), Id.valueOf(4)), Publisher.all(), Annotation.all()));


### PR DESCRIPTION
- When deleting a graph in the equivalent content store check all
content belonging to that set. If that content cannot be found in
the updated or created graphs that are part of the same update
message then assume that could be stale content that was caused by
a previous missed update and update it immediately to avoid 404'ing
when someone requests those content IDs via the API
- When a single piece of content is updated in the equivalent content
store also update the corresponding entry in the equivalent content
index to ensure we maximise the chances of fixing stale entries in
the index caused by past messages that did not get processed correctly
- The updateContent method in the AbstractEquivalentContentStore
should accept content ID instead of the content itself and only
resolve the content after it has acquired a lock on the content ID.
This avoids race conditions when there are concurrent updates on the
same content