### PR TITLE
Make equivalence updates for the equiv schedule and the index idempotent

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
@@ -69,7 +69,7 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
                     = ImmutableSetMultimap.builder();
             Function<Id, Optional<Content>> toContent = Functions.forMap(resolveIds(ids));
 
-            for (EquivalenceGraph graph : graphsOf(update)) {
+            for (EquivalenceGraph graph : update.getAllGraphs()) {
                 Iterable<Optional<Content>> content =
                         Collections2.transform(graph.getEquivalenceSet(), toContent);
                 graphsAndContentBuilder.putAll(graph, Optional.presentInstances(content));
@@ -137,13 +137,6 @@ public abstract class AbstractEquivalentContentStore implements EquivalentConten
 
     protected ContentResolver getContentResolver() {
         return contentResolver;
-    }
-
-    private Iterable<EquivalenceGraph> graphsOf(EquivalenceGraphUpdate update) {
-        return ImmutableSet.<EquivalenceGraph>builder()
-                .add(update.getUpdated())
-                .addAll(update.getCreated())
-                .build();
     }
 
     private ImmutableSet<Id> idsOf(EquivalenceGraphUpdate update) {

--- a/atlas-core/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
@@ -18,7 +18,6 @@ import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphStore;
-import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.Equivalent;
 import org.atlasapi.media.entity.Publisher;
 
@@ -186,8 +185,9 @@ public abstract class AbstractEquivalentScheduleStore implements EquivalentSched
     }
 
     @Override
-    public final void updateEquivalences(EquivalenceGraphUpdate update) throws WriteException {
-        for (EquivalenceGraph graph : update.getAllGraphs()) {
+    public final void updateEquivalences(ImmutableSet<EquivalenceGraph> graphs)
+            throws WriteException {
+        for (EquivalenceGraph graph : graphs) {
             Resolved<Content> graphContent = get(contentStore.resolveIds(graph.getEquivalenceSet()));
             for (Content elem : graphContent.getResources()) {
                 if (elem instanceof Item) {

--- a/atlas-core/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
@@ -21,7 +21,6 @@ import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphStore;
-import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.Equivalent;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.util.ImmutableCollectors;
@@ -63,8 +62,9 @@ public abstract class AbstractEquivalentScheduleStore implements EquivalentSched
     }
 
     @Override
-    public final void updateEquivalences(EquivalenceGraphUpdate update) throws WriteException {
-        for (EquivalenceGraph graph : update.getAllGraphs()) {
+    public final void updateEquivalences(ImmutableSet<EquivalenceGraph> graphs)
+            throws WriteException {
+        for (EquivalenceGraph graph : graphs) {
             Resolved<Content> graphContent = get(contentStore.resolveIds(graph.getEquivalenceSet()));
             for (Content elem : graphContent.getResources()) {
                 if (elem instanceof Item) {

--- a/atlas-core/src/main/java/org/atlasapi/schedule/EquivalentScheduleWriter.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/EquivalentScheduleWriter.java
@@ -2,7 +2,9 @@ package org.atlasapi.schedule;
 
 import org.atlasapi.content.Item;
 import org.atlasapi.entity.util.WriteException;
-import org.atlasapi.equivalence.EquivalenceGraphUpdate;
+import org.atlasapi.equivalence.EquivalenceGraph;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Maintains an equivalent schedule that can be resolved through an {@link
@@ -10,29 +12,10 @@ import org.atlasapi.equivalence.EquivalenceGraphUpdate;
  */
 public interface EquivalentScheduleWriter {
 
-    /**
-     * <p>Updates the schedule and removes stale schedule entries according to a {@link
-     * ScheduleUpdate} such that it can be retrieved through {@link #resolveSchedules}.</p>
-     *
-     * @param update - the update to apply
-     * @throws WriteException - if there is an error during updating the schedule.
-     */
     void updateSchedule(ScheduleUpdate update) throws WriteException;
 
-    /**
-     * <p>Update equivalences for particular items according to an {@link EquivalenceUpdate}.</p>
-     *
-     * @param update - the update to apply.
-     * @throws WriteException - if there is an error during updating the schedule.
-     */
-    void updateEquivalences(EquivalenceGraphUpdate update) throws WriteException;
+    void updateEquivalences(ImmutableSet<EquivalenceGraph> graphs) throws WriteException;
 
-    /**
-     * Updates content in equivalent schedule store.
-     *
-     * @param content - content in the equivalent set
-     * @throws WriteException
-     */
     void updateContent(Iterable<Item> content) throws WriteException;
 
 }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalenceGraphUpdateResolver.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalenceGraphUpdateResolver.java
@@ -1,0 +1,71 @@
+package org.atlasapi.messaging;
+
+import java.util.concurrent.ExecutionException;
+
+import org.atlasapi.entity.Id;
+import org.atlasapi.equivalence.EquivalenceGraph;
+import org.atlasapi.equivalence.EquivalenceGraphStore;
+import org.atlasapi.equivalence.EquivalenceGraphUpdate;
+import org.atlasapi.util.ImmutableCollectors;
+
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The purpose of this class it to make
+ * {@link org.atlasapi.equivalence.EquivalenceGraphUpdateMessage} messages idempotent by
+ * resolving the referenced graphs from the {@link org.atlasapi.equivalence.EquivalenceGraphStore}
+ * and updating the message to contain an up-to-date view of the system.
+ * <p>
+ * This accomplishes:
+ * <ul>
+ *     <li>Allows us to replay messages as needed to cope with a failure</li>
+ *     <li>Eliminates issues where a backlogged queue will not apply updates that represent
+ *     an out-of-date view of the system when processing old messages</li>
+ *     <li>Allows us to retry messages out of order if they fail</li>
+ * </ul>
+ * <p>
+ * This class can only be used when the updated/created graphs can be treated identically and the
+ * deleted graphs ignored, i.e. if the only part of the message that the consumer intends to use
+ * is the output of {@link EquivalenceGraphUpdate#getAllGraphs()}.
+ */
+public class EquivalenceGraphUpdateResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(EquivalenceGraphUpdateResolver.class);
+
+    private final EquivalenceGraphStore graphStore;
+
+    private EquivalenceGraphUpdateResolver(EquivalenceGraphStore graphStore) {
+        this.graphStore = checkNotNull(graphStore);
+    }
+
+    public static EquivalenceGraphUpdateResolver create(EquivalenceGraphStore graphStore) {
+        return new EquivalenceGraphUpdateResolver(graphStore);
+    }
+
+    public ImmutableSet<EquivalenceGraph> resolve(EquivalenceGraphUpdate graphUpdate) {
+        ImmutableSet<Id> graphIds = graphUpdate.getAllGraphs()
+                .stream()
+                .map(EquivalenceGraph::getId)
+                .collect(ImmutableCollectors.toSet());
+
+        try {
+            return graphStore.resolveIds(graphIds).get()
+                    .values()
+                    .stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(ImmutableCollectors.toSet());
+
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to resolve equivalence graphs for {}", Joiner.on(",").join(graphIds));
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ChannelIntervalScheduleBootstrapTask.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ChannelIntervalScheduleBootstrapTask.java
@@ -182,8 +182,9 @@ public class ChannelIntervalScheduleBootstrapTask implements Callable<UpdateProg
             for (Id id : ids) {
                 Optional<EquivalenceGraph> graph = graphs.get(id);
                 if (graph.isPresent()) {
-                    updater.updateEquivalences(new EquivalenceGraphUpdate(
-                            graph.get(), Lists.newArrayList(), Lists.newArrayList()));
+                    EquivalenceGraphUpdate update = new EquivalenceGraphUpdate(
+                            graph.get(), Lists.newArrayList(), Lists.newArrayList());
+                    updater.updateEquivalences(update.getAllGraphs());
                 } else {
                     log.warn("Failed to resolve graph for {}", id);
                 }

--- a/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalenceGraphUpdateResolverTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalenceGraphUpdateResolverTest.java
@@ -1,0 +1,123 @@
+package org.atlasapi.messaging;
+
+import java.util.Map;
+
+import org.atlasapi.content.ItemRef;
+import org.atlasapi.entity.Id;
+import org.atlasapi.equivalence.EquivalenceGraph;
+import org.atlasapi.equivalence.EquivalenceGraphStore;
+import org.atlasapi.equivalence.EquivalenceGraphUpdate;
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.collect.ImmutableOptionalMap;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EquivalenceGraphUpdateResolverTest {
+    
+    @Mock private EquivalenceGraphStore graphStore;
+    
+    private EquivalenceGraphUpdateResolver graphUpdateResolver;
+
+    private EquivalenceGraph staleUpdated;
+    private EquivalenceGraph currentUpdated;
+    private EquivalenceGraph staleCreated;
+    private EquivalenceGraph currentCreated;
+
+    @Before
+    public void setUp() throws Exception {
+        graphUpdateResolver = EquivalenceGraphUpdateResolver.create(graphStore);
+
+        staleUpdated = EquivalenceGraph.valueOf(getItem(0L));
+        currentUpdated = EquivalenceGraph.valueOf(getItem(1L));
+
+        staleCreated = EquivalenceGraph.valueOf(getItem(2L));
+        currentCreated = EquivalenceGraph.valueOf(getItem(3L));
+    }
+
+    @Test
+    public void resolveUpdatedGraph() throws Exception {
+        setupMocks(ImmutableMap.of(staleUpdated.getId(), currentUpdated));
+
+        ImmutableSet<EquivalenceGraph> graphs = graphUpdateResolver.resolve(
+                EquivalenceGraphUpdate.builder(staleUpdated).build()
+        );
+
+        assertThat(graphs.size(), is(1));
+        assertThat(graphs.contains(currentUpdated), is(true));
+    }
+
+    @Test
+    public void resolveCreatedGraphs() throws Exception {
+        setupMocks(ImmutableMap.of(
+                staleUpdated.getId(), currentUpdated,
+                staleCreated.getId(), currentCreated
+        ));
+
+        ImmutableSet<EquivalenceGraph> graphs = graphUpdateResolver.resolve(
+                EquivalenceGraphUpdate.builder(staleUpdated)
+                        .withCreated(ImmutableList.of(staleCreated))
+                        .build()
+        );
+
+        assertThat(graphs.size(), is(2));
+        assertThat(graphs.contains(currentCreated), is(true));
+    }
+
+    @Test
+    public void doNotReturnUpdatedGraphIfItDoesNotResolve() throws Exception {
+        setupMocks(ImmutableMap.of(), staleUpdated.getId());
+
+        ImmutableSet<EquivalenceGraph> graphs = graphUpdateResolver.resolve(
+                EquivalenceGraphUpdate.builder(staleUpdated).build()
+        );
+
+        assertThat(graphs.size(), is(0));
+    }
+
+    @Test
+    public void doNotReturnCreatedGraphIfItDoesNotResolve() throws Exception {
+        setupMocks(
+                ImmutableMap.of(staleUpdated.getId(), currentUpdated),
+                staleCreated.getId()
+        );
+
+        ImmutableSet<EquivalenceGraph> graphs = graphUpdateResolver.resolve(
+                EquivalenceGraphUpdate.builder(staleUpdated)
+                        .withCreated(ImmutableList.of(staleCreated))
+                        .build()
+        );
+
+        assertThat(graphs.size(), is(1));
+        assertThat(graphs.contains(currentUpdated), is(true));
+        assertThat(graphs.contains(staleCreated), is(false));
+    }
+
+    private void setupMocks(Map<Id, EquivalenceGraph> graphs, Id... missingIds) {
+        when(graphStore.resolveIds(
+                Sets.union(graphs.keySet(), ImmutableSet.copyOf(missingIds))
+        ))
+                .thenReturn(Futures.immediateFuture(
+                        ImmutableOptionalMap.fromMap(graphs)
+                ));
+    }
+
+    private ItemRef getItem(long id) {
+        return new ItemRef(Id.valueOf(id), Publisher.METABROADCAST, "", DateTime.now());
+    }
+}

--- a/atlas-processing/src/test/resources/log4j.properties
+++ b/atlas-processing/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n

--- a/atlas-testlib/src/main/java/org/atlasapi/schedule/EquivalentScheduleStoreTester.java
+++ b/atlas-testlib/src/main/java/org/atlasapi/schedule/EquivalentScheduleStoreTester.java
@@ -4,11 +4,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.content.Broadcast;
-import org.atlasapi.content.BroadcastRef;
 import org.atlasapi.content.Item;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identifiables;
-import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.Equivalent;
 import org.atlasapi.media.entity.Publisher;
@@ -55,7 +53,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -100,7 +98,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         scheduleRef = ScheduleRef.forChannel(channel.getId(), interval)
@@ -161,7 +159,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -202,7 +200,7 @@ public final class EquivalentScheduleStoreTester
 
         getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(item.toRef(),
-                        ImmutableSet.<ResourceRef>of(equiv.toRef()),
+                        ImmutableSet.of(equiv.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 );
 
@@ -216,7 +214,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -255,7 +253,7 @@ public final class EquivalentScheduleStoreTester
 
         getSubjectGenerator().getEquivalenceGraphStore().updateEquivalences(
                 item.toRef(),
-                ImmutableSet.<ResourceRef>of(equiv.toRef()),
+                ImmutableSet.of(equiv.toRef()),
                 ImmutableSet.of(Publisher.METABROADCAST)
         );
 
@@ -269,7 +267,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -315,12 +313,12 @@ public final class EquivalentScheduleStoreTester
 
         getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(item.toRef(),
-                        ImmutableSet.<ResourceRef>of(equiv.toRef()),
+                        ImmutableSet.of(equiv.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 );
         getSubjectGenerator().getEquivalenceGraphStore().updateEquivalences(
                 otherEquiv.toRef(),
-                ImmutableSet.<ResourceRef>of(item.toRef()),
+                ImmutableSet.of(item.toRef()),
                 ImmutableSet.of(Publisher.METABROADCAST)
         );
 
@@ -335,7 +333,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -378,7 +376,7 @@ public final class EquivalentScheduleStoreTester
 
         getSubjectGenerator().getEquivalenceGraphStore().updateEquivalences(
                 otherEquiv.toRef(),
-                ImmutableSet.<ResourceRef>of(
+                ImmutableSet.of(
                         item.toRef()),
                 ImmutableSet.of(Publisher.METABROADCAST)
         );
@@ -394,18 +392,19 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore().updateSchedule(new ScheduleUpdate(
                 Publisher.METABROADCAST,
                 scheduleRef,
-                ImmutableSet.<BroadcastRef>of()
+                ImmutableSet.of()
         ));
 
         EquivalenceGraphUpdate equivUpdate = getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(
                         item.toRef(),
-                        ImmutableSet.<ResourceRef>of(equiv.toRef()),
+                        ImmutableSet.of(equiv.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 )
                 .get();
 
-        getSubjectGenerator().getEquivalentScheduleStore().updateEquivalences(equivUpdate);
+        getSubjectGenerator().getEquivalentScheduleStore()
+                .updateEquivalences(equivUpdate.getAllGraphs());
 
         EquivalentSchedule resolved
                 = get(getSubjectGenerator().getEquivalentScheduleStore()
@@ -485,7 +484,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -593,7 +592,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -684,7 +683,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef1,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         ScheduleRef scheduleRef2 = ScheduleRef
@@ -697,7 +696,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -752,7 +751,7 @@ public final class EquivalentScheduleStoreTester
 
         getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(item.toRef(),
-                        ImmutableSet.<ResourceRef>of(equiv.toRef()),
+                        ImmutableSet.of(equiv.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 );
 
@@ -766,7 +765,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore().updateSchedule(new ScheduleUpdate(
                 Publisher.METABROADCAST,
                 scheduleRef,
-                ImmutableSet.<BroadcastRef>of()
+                ImmutableSet.of()
         ));
 
         EquivalentSchedule resolved
@@ -833,7 +832,7 @@ public final class EquivalentScheduleStoreTester
                 new ScheduleUpdate(
                         Publisher.METABROADCAST,
                         scheduleRef1,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 )
         );
 
@@ -846,7 +845,7 @@ public final class EquivalentScheduleStoreTester
                 new ScheduleUpdate(
                         Publisher.BBC_KIWI,
                         scheduleRef2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 )
         );
 
@@ -883,18 +882,21 @@ public final class EquivalentScheduleStoreTester
         EquivalenceGraphUpdate equivUpdate = getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(
                         item1.toRef(),
-                        ImmutableSet.<ResourceRef>of(item2.toRef()),
+                        ImmutableSet.of(item2.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 ).get();
         EquivalenceGraphUpdate equivUpdate2 = getSubjectGenerator().getEquivalenceGraphStore()
                 .updateEquivalences(
                         item2.toRef(),
-                        ImmutableSet.<ResourceRef>of(item1.toRef()),
+                        ImmutableSet.of(item1.toRef()),
                         ImmutableSet.of(Publisher.METABROADCAST)
                 ).get();
 
-        getSubjectGenerator().getEquivalentScheduleStore().updateEquivalences(equivUpdate);
-        getSubjectGenerator().getEquivalentScheduleStore().updateEquivalences(equivUpdate2);
+        getSubjectGenerator().getEquivalentScheduleStore()
+                .updateEquivalences(equivUpdate.getAllGraphs());
+
+        getSubjectGenerator().getEquivalentScheduleStore()
+                .updateEquivalences(equivUpdate2.getAllGraphs());
 
         currentMbSched = get(
                 getSubjectGenerator().getEquivalentScheduleStore().resolveSchedules(
@@ -1014,7 +1016,7 @@ public final class EquivalentScheduleStoreTester
                 new ScheduleUpdate(
                         Publisher.METABROADCAST,
                         scheduleRef1,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 )
         );
 
@@ -1027,7 +1029,7 @@ public final class EquivalentScheduleStoreTester
                 new ScheduleUpdate(
                         Publisher.BBC_KIWI,
                         scheduleRef2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 )
         );
         getSubjectGenerator().getEquivalentScheduleStore()
@@ -1094,12 +1096,12 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRefBefore,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRefAfter,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         Item item1 = new Item(Id.valueOf(1), Publisher.METABROADCAST);
@@ -1127,7 +1129,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         Item item4 = new Item(Id.valueOf(4), Publisher.METABROADCAST);
@@ -1143,7 +1145,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -1253,7 +1255,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         Item item4 = new Item(Id.valueOf(4), Publisher.METABROADCAST);
@@ -1269,7 +1271,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         scheduleRef2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved
@@ -1352,7 +1354,7 @@ public final class EquivalentScheduleStoreTester
                 .build();
 
         getSubjectGenerator().getEquivalentScheduleStore()
-                             .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST, update1, ImmutableSet.<BroadcastRef>of()));
+                             .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST, update1, ImmutableSet.of()));
 
         Broadcast item2NewBroadcast = new Broadcast(channel, item2BroadcastStart, item2BroadcastEnd).withId("bid2");
         item2.setBroadcasts(ImmutableSet.of(item2NewBroadcast));
@@ -1365,7 +1367,7 @@ public final class EquivalentScheduleStoreTester
                 .build();
 
         getSubjectGenerator().getEquivalentScheduleStore()
-                .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST, update1, ImmutableSet.<BroadcastRef>of(item2Broadcast.toRef())));
+                .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST, update1, ImmutableSet.of(item2Broadcast.toRef())));
 
         EquivalentSchedule resolved = get(
                 getSubjectGenerator().getEquivalentScheduleStore().resolveSchedules(
@@ -1466,7 +1468,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         update1,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         item1.setBroadcasts(ImmutableSet.of(item1Broadcast2));
@@ -1486,7 +1488,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         update2,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         item4.addBroadcast(item4Broadcast);
@@ -1503,7 +1505,7 @@ public final class EquivalentScheduleStoreTester
         getSubjectGenerator().getEquivalentScheduleStore()
                 .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
                         update3,
-                        ImmutableSet.<BroadcastRef>of()
+                        ImmutableSet.of()
                 ));
 
         EquivalentSchedule resolved = get(


### PR DESCRIPTION
- As it is right now equivalence update messages are fat messages that
  contain the equivalent sets that have been updated. This means if
  we have a queue that is backlogged for several hours, when those
  messages do get processed they may temporarily reset the updated
  stores to an out-of-date view of the equivalence graphs. This could
  potentially undo manual bootstraps that might have been applied to
  mitigate the backlog
- Create delegate EquivalenceGraphUpdateResolver that resolves the
  current state of the graphs references by the graph update message
  and change EquivalentContentIndexingGraphWorker and
  EquivalentScheduleStoreGraphUpdateWorker to use the new delegate to
  get an up-to-date view of the graphs before passing them to the
  downstream stores
- The respective equivalent content graph update worker cannot be
  similarly modified because the downstream store needs to fully
  process all equivalence graph update messages to avoid introducing
  stale data. This is to ensure that content moved from graph A to
  graph B is properly deleted from graph A.
- Minor code style cleanup; add test log4j.properties to clean up
  test console output