### PR TITLE
Change ES deduping to take duplicate with highest precedence publisher

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/content/IndexQueryResult.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/IndexQueryResult.java
@@ -1,41 +1,26 @@
 package org.atlasapi.content;
 
-import java.util.List;
-
 import org.atlasapi.entity.Id;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 
 public class IndexQueryResult {
 
     private final ImmutableList<Id> ids;
-    private final ImmutableListMultimap<Id, Id> canonicalIdToIdMultiMap;
     private final Long count;
 
-    private IndexQueryResult(Iterable<Id> ids, ImmutableListMultimap<Id, Id> canonicalIdToIdMultiMap,
-            long totalResultCount) {
+    private IndexQueryResult(Iterable<Id> ids, long totalResultCount) {
         this.ids = ImmutableList.copyOf(ids);
-        this.canonicalIdToIdMultiMap = ImmutableListMultimap.copyOf(canonicalIdToIdMultiMap);
         this.count = totalResultCount;
     }
 
     public static IndexQueryResult withSingleId(Id id) {
-        return new IndexQueryResult(ImmutableList.of(id), ImmutableListMultimap.of(), 1L);
+        return new IndexQueryResult(ImmutableList.of(id), 1);
     }
 
     public static IndexQueryResult withIds(Iterable<Id> ids, long resultCount) {
-        return new IndexQueryResult(ids, ImmutableListMultimap.of(), resultCount);
-    }
-
-    public static IndexQueryResult withIdsAndCanonicalIds(
-            ImmutableListMultimap<Id, Id> canonicalIdToIdMultiMap, long resultCount) {
-        return new IndexQueryResult(
-                canonicalIdToIdMultiMap.values(),
-                canonicalIdToIdMultiMap,
-                resultCount
-        );
+        return new IndexQueryResult(ImmutableList.copyOf(ids), resultCount);
     }
 
     public Long getTotalCount() {
@@ -44,13 +29,5 @@ public class IndexQueryResult {
 
     public FluentIterable<Id> getIds() {
         return FluentIterable.from(ids);
-    }
-
-    public List<Id> getIds(Id canonicalId) {
-        return ImmutableList.copyOf(canonicalIdToIdMultiMap.get(canonicalId));
-    }
-
-    public List<Id> getCanonicalIds() {
-        return ImmutableList.copyOf(canonicalIdToIdMultiMap.keySet());
     }
 }

--- a/atlas-core/src/test/java/org/atlasapi/content/IndexQueryResultTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/IndexQueryResultTest.java
@@ -1,24 +1,17 @@
 package org.atlasapi.content;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import org.atlasapi.entity.Id;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.atlasapi.entity.Id;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Lists;
-
 public class IndexQueryResultTest {
 
-    private final Id canonicalIdA = Id.valueOf(0L);
-    private final Id canonicalIdB = Id.valueOf(1L);
-    private final Id canonicalIdC = Id.valueOf(2L);
     private final Id idA = Id.valueOf(10L);
     private final Id idB = Id.valueOf(11L);
-    private final Id idC = Id.valueOf(12L);
 
     @Test
     public void testResultWithSingleId() throws Exception {
@@ -28,7 +21,6 @@ public class IndexQueryResultTest {
 
         assertThat(result.getIds().size(), is(1));
         assertThat(result.getIds().first().get(), is(idA));
-        assertThat(result.getCanonicalIds().size(), is(0));
     }
 
     @Test
@@ -40,87 +32,5 @@ public class IndexQueryResultTest {
         assertThat(result.getIds().size(), is(2));
         assertThat(result.getIds().get(0), is(idA));
         assertThat(result.getIds().get(1), is(idB));
-    }
-
-    @Test
-    public void testResultWithIdsAndCanonicalIdsHasExpectedIds() throws Exception {
-        IndexQueryResult result = IndexQueryResult.withIdsAndCanonicalIds(
-                ImmutableListMultimap.<Id, Id>builder()
-                        .put(canonicalIdA, idA)
-                        .put(canonicalIdA, idB)
-                        .put(canonicalIdB, idC)
-                        .build(),
-                10L
-        );
-
-        assertThat(result.getTotalCount(), is(10L));
-
-        assertThat(result.getIds().size(), is(3));
-        assertThat(result.getIds().get(0), is(idA));
-        assertThat(result.getIds().get(1), is(idB));
-        assertThat(result.getIds().get(2), is(idC));
-    }
-
-    @Test
-    public void testGetCanonicalIdsOnlyReturnsUniqueIds() throws Exception {
-        IndexQueryResult result = IndexQueryResult.withIdsAndCanonicalIds(
-                ImmutableListMultimap.<Id, Id>builder()
-                        .put(canonicalIdA, idA)
-                        .put(canonicalIdA, idB)
-                        .put(canonicalIdB, idC)
-                        .build(),
-                10L
-        );
-
-        assertThat(result.getCanonicalIds().size(), is(2));
-        assertThat(result.getCanonicalIds(), containsInAnyOrder(canonicalIdA, canonicalIdB));
-    }
-
-    @Test
-    public void testGetIdsByCanonicalIdReturnsExpectedIds() throws Exception {
-        IndexQueryResult result = IndexQueryResult.withIdsAndCanonicalIds(
-                ImmutableListMultimap.<Id, Id>builder()
-                        .put(canonicalIdA, idA)
-                        .put(canonicalIdA, idB)
-                        .put(canonicalIdB, idC)
-                        .build(),
-                10L
-        );
-
-        assertThat(result.getIds(canonicalIdA).size(), is(2));
-        assertThat(result.getIds(canonicalIdA).contains(idA), is(true));
-        assertThat(result.getIds(canonicalIdA).contains(idB), is(true));
-    }
-
-    @Test
-    public void testGetIdsPreservesTheirOrder() throws Exception {
-        IndexQueryResult result = IndexQueryResult.withIds(
-                ImmutableList.of(idA, idB, idC), 3
-        );
-
-        assertThat(result.getIds().size(), is(3));
-        assertThat(result.getIds().get(0), is(idA));
-        assertThat(result.getIds().get(1), is(idB));
-        assertThat(result.getIds().get(2), is(idC));
-    }
-
-    @Test
-    public void testGetCanonicalIdsPreservesTheirOrder() throws Exception {
-        IndexQueryResult result = IndexQueryResult.withIdsAndCanonicalIds(
-                ImmutableListMultimap.<Id, Id>builder()
-                        .put(canonicalIdA, Id.valueOf(50L))
-                        .put(canonicalIdB, Id.valueOf(51L))
-                        .put(canonicalIdB, Id.valueOf(52L))
-                        .put(canonicalIdA, Id.valueOf(53L))
-                        .put(canonicalIdC, Id.valueOf(54L))
-                        .put(canonicalIdB, Id.valueOf(55L))
-                        .build(),
-                10L
-        );
-
-        assertThat(result.getCanonicalIds().size(), is(3));
-        assertThat(result.getCanonicalIds().get(0), is(canonicalIdA));
-        assertThat(result.getCanonicalIds().get(1), is(canonicalIdB));
-        assertThat(result.getCanonicalIds().get(2), is(canonicalIdC));
     }
 }

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/ElasticSearchContentIndexModule.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/ElasticSearchContentIndexModule.java
@@ -13,17 +13,17 @@ import org.atlasapi.content.PseudoEquivalentContentIndex;
 import org.atlasapi.topic.EsPopularTopicIndex;
 import org.atlasapi.topic.EsTopicIndex;
 import org.atlasapi.util.SecondaryIndex;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.Service.State;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.Service.State;
 
 public class ElasticSearchContentIndexModule implements IndexModule {
 
@@ -69,7 +69,7 @@ public class ElasticSearchContentIndexModule implements IndexModule {
         );
 
         PseudoEquivalentContentIndex equivalentEsIndex =
-                new PseudoEquivalentContentIndex(unequivIndex, equivContentIndex);
+                new PseudoEquivalentContentIndex(unequivIndex);
 
         this.equivContentIndex = new InstrumentedContentIndex(equivalentEsIndex, metrics);
         this.popularTopicsIndex = new EsPopularTopicIndex(esClient);

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/DelegateContentIndex.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/DelegateContentIndex.java
@@ -1,0 +1,22 @@
+package org.atlasapi.content;
+
+import java.util.Optional;
+
+import org.atlasapi.criteria.AttributeQuerySet;
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.query.Selection;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * This interface is used when a content index is used as a delegate of another content index to
+ * pass additional information between them without polluting the {@link ContentIndex} interface
+ * with it.
+ */
+public interface DelegateContentIndex {
+
+    ListenableFuture<DelegateIndexQueryResult> delegateQuery(AttributeQuerySet query,
+            Iterable<Publisher> publishers, Selection selection,
+            Optional<IndexQueryParams> queryParams);
+}

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/DelegateIndexQueryResult.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/DelegateIndexQueryResult.java
@@ -1,0 +1,97 @@
+package org.atlasapi.content;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.atlasapi.entity.Id;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.util.ImmutableCollectors;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This class is used when a content index is used as a delegate of another content index to
+ * pass additional information between them without polluting {@link IndexQueryResult} with it
+ */
+public class DelegateIndexQueryResult {
+
+    private final ImmutableList<Result> results;
+    private final Long count;
+
+    private DelegateIndexQueryResult(Iterable<Result> results, long totalResultCount) {
+        this.results = ImmutableList.copyOf(results);
+        this.count = totalResultCount;
+    }
+
+    public static Builder builder(long totalResultCount) {
+        return new Builder(totalResultCount);
+    }
+
+    public Long getTotalCount() {
+        return count;
+    }
+
+    public FluentIterable<Id> getIds() {
+        return FluentIterable.from(
+                results.stream()
+                    .map(Result::getId)
+                    .collect(ImmutableCollectors.toList())
+        );
+    }
+
+    public FluentIterable<Result> getResults() {
+        return FluentIterable.from(results);
+    }
+
+    public static class Builder {
+
+        private final long totalResultCount;
+
+        private List<Result> results = new LinkedList<>();
+
+        private Builder(long totalResultCount) {
+            this.totalResultCount = totalResultCount;
+        }
+
+        public Builder add(Id id, Id canonicalId, Publisher publisher) {
+            results.add(Result.of(id, canonicalId, publisher));
+            return this;
+        }
+
+        public DelegateIndexQueryResult build() {
+            return new DelegateIndexQueryResult(results, totalResultCount);
+        }
+    }
+
+    public static class Result {
+
+        private final Id id;
+        private final Id canonicalId;
+        private final Publisher publisher;
+
+        private Result(Id id, Id canonicalId, Publisher publisher) {
+            this.id = checkNotNull(id);
+            this.canonicalId = checkNotNull(canonicalId);
+            this.publisher = checkNotNull(publisher);
+        }
+
+        public static Result of(Id id, Id canonicalId, Publisher publisher) {
+            return new Result(id, canonicalId, publisher);
+        }
+
+        public Id getId() {
+            return id;
+        }
+
+        public Id getCanonicalId() {
+            return canonicalId;
+        }
+
+        public Publisher getPublisher() {
+            return publisher;
+        }
+    }
+}

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/PseudoEquivalentContentIndex.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/PseudoEquivalentContentIndex.java
@@ -1,9 +1,6 @@
 package org.atlasapi.content;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.IOException;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
@@ -11,29 +8,27 @@ import org.atlasapi.criteria.AttributeQuerySet;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.util.ImmutableCollectors;
-import org.atlasapi.util.SecondaryIndex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.metabroadcast.common.query.Selection;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.metabroadcast.common.query.Selection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class PseudoEquivalentContentIndex implements ContentIndex {
 
     private static final Logger LOG = LoggerFactory.getLogger(PseudoEquivalentContentIndex.class);
 
     private final EsUnequivalentContentIndex delegate;
-    private final SecondaryIndex equivIdIndex;
 
-    public PseudoEquivalentContentIndex(EsUnequivalentContentIndex delegate,
-            SecondaryIndex equivIdIndex) {
+    public PseudoEquivalentContentIndex(EsUnequivalentContentIndex delegate) {
         this.delegate = checkNotNull(delegate);
-        this.equivIdIndex = checkNotNull(equivIdIndex);
     }
 
     @Override
@@ -44,18 +39,16 @@ public class PseudoEquivalentContentIndex implements ContentIndex {
 
             Selection selectionForDelegate = getSelectionForDelegate(publishers, selection);
 
-            IndexQueryResult result = Futures.get(
-                    delegate.query(query, publishers, selectionForDelegate, searchParam),
+            DelegateIndexQueryResult result = Futures.get(
+                    delegate.delegateQuery(query, publishers, selectionForDelegate, searchParam),
                     Exception.class
             );
 
-            List<Id> canonicalIds = result.getCanonicalIds();
-            ImmutableList<Id> paginatedCanonicalIds = paginateIds(canonicalIds, selection);
-
-            ImmutableList<Id> ids = resolveCanonicalIds(paginatedCanonicalIds, result);
+            ImmutableList<Id> dedupedIds = dedupeIds(result, publishers);
+            ImmutableList<Id> paginatedIds = paginateIds(dedupedIds, selection);
 
             return Futures.immediateFuture(
-                    IndexQueryResult.withIds(ids, result.getTotalCount())
+                    IndexQueryResult.withIds(paginatedIds, result.getTotalCount())
             );
 
         } catch (Exception e) {
@@ -83,55 +76,67 @@ public class PseudoEquivalentContentIndex implements ContentIndex {
 
         return Selection.limitedTo(delegateLimit);
     }
+    
+    private ImmutableList<Id> dedupeIds(DelegateIndexQueryResult result,
+            Iterable<Publisher> publishers) {
+        LinkedHashMap<Id, DelegateIndexQueryResult.Result> dedupedEntries = new LinkedHashMap<>();
+
+        for (DelegateIndexQueryResult.Result entry : result.getResults()) {
+            addToDedupedResults(entry, dedupedEntries, publishers);
+        }
+
+        return dedupedEntries.entrySet().stream()
+                .map(entry -> entry.getValue().getId())
+                .collect(ImmutableCollectors.toList());
+    }
+
+    private void addToDedupedResults(DelegateIndexQueryResult.Result entry,
+            LinkedHashMap<Id, DelegateIndexQueryResult.Result> dedupedEntries,
+            Iterable<Publisher> publishers) {
+        Id canonicalId = entry.getCanonicalId();
+
+        if (!dedupedEntries.containsKey(canonicalId)) {
+            dedupedEntries.put(canonicalId, entry);
+            return;
+        }
+
+        DelegateIndexQueryResult.Result existingEntry = dedupedEntries.get(canonicalId);
+        if (hasHigherPrecedence(entry, existingEntry, publishers)) {
+            // Remove before put to ensure we update the ordering for this canonical ID
+            // to the position of this entry
+            dedupedEntries.remove(canonicalId);
+            dedupedEntries.put(canonicalId, entry);
+        }
+    }
+
+    private boolean hasHigherPrecedence(DelegateIndexQueryResult.Result currentEntry,
+            DelegateIndexQueryResult.Result existingEntry, Iterable<Publisher> publishers) {
+        return hasHigherPrecedence(
+                currentEntry.getPublisher(), existingEntry.getPublisher(), publishers
+        );
+    }
+
+    private boolean hasHigherPrecedence(Publisher currentPublisher, Publisher existingPublisher,
+            Iterable<Publisher> publisherPrecedence) {
+        for (Publisher publisher : publisherPrecedence) {
+            if (publisher == existingPublisher) {
+                return false;
+            }
+            if (publisher == currentPublisher) {
+                return true;
+            }
+        }
+
+        // This should never happen as the delegate uses the same publishers for the query
+        LOG.error("Delegate content index returned publisher {} that was not asked for."
+                + " Requested publishers: {}", currentPublisher, publisherPrecedence);
+        return false;
+    }
 
     private ImmutableList<Id> paginateIds(Iterable<Id> ids, Selection selection) {
          return StreamSupport.stream(ids.spliterator(), false)
                 .skip(selection.hasNonZeroOffset() ? selection.getOffset() : 0)
                 .limit(selection.limitOrDefaultValue(100))
                 .collect(ImmutableCollectors.toList());
-    }
-
-    // This is to deal with a bug where the canonical ID in the index is wrong
-    // To fix it we are trying to resolve the canonical ID from the secondary index
-    // using the IDs in the index canonical ID. This still returns the index canonical
-    // ID if it fails to resolve it from the secondary index
-    private ImmutableList<Id> resolveCanonicalIds(Iterable<Id> indexCanonicalIds,
-            IndexQueryResult queryResult) {
-        return StreamSupport.stream(indexCanonicalIds.spliterator(), false)
-                .map(indexCanonicalId -> resolveCanonicalIdFromIndexCanonicalId(
-                        indexCanonicalId, queryResult
-                ))
-                .collect(ImmutableCollectors.toList());
-    }
-
-    private Id resolveCanonicalIdFromIndexCanonicalId(Id indexCanonicalId,
-            IndexQueryResult queryResult) {
-
-        for (Id id : queryResult.getIds(indexCanonicalId)) {
-            Optional<Id> resolvedCanonicalId = resolveCanonicalId(id);
-
-            if(resolvedCanonicalId.isPresent()) {
-                return resolvedCanonicalId.get();
-            }
-        }
-
-        LOG.warn("Failed to resolve canonical ID for index canonical ID {}", indexCanonicalId);
-        return indexCanonicalId;
-    }
-
-    private Optional<Id> resolveCanonicalId(Id id) {
-        try {
-            ListenableFuture<ImmutableMap<Long, Long>> result =
-                    equivIdIndex.lookup(ImmutableList.of(id.longValue()));
-            ImmutableMap<Long, Long> idToCanonical = Futures.get(result, IOException.class);
-            Long canonicalId = idToCanonical.get(id.longValue());
-            if (canonicalId != null) {
-                return Optional.of(Id.valueOf(canonicalId));
-            }
-            LOG.warn("Found no canonical ID for {} using {}", id, id);
-        } catch (IOException e) {
-            LOG.warn("Found no canonical ID for {} using {}", id, id, e);
-        }
-        return Optional.empty();
     }
 }

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/DelegateIndexQueryResultTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/DelegateIndexQueryResultTest.java
@@ -1,0 +1,62 @@
+package org.atlasapi.content;
+
+import org.atlasapi.entity.Id;
+import org.atlasapi.media.entity.Publisher;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DelegateIndexQueryResultTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private final Id canonicalIdA = Id.valueOf(0L);
+    private final Id canonicalIdB = Id.valueOf(1L);
+    private final Id idA = Id.valueOf(10L);
+    private final Id idB = Id.valueOf(11L);
+
+    @Test
+    public void testResultWithCanonicalIdsAndPublishers() throws Exception {
+        DelegateIndexQueryResult result = DelegateIndexQueryResult.builder(4)
+                .add(idA, canonicalIdA, Publisher.METABROADCAST)
+                .add(idB, canonicalIdB, Publisher.BBC)
+                .build();
+
+        assertThat(result.getTotalCount(), is(4L));
+
+        assertThat(result.getIds().size(), is(2));
+        assertThat(result.getIds().get(0), is(idA));
+        assertThat(result.getIds().get(1), is(idB));
+
+        assertThat(result.getResults().size(), is(2));
+
+        assertThat(result.getResults().get(0).getId(), is(idA));
+        assertThat(result.getResults().get(0).getCanonicalId(), is(canonicalIdA));
+        assertThat(result.getResults().get(0).getPublisher(), is(Publisher.METABROADCAST));
+
+        assertThat(result.getResults().get(1).getId(), is(idB));
+        assertThat(result.getResults().get(1).getCanonicalId(), is(canonicalIdB));
+        assertThat(result.getResults().get(1).getPublisher(), is(Publisher.BBC));
+    }
+
+    @Test
+    public void testResultBuilderRejectsNullCanonicalIds() throws Exception {
+        exception.expect(NullPointerException.class);
+        DelegateIndexQueryResult.builder(1)
+                .add(idA, null, Publisher.METABROADCAST)
+                .build();
+    }
+
+    @Test
+    public void testResultBuilderRejectsNullPublishers() throws Exception {
+        exception.expect(NullPointerException.class);
+        DelegateIndexQueryResult.builder(1)
+                .add(idA, canonicalIdA, null)
+                .build();
+    }
+}

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
@@ -1,11 +1,5 @@
 package org.atlasapi.content;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -18,16 +12,23 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.util.CassandraSecondaryIndex;
 import org.atlasapi.util.ElasticSearchHelper;
 import org.atlasapi.util.SecondaryIndex;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.client.Client;
-import org.junit.Before;
-import org.junit.Test;
+
+import com.metabroadcast.common.query.Selection;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.metabroadcast.common.query.Selection;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PseudoEquivalentContentIndexIT {
 
@@ -46,7 +47,7 @@ public class PseudoEquivalentContentIndexIT {
                 60000
         );
         delegate.startAsync().awaitRunning();
-        contentIndex = new PseudoEquivalentContentIndex(delegate, equivIndex);
+        contentIndex = new PseudoEquivalentContentIndex(delegate);
     }
 
     @Test


### PR DESCRIPTION
- Currently we grab the ID we see out of every equivalent set. This
creates the problem that after merging on output we might show
different values on the API than the ones used for ordering by ES
thus the ordering will appear wrong. This is intended to fix that
- Change IndexQueryResult to only store IDs and create separate
DelegateIndexQueryResult to store additional information required by
the PseudoEquivalentContentIndex (namely canonicalID and publisher) to
avoid leaking that information to other parts of the code that don't
need them and making those interfaces more confusing. The interface
DelegateContentIndex has been created to handle communication between
the PseudoEquivalentContentIndex and EsUnequivalentContentIndex
- Have PseudoEquivalentContentIndex return the normal ID of the
content chosen after deduping. This is better than returning the
canonicalId since--deduping aside--the ES store does not store
equivalent sets and therefore should not be returning a canonical ID.
It also eliminates several issues we've had caused by inconsistencies
of canonical ID between the ES store and the equivalent content store