### PR TITLE
Remove non actively published broadcasts when denormalising on ES series

### DIFF
--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentTranslatorTest.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/EsContentTranslatorTest.java
@@ -1,0 +1,240 @@
+package org.atlasapi.content;
+
+import java.util.List;
+import java.util.Map;
+
+import org.atlasapi.entity.Id;
+import org.atlasapi.util.SecondaryIndex;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.elasticsearch.client.Client;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EsContentTranslatorTest {
+
+    private @Mock Client client;
+    private @Mock SecondaryIndex secondaryIndex;
+    private @Mock ContentResolver contentResolver;
+
+    private EsContentTranslator translator;
+
+    @Before
+    public void setUp() throws Exception {
+        translator = new EsContentTranslator(
+                "index", client, secondaryIndex, 10L, contentResolver
+        );
+    }
+
+    @Test
+    public void testDenormaliseEpisodeBroadcastsOnSeriesWhenSeriesHasNoBroadcasts()
+            throws Exception {
+        Broadcast broadcastA = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC),
+                DateTime.now(DateTimeZone.UTC).plusHours(1)
+        );
+
+        Broadcast broadcastB = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC).plusDays(1),
+                DateTime.now(DateTimeZone.UTC).plusDays(1).plusHours(1)
+        );
+
+        Episode episode = getEpisode(broadcastA, broadcastB);
+        Map<String, Object> existingSeries = getExistingSeries();
+
+        Map<String, Object> series = translator.denormalizeEpisodeOntoSeries(
+                episode, existingSeries
+        );
+
+        List<Map<String, Object>> actualBroadcasts =
+                (List<Map<String, Object>>) series.get(EsContent.BROADCASTS);
+
+        assertThat(actualBroadcasts.size(), is(2));
+
+        isExpectedBroadcast(broadcastA, actualBroadcasts.get(0));
+        isExpectedBroadcast(broadcastB, actualBroadcasts.get(1));
+    }
+
+    @Test
+    public void testDoNotDenormalisedNonActivelyPublishedBroadcastsFromEpisodeOnSeries()
+            throws Exception {
+        Broadcast broadcastA = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC),
+                DateTime.now(DateTimeZone.UTC).plusHours(1)
+        );
+        broadcastA.setIsActivelyPublished(false);
+
+        Broadcast broadcastB = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC).plusDays(1),
+                DateTime.now(DateTimeZone.UTC).plusDays(1).plusHours(1)
+        );
+
+        Episode episode = getEpisode(broadcastA, broadcastB);
+        Map<String, Object> existingSeries = getExistingSeries();
+
+        Map<String, Object> series = translator.denormalizeEpisodeOntoSeries(
+                episode, existingSeries
+        );
+
+        List<Map<String, Object>> actualBroadcasts =
+                (List<Map<String, Object>>) series.get(EsContent.BROADCASTS);
+
+        assertThat(actualBroadcasts.size(), is(1));
+
+        isExpectedBroadcast(broadcastB, actualBroadcasts.get(0));
+    }
+
+    @Test
+    public void testKeepExistingBroadcastsWhenDenormalisingEpisodeBroadcastsOnSeries()
+            throws Exception {
+        Broadcast broadcastA = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC),
+                DateTime.now(DateTimeZone.UTC).plusHours(1)
+        );
+
+        Broadcast broadcastB = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC).plusDays(1),
+                DateTime.now(DateTimeZone.UTC).plusDays(1).plusHours(1)
+        );
+
+        Episode episode = getEpisode(broadcastB);
+        Map<String, Object> existingSeries = getExistingSeries(broadcastA);
+
+        Map<String, Object> series = translator.denormalizeEpisodeOntoSeries(
+                episode, existingSeries
+        );
+
+        List<Map<String, Object>> actualBroadcasts =
+                (List<Map<String, Object>>) series.get(EsContent.BROADCASTS);
+
+        assertThat(actualBroadcasts.size(), is(2));
+
+        isExpectedBroadcast(broadcastA, actualBroadcasts.get(0));
+        isExpectedBroadcast(broadcastB, actualBroadcasts.get(1));
+    }
+
+    @Test
+    public void testMergeEpisodeBroadcastsWithParentBroadcastsWhenDenormalising() throws Exception {
+        Broadcast broadcastA = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC),
+                DateTime.now(DateTimeZone.UTC).plusHours(1)
+        );
+
+        Broadcast broadcastB = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC).plusDays(1),
+                DateTime.now(DateTimeZone.UTC).plusDays(1).plusHours(1)
+        );
+
+        Episode episode = getEpisode(broadcastA, broadcastB);
+        Map<String, Object> existingSeries = getExistingSeries(broadcastA);
+
+        Map<String, Object> series = translator.denormalizeEpisodeOntoSeries(
+                episode, existingSeries
+        );
+
+        List<Map<String, Object>> actualBroadcasts =
+                (List<Map<String, Object>>) series.get(EsContent.BROADCASTS);
+
+        assertThat(actualBroadcasts.size(), is(2));
+
+        isExpectedBroadcast(broadcastA, actualBroadcasts.get(0));
+        isExpectedBroadcast(broadcastB, actualBroadcasts.get(1));
+    }
+
+    @Test
+    public void testRemoveExistingBroadcastIfNoLongerActivelyPublishedWhenDenormalising()
+            throws Exception {
+        Broadcast broadcastA = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC),
+                DateTime.now(DateTimeZone.UTC).plusHours(1)
+        );
+        broadcastA.setIsActivelyPublished(false);
+
+        Broadcast broadcastB = getBroadcast(
+                10L,
+                DateTime.now(DateTimeZone.UTC).plusDays(1),
+                DateTime.now(DateTimeZone.UTC).plusDays(1).plusHours(1)
+        );
+
+        Episode episode = getEpisode(broadcastA, broadcastB);
+        Map<String, Object> existingSeries = getExistingSeries(broadcastA);
+
+        Map<String, Object> series = translator.denormalizeEpisodeOntoSeries(
+                episode, existingSeries
+        );
+
+        List<Map<String, Object>> actualBroadcasts =
+                (List<Map<String, Object>>) series.get(EsContent.BROADCASTS);
+
+        assertThat(actualBroadcasts.size(), is(1));
+
+        isExpectedBroadcast(broadcastB, actualBroadcasts.get(0));
+    }
+
+    private Episode getEpisode(Broadcast... broadcasts) {
+        Episode episode = new Episode();
+
+        for (Broadcast broadcast : broadcasts) {
+            episode.addBroadcast(broadcast);
+        }
+
+        return episode;
+    }
+
+    private Broadcast getBroadcast(long channelId, DateTime startTime, DateTime endTime) {
+        return new Broadcast(Id.valueOf(channelId), startTime, endTime);
+    }
+
+    private Map<String, Object> getExistingSeries(Broadcast... broadcasts) {
+        Map<String, Object> existingSeries = Maps.newHashMap();
+        existingSeries.put(EsContent.LOCATIONS, Lists.<Map<String, Object>>newArrayList());
+
+        List<Map<String, Object>> esBroadcasts = Lists.<Map<String, Object>>newArrayList();
+        for (Broadcast broadcast : broadcasts) {
+            esBroadcasts.add(toEsBroadcast(broadcast));
+        }
+        existingSeries.put(EsContent.BROADCASTS, esBroadcasts);
+
+        return existingSeries;
+    }
+
+    private Map<String, Object> toEsBroadcast(Broadcast broadcast) {
+        return new EsBroadcast()
+                .channel(broadcast.getChannelId().longValue())
+                .transmissionTime(broadcast.getTransmissionTime().toDate())
+                .transmissionEndTime(broadcast.getTransmissionEndTime().toDate())
+                .toMap();
+    }
+
+    private void isExpectedBroadcast(Broadcast expected, Map<String, Object> actual) {
+        assertThat(
+                actual.get(EsBroadcast.CHANNEL),
+                is(expected.getChannelId().longValue())
+        );
+
+        DateTime actualStartTime = new DateTime(actual.get(EsBroadcast.TRANSMISSION_TIME));
+        assertThat(actualStartTime.isEqual(expected.getTransmissionTime()), is(true));
+
+        DateTime actualEndTime = new DateTime(actual.get(EsBroadcast.TRANSMISSION_END_TIME));
+        assertThat(actualEndTime.isEqual(expected.getTransmissionEndTime()), is(true));
+    }
+}

