### PR TITLE
Fix scariest and some scary FindBugs bugs

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/search/SearchController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/search/SearchController.java
@@ -159,7 +159,7 @@ public class SearchController {
                                     : null)
                     .withCurrentBroadcastsOnly(!Strings.isNullOrEmpty(currentBroadcastsOnly)
                                                ? Boolean.valueOf(currentBroadcastsOnly)
-                                               : null)
+                                               : false)
                     .build(), appSources);
             resultWriter.write(QueryResult.listResult(
                     Iterables.filter(content, Content.class),

--- a/atlas-core/src/main/java/org/atlasapi/application/users/User.java
+++ b/atlas-core/src/main/java/org/atlasapi/application/users/User.java
@@ -105,7 +105,7 @@ public class User implements Identifiable {
     }
 
     public boolean manages(Id applicationId) {
-        return applicationIds.contains(applicationIds);
+        return applicationIds.contains(applicationId);
     }
 
     public boolean manages(Optional<Publisher> possibleSource) {

--- a/atlas-core/src/main/java/org/atlasapi/content/Actor.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Actor.java
@@ -1,5 +1,7 @@
 package org.atlasapi.content;
 
+import java.util.Objects;
+
 import org.atlasapi.entity.Person;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
@@ -63,17 +65,23 @@ public class Actor extends CrewMember {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof Actor) {
-            Actor actor = (Actor) obj;
-            return super.equals(actor) && character.equals(character);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
-        return false;
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        Actor actor = (Actor) o;
+        return Objects.equals(character, actor.character);
     }
 
     @Override
     public int hashCode() {
-        return this.getCanonicalUri().hashCode();
+        return Objects.hash(super.hashCode(), character);
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/content/KeyPhrase.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/KeyPhrase.java
@@ -58,7 +58,9 @@ public final class KeyPhrase {
 
     @Override
     public String toString() {
-        return String.format("%s (%s): %s", phrase,
+        return String.format(
+                "%s: %s",
+                phrase,
                 weighting != null ? weighting : "unweighted"
         );
     }

--- a/atlas-core/src/main/java/org/atlasapi/schedule/ChannelSchedule.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/ChannelSchedule.java
@@ -16,7 +16,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ChannelSchedule {
 
-    public static final Function<ChannelSchedule, ImmutableList<ItemAndBroadcast>> toEntries() {
+    public static Function<ChannelSchedule, ImmutableList<ItemAndBroadcast>> toEntries() {
         return TO_ENTRIES;
     }
 
@@ -59,19 +59,22 @@ public class ChannelSchedule {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof ChannelSchedule) {
-            ChannelSchedule scheduleChannel = (ChannelSchedule) obj;
-            return channel.equals(scheduleChannel.channel)
-                    && interval.equals(interval)
-                    && entries.equals(scheduleChannel.entries);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
-        return false;
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ChannelSchedule that = (ChannelSchedule) o;
+        return java.util.Objects.equals(channel, that.channel) &&
+                java.util.Objects.equals(interval, that.interval) &&
+                java.util.Objects.equals(entries, that.entries);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(channel, interval);
+        return java.util.Objects.hash(channel, interval, entries);
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/schedule/ScheduleRef.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/ScheduleRef.java
@@ -73,22 +73,22 @@ public final class ScheduleRef {
     }
 
     @Override
-    public boolean equals(Object that) {
-        if (this == that) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (that instanceof ScheduleRef) {
-            ScheduleRef other = (ScheduleRef) that;
-            return channel.equals(channel)
-                    && interval.equals(interval)
-                    && entries.equals(other.entries);
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
-        return false;
+        ScheduleRef that = (ScheduleRef) o;
+        return java.util.Objects.equals(channel, that.channel) &&
+                java.util.Objects.equals(interval, that.interval) &&
+                java.util.Objects.equals(entries, that.entries);
     }
 
     @Override
     public int hashCode() {
-        return channel.hashCode();
+        return java.util.Objects.hash(channel, interval, entries);
     }
 
     @Override

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
@@ -329,10 +329,11 @@ public class EsContentTranslator {
                 .filter(policy -> policy != null)
                 .collect(ImmutableCollectors.toSet());
 
+        List<Map<String, Object>> nonNullExistingLocations = existingLocations != null
+                                                       ? existingLocations
+                                                       : ImmutableList.of();
         Predicate<Policy> filter = createLocationNotPresentFilter(
-                fromEsLocations(
-                        existingLocations != null ? existingLocations : ImmutableList.of()
-                )
+                fromEsLocations(nonNullExistingLocations)
         );
 
         ImmutableList<Map<String, Object>> newPolicies = policies.stream()
@@ -341,7 +342,10 @@ public class EsContentTranslator {
                 .map(EsObject::toMap)
                 .collect(ImmutableCollectors.toList());
 
-        return (List) ImmutableList.builder().addAll(existingLocations).addAll(newPolicies).build();
+        return ImmutableList.<Map<String, Object>>builder()
+                .addAll(nonNullExistingLocations)
+                .addAll(newPolicies)
+                .build();
     }
 
     private ImmutableList<Policy> fromEsLocations(List<Map<String, Object>> existingLocations) {


### PR DESCRIPTION
- SearchController: withCurrentBroadcastsOnly expects a primitive
boolean. Passing null with throw a RuntimeException. Change to
passing false instead if not specified
- User: manages method was checking applicationIds contains itself
rather than the provided applicationId. This code is currently unused
- Actor: Fix inconsistent equals/hashCode and change equals to follow
usual patterns rather than doing an instanceof to a specific type
that breaks symmetry of equals with superclass' equals
- KeyPhrase: String.format was expecting 3 parameters, but only two
are passed
- ChannelSchedule: Remove misleading final on a static field; Fix
inconsistent equals/hashCode and non-standard equals as before
- ScheduleRef: Fix inconsistent equals/hashCode and non-standard equals
as before
- EsContentTranslator: Fix possible NPE if existing series does not
have locations and returns null instead of the empty list