### PR TITLE
Enable persistent retry policy / failed message persistence on workers

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
@@ -123,6 +123,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(topicIndexingNumOfConsumers)
                 .withMaxConsumers(topicIndexingNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -147,6 +148,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(equivContentGraphChangesNumOfConsumers)
                 .withMaxConsumers(equivContentGraphChangesNumOfConsumers)
+                .withFailedMessagePersistence(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -176,6 +178,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(equivContentContentChangesNumOfConsumers)
                 .withMaxConsumers(equivContentContentChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -211,6 +214,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(equivScheduleGraphChangesNumOfConsumers)
                 .withMaxConsumers(equivScheduleGraphChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -226,6 +230,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(equivScheduleContentChangesNumOfConsumers)
                 .withMaxConsumers(equivScheduleContentChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -250,6 +255,7 @@ public class WorkersModule {
                 )
                 .withDefaultConsumers(equivScheduleScheduleChangesNumOfConsumers)
                 .withMaxConsumers(equivScheduleScheduleChangesNumOfConsumers)
+                .withFailedMessagePersistence(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -276,6 +282,7 @@ public class WorkersModule {
                 .withProducerSystem(equivSystem)
                 .withDefaultConsumers(contentEquivalenceGraphChangesNumOfConsumers)
                 .withMaxConsumers(contentEquivalenceGraphChangesNumOfConsumers)
+                .withFailedMessagePersistence(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -300,6 +307,7 @@ public class WorkersModule {
                 .withMaxConsumers(contentIndexingNumOfConsumers)
                 .withDefaultConsumers(contentIndexingNumOfConsumers)
                 .withConsumerSystem(consumerSystem)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -326,6 +334,7 @@ public class WorkersModule {
                 .withMaxConsumers(contentIndexingEquivalenceGraphChangesNumOfConsumers)
                 .withDefaultConsumers(contentIndexingEquivalenceGraphChangesNumOfConsumers)
                 .withConsumerSystem(consumerSystem)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
@@ -126,6 +126,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(contentChangesNumOfConsumers)
                 .withMaxConsumers(contentChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -147,6 +148,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(organisationChangesNumOfConsumers)
                 .withMaxConsumers(organisationChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -169,6 +171,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(scheduleChangesNumOfConsumers)
                 .withMaxConsumers(scheduleChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -191,6 +194,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(scheduleChangesNumOfConsumers)
                 .withMaxConsumers(scheduleChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -212,6 +216,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(topicChangesNumOfConsumers)
                 .withMaxConsumers(topicChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -233,6 +238,7 @@ public class BootstrapWorkersModule {
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(eventChangesNumOfConsumers)
                 .withMaxConsumers(eventChangesNumOfConsumers)
+                .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .build();
     }
 
@@ -323,7 +329,8 @@ public class BootstrapWorkersModule {
 
     @Bean
     public ChannelIntervalScheduleBootstrapTaskFactory scheduleV2BootstrapTaskFactory() {
-        return new ChannelIntervalScheduleBootstrapTaskFactory(legacy.legacyScheduleStore(),
+        return new ChannelIntervalScheduleBootstrapTaskFactory(
+                legacy.legacyScheduleStore(),
                 persistence.v2ScheduleStore(),
                 new DelegatingContentStore(
                         legacy.legacyContentResolver(),


### PR DESCRIPTION
- Workers where it is not safe to replay messages out of order are set
  to only persist failed messages. The others will attempt to retry
  persisted failed messages before giving up permanently.