--- a/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
+++ b/atlas-elasticsearch/src/test/java/org/atlasapi/content/PseudoEquivalentContentIndexIT.java
@@ -52,7 +52,7 @@ public class PseudoEquivalentContentIndexIT {
 
     @Test
     public void testQuery() throws Exception {
-        Item item1 = new Item(Id.valueOf(1l), Publisher.METABROADCAST);
+        Item item1 = new Item(Id.valueOf(1l), Publisher.BBC);
         Item item2 = new Item(Id.valueOf(2l), Publisher.METABROADCAST);
         Item item3 = new Item(Id.valueOf(3l), Publisher.METABROADCAST);
 


### PR DESCRIPTION
- Change denormalisation logic to check if a broadcast is actively
published before denormalising it
- Change denormalisation logic to remove existing broadcasts from
parent series that have the same channel ID and start/end
transmission times as item broadcasts before merging them with the
item broadcasts. This is to effectively remove broadcasts belonging
to this item if they are no longer actively published
- Move logic to get possible parent series from ES and to reindex a
series on ES out of the EsContentTranslator and into
EsUnequivalentContentIndexer to improve separation of concerns and to
make testing easier
- Change parsing of ES broadcast channel ID to expect long since IDs
are longs
- Fix Failing test in PseudoEquivalentContentIndexIT