### PR TITLE
MBST-14517: Tighten RequestPath in * Controllers so return 404 

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelController.java
@@ -46,7 +46,7 @@ public class ChannelController {
         this.resultWriter = checkNotNull(resultWriter);
     }
 
-    @RequestMapping({ "", ".*", "/{id}.*", "/{id}" })
+    @RequestMapping({ "", "\\.[a-z]+", "/{id}\\.[a-z]+", "/{id}" })
     public void fetchChannel(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupController.java
@@ -46,7 +46,7 @@ public class ChannelGroupController {
         this.resultWriter = checkNotNull(resultWriter);
     }
 
-    @RequestMapping({ "", ".*", "/{id}.*", "/{id}" })
+    @RequestMapping({ "", "\\.[a-z]+", "/{id}\\.[a-z]+", "/{id}" })
     public void fetchChannelGroup(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/content/ContentController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/content/ContentController.java
@@ -47,7 +47,7 @@ public class ContentController {
         this.resultWriter = resultWriter;
     }
 
-    @RequestMapping({ "/{id}.*", "/{id}", ".*", "" })
+    @RequestMapping({ "/{id}\\.[a-z]+", "/{id}", "\\.[a-z]+", "" })
     public void fetchContent(HttpServletRequest request, HttpServletResponse response,
             @RequestParam(value = "order_by", required = false) String orderBy)
             throws IOException {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/event/EventController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/event/EventController.java
@@ -47,7 +47,7 @@ public class EventController {
         this.queryResultWriter = queryResultWriter;
     }
 
-    @RequestMapping({ "/{id}.*", "/{id}" })
+    @RequestMapping({ "/{id}\\.[a-z]+", "/{id}" })
     public void fetchEvent(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/meta/endpoint/EndpointController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/meta/endpoint/EndpointController.java
@@ -47,7 +47,7 @@ public class EndpointController {
         this.contextParser = checkNotNull(contextParser);
     }
 
-    @RequestMapping({ "/4/meta/resources.*", "/4/meta/resources" })
+    @RequestMapping({ "/4/meta/resources\\.[a-z]+", "/4/meta/resources" })
     public void fetchAllEndpointInfo(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;
@@ -78,7 +78,7 @@ public class EndpointController {
         );
     }
 
-    @RequestMapping({ "/4/meta/resources/{key}.*", "/4/meta/resources/{key}" })
+    @RequestMapping({ "/4/meta/resources/{key}\\.[a-z]+", "/4/meta/resources/{key}" })
     public void fetchSingleEndpointInfo(HttpServletRequest request, HttpServletResponse response,
             @PathVariable("key") String key) throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/meta/model/ModelController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/meta/model/ModelController.java
@@ -53,7 +53,7 @@ public class ModelController {
     // as the rest of the query parsing and query execution framework can be used. it might make annotations
     // a little more friendly
     // also means that the resolution/result creation methods can be removed from this controller class
-    @RequestMapping({ "/4/meta/types.*", "/4/meta/types" })
+    @RequestMapping({ "/4/meta/types\\.[a-z]+", "/4/meta/types" })
     public void fetchAllModelInfo(HttpServletRequest request, HttpServletResponse response)
             throws IOException, UnsupportedFormatException, NotAcceptableException {
         ResponseWriter writer = null;
@@ -84,7 +84,7 @@ public class ModelController {
         );
     }
 
-    @RequestMapping({ "/4/meta/types/{key}.*", "/4/meta/types/{key}" })
+    @RequestMapping({ "/4/meta/types/{key}\\.[a-z]+", "/4/meta/types/{key}" })
     public void fetchSingleModelInfo(HttpServletRequest request, HttpServletResponse response,
             @PathVariable("key") String key) throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/organisation/OrganisationController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/organisation/OrganisationController.java
@@ -43,7 +43,7 @@ public class OrganisationController {
         this.resultWriter = resultWriter;
     }
 
-    @RequestMapping({ "/{id}.*", "/{id}" })
+    @RequestMapping({ "/{id}\\.[a-z]+", "/{id}" })
     public void fetchContent(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleController.java
@@ -54,7 +54,7 @@ public class ScheduleController {
         this.resultWriter = resultWriter;
     }
 
-    @RequestMapping({ "", ".*", "/{id}.*", "/{id}" })
+    @RequestMapping({ "", "\\.[a-z]+", "/{id}\\.[a-z]+", "/{id}" })
     public void getChannelSchedule(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleIndexDebugController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleIndexDebugController.java
@@ -76,7 +76,7 @@ public class ScheduleIndexDebugController {
         );
     }
 
-    @RequestMapping({ "/system/debug/schedules/{cid}.*", "/system/debug/schedules/{cid}" })
+    @RequestMapping({ "/system/debug/schedules/{cid}\\.[a-z]+", "/system/debug/schedules/{cid}" })
     public void debugSchedule(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         ScheduleQuery query = requestParser.queryFrom(request);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/search/SearchController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/search/SearchController.java
@@ -95,7 +95,7 @@ public class SearchController {
         this.resultWriter = resultWriter;
     }
 
-    @RequestMapping({ "/4/search.*", "/4/search" })
+    @RequestMapping({ "/4/search\\.[a-z]+", "/4/search" })
     public void search(@RequestParam(QUERY_PARAM) String q,
             @RequestParam(value = SPECIALIZATION_PARAM, required = false) String specialization,
             @RequestParam(value = PUBLISHER_PARAM, required = false) String publisher,

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/topic/PopularTopicController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/topic/PopularTopicController.java
@@ -58,7 +58,7 @@ public class PopularTopicController {
         this.sourcesFetcher = configurationFetcher;
     }
 
-    @RequestMapping({ "/4/topics/popular.*", "/4/topics/popular" })
+    @RequestMapping({ "/4/topics/popular\\.[a-z]+", "/4/topics/popular" })
     public void popularTopics(@RequestParam(required = true) String from,
             @RequestParam(required = true) String to, HttpServletRequest request,
             HttpServletResponse response) throws IOException {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/topic/TopicContentController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/topic/TopicContentController.java
@@ -45,7 +45,7 @@ public class TopicContentController {
         this.resultWriter = checkNotNull(resultWriter);
     }
 
-    @RequestMapping({ "/4/topics/{id}/content.*", "/4/topics/{id}/content" })
+    @RequestMapping({ "/4/topics/{id}/content\\.[a-z]+", "/4/topics/{id}/content" })
     public void writeSingleTopic(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/topic/TopicController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/topic/TopicController.java
@@ -42,7 +42,7 @@ public class TopicController {
         this.resultWriter = resultWriter;
     }
 
-    @RequestMapping({ "/{id}.*", "/{id}", ".*", "" })
+    @RequestMapping({ "/{id}\\.[a-z]+", "/{id}", "\\.[a-z]+", "" })
     public void writeSingleTopic(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ResponseWriter writer = null;


### PR DESCRIPTION
in case of broken path rather than 500 from ResponseWriterFactory.


Changed wildcard matcher to alpha extension matcher:

i.e.
`schedules.*` to `schedules\\.[a-z]+`
so match schedules.xml & schedules.json, but not schedules.hk45.json
