### PR TITLE
MBST-15466: Fix C* CrewMember asymmetric serialisation bug

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CrewMemberSerializer.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CrewMemberSerializer.java
@@ -28,17 +28,34 @@ public class CrewMemberSerializer {
     }
 
     public CrewMember deserialize(ContentProtos.CrewMember crewMember) {
-        CrewMember.Role role = CrewMember.Role.fromKey(crewMember.getRole());
-        CrewMember member;
-        if (role == CrewMember.Role.ACTOR) {
-            member = new Actor().withCharacter(crewMember.getCharacter());
-        } else {
-            member = new CrewMember();
+        CrewMember member = new CrewMember();
+
+        // roles are optional, but used as a determining factor for Actor vs CrewMember
+        if (crewMember.hasRole()) {
+            CrewMember.Role role = CrewMember.Role.fromKey(crewMember.getRole());
+
+            if (role == CrewMember.Role.ACTOR) {
+                member = new Actor();
+                if (crewMember.hasCharacter()) {
+                    ((Actor) member).withCharacter(crewMember.getCharacter());
+                }
+
+            } else {
+                member.withRole(role);
+            }
         }
-        member.withName(crewMember.getName())
-                .withRole(role)
-                .withProfileLinks(ImmutableSet.copyOf(crewMember.getProfileLinksList()));
-        member.setCanonicalUri(crewMember.getUri());
+
+
+        if (crewMember.hasName()) {
+            member.withName(crewMember.getName());
+        }
+
+        if (crewMember.hasUri()) {
+            member.setCanonicalUri(crewMember.getUri());
+        }
+
+        member.withProfileLinks(ImmutableSet.copyOf(crewMember.getProfileLinksList()));
+
         return member;
     }
 

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/CrewMemberSerializerTest.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/CrewMemberSerializerTest.java
@@ -21,7 +21,7 @@ public class CrewMemberSerializerTest {
 
         CrewMember deserialized = serializer.deserialize(serializer.serialize(member));
 
-        checkMemeberProperties(member, deserialized);
+        checkMemberProperties(member, deserialized);
     }
 
     @Test
@@ -32,12 +32,46 @@ public class CrewMemberSerializerTest {
         CrewMember deserialized = serializer.deserialize(serializer.serialize(actor));
 
         assertThat(deserialized, is(instanceOf(Actor.class)));
-        checkMemeberProperties(actor, deserialized);
+        checkMemberProperties(actor, deserialized);
         assertThat(((Actor) deserialized).character(), is(actor.character()));
 
     }
 
-    private void checkMemeberProperties(CrewMember member, CrewMember deserialized) {
+    @Test
+    public void testMinimalCrewMember() {
+        CrewMember deserialized;
+        CrewMember minimalCrewMember = new CrewMember();
+
+        deserialized = serializer.deserialize(serializer.serialize(minimalCrewMember));
+        assertThat(deserialized, is(instanceOf(CrewMember.class)));
+        checkMemberProperties(minimalCrewMember, deserialized);
+
+        minimalCrewMember.withRole(CrewMember.Role.ADVERTISER);
+        deserialized = serializer.deserialize(serializer.serialize(minimalCrewMember));
+        assertThat(deserialized, is(instanceOf(CrewMember.class)));
+        checkMemberProperties(minimalCrewMember, deserialized);
+    }
+
+
+    @Test
+    public void testMinimalActor() {
+        Actor minimalActor = new Actor();
+
+        CrewMember deserialized = serializer.deserialize(serializer.serialize(minimalActor));
+        assertThat(deserialized, is(instanceOf(Actor.class)));
+
+        checkMemberProperties(minimalActor, deserialized);
+        assertThat(((Actor) deserialized).character(), is(minimalActor.character()));
+
+        minimalActor.withCharacter("Bob Smith");
+        deserialized = serializer.deserialize(serializer.serialize(minimalActor));
+        assertThat(deserialized, is(instanceOf(Actor.class)));
+
+        checkMemberProperties(minimalActor, deserialized);
+        assertThat(((Actor) deserialized).character(), is(minimalActor.character()));
+    }
+
+    private void checkMemberProperties(CrewMember member, CrewMember deserialized) {
         assertThat(deserialized.getCanonicalUri(), is(member.getCanonicalUri()));
         assertThat(deserialized.name(), is(member.name()));
         assertThat(deserialized.role(), is(member.role()));


### PR DESCRIPTION
CrewMembers have a bunch of optional fields.
These are serialised without problems, but the deserialiser assumes presence of everything.

Owl only sparsely populates CrewMembers in most cases