### PR TITLE
Use EPoll transport for Netty.

### DIFF
--- a/atlas-cassandra/pom.xml
+++ b/atlas-cassandra/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>cassandra-driver-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.netflix.astyanax</groupId>
       <artifactId>astyanax-core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
         <version>${datastax.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.1.0</version>
@@ -430,6 +436,7 @@
     <sonar.branch>deer</sonar.branch>
     <sonar.language>java</sonar.language>
     <sonar.exclusions>**/target/**/*,**/src/main/java/**/generated/**/*</sonar.exclusions>
+    <netty.version>4.0.27.Final</netty.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This should reduce GC churn from various `byte[]` allocations in the C* driver.

Tested on `stage`, basic heap profiling says it's good at getting rid of the crazy amounts of `byte[]` allocations we have, and GC gets a bit better. As far as I can tell, there are no downsides.