### PR TITLE
added annotation to return non-merged content

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -20,7 +20,7 @@ import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.content.ContainerSummaryResolver;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.MergingEquivalentsResolverBackedContainerSummaryResolver;
-import org.atlasapi.equivalence.DefaultMergingEquivalentsResolver;
+import org.atlasapi.equivalence.AnnotationBasedMergingEquivalentsResolver;
 import org.atlasapi.equivalence.MergingEquivalentsResolver;
 import org.atlasapi.event.Event;
 import org.atlasapi.organisation.Organisation;
@@ -91,7 +91,7 @@ public class QueryModule {
 
 
     public MergingEquivalentsResolver<Content> mergingContentResolver() {
-        return new DefaultMergingEquivalentsResolver<Content>(
+        return new AnnotationBasedMergingEquivalentsResolver<Content>(
             persistenceModule.getEquivalentContentStore(), 
             equivalentsMerger()
         );

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -31,6 +31,7 @@ import static org.atlasapi.annotation.Annotation.LOCATIONS;
 import static org.atlasapi.annotation.Annotation.META_ENDPOINT;
 import static org.atlasapi.annotation.Annotation.META_MODEL;
 import static org.atlasapi.annotation.Annotation.NEXT_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.NON_MERGED;
 import static org.atlasapi.annotation.Annotation.PARENT;
 import static org.atlasapi.annotation.Annotation.PEOPLE;
 import static org.atlasapi.annotation.Annotation.PLATFORM;
@@ -793,6 +794,7 @@ public class QueryWebModule {
                         SUPPRESS_EPISODE_NUMBERS,
                         NullWriter.create(Content.class)
                 )
+                .register(NON_MERGED, NullWriter.create(Content.class))
                 .build();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -66,7 +66,8 @@ public enum Annotation {
     EVENT,
     EVENT_DETAILS,
     ADVERTISED_CHANNELS,
-    SUPPRESS_EPISODE_NUMBERS
+    SUPPRESS_EPISODE_NUMBERS,
+    NON_MERGED
     ;
     
     public String toKey() {

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/AnnotationBasedMergingEquivalentsResolver.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/AnnotationBasedMergingEquivalentsResolver.java
@@ -15,13 +15,13 @@ import com.google.common.base.Optional;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
-public class DefaultMergingEquivalentsResolver<E extends Equivalable<E>>
+public class AnnotationBasedMergingEquivalentsResolver<E extends Equivalable<E>>
         implements MergingEquivalentsResolver<E> {
     
     private final EquivalentsResolver<E> resolver;
     private final ApplicationEquivalentsMerger<E> merger;
 
-    public DefaultMergingEquivalentsResolver(EquivalentsResolver<E> resolver, ApplicationEquivalentsMerger<E> merger) {
+    public AnnotationBasedMergingEquivalentsResolver(EquivalentsResolver<E> resolver, ApplicationEquivalentsMerger<E> merger) {
         this.resolver = checkNotNull(resolver);
         this.merger = checkNotNull(merger);
     }
@@ -31,8 +31,12 @@ public class DefaultMergingEquivalentsResolver<E extends Equivalable<E>>
             ApplicationSources sources, Set<Annotation> activeAnnotations) {
         ListenableFuture<ResolvedEquivalents<E>> unmerged
             = resolver.resolveIds(ids, sources.getEnabledReadSources(), activeAnnotations);
-        
-        return Futures.transform(unmerged, mergeUsing(sources));
+
+        if(activeAnnotations.contains(Annotation.NON_MERGED)) {
+            return unmerged;
+        } else {
+            return Futures.transform(unmerged, mergeUsing(sources));
+        }
     }
 
     private Function<ResolvedEquivalents<E>, ResolvedEquivalents<E>> mergeUsing(


### PR DESCRIPTION
The Data Comparison Service needs to be able to see unequivalated output, so that each data source's data can be rendered and compared by a user.