### PR TITLE
Be less eager to remove stale broadcasts

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/schedule/CassandraEquivalentScheduleStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/schedule/CassandraEquivalentScheduleStore.java
@@ -571,9 +571,12 @@ public final class CassandraEquivalentScheduleStore extends AbstractEquivalentSc
             Interval interval) {
         ImmutableList.Builder<Statement> stmts = ImmutableList.builder();
         for (BroadcastRef ref : staleBroadcasts) {
-            for (Date day : daysIn(interval)) {
-                stmts.add(delete(ref, src, day));
-            }
+            stmts.add(delete(ref, src,
+                    ref.getTransmissionInterval()
+                            .getStart()
+                            .toLocalDate()
+                            .toDate()
+            ));
         }
         return stmts.build();
     }


### PR DESCRIPTION
In the case where a broadcast ID is used on mulitple broadcasts
across two days, and one is removed, if the update interval of
the schedule spans both days, then all broadcasts with that
ID were removed.

We now only remove broadcasts on the calendar day in which the
stale broadcast is. There remains an edge case if both the valid
and invalid broadcast are on the same day.