### PR TITLE
Fix bug with POST /application throwing a 403

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/application/ApplicationsController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/ApplicationsController.java
@@ -162,7 +162,7 @@ public class ApplicationsController {
 
             // There will only every be 0 or 1 user in this iterable
             Optional<User> user = Iterables.tryFind(
-                    writeResult.getUserAccountsWithNewApplication(),
+                    userAccounts,
                     Predicates.alwaysTrue()
             );
 
@@ -208,7 +208,7 @@ public class ApplicationsController {
             UserAccountsAwareQueryContext context = new UserAccountsAwareQueryContext(
                     ApplicationSources.defaults(),
                     ActiveAnnotations.standard(),
-                    writeResult.getUserAccountsWithNewApplication(),
+                    userAccounts,
                     request
             );
             UserAccountsAwareQuery<Application> applicationsQuery = UserAccountsAwareQuery


### PR DESCRIPTION
- We querying for the modified application we were only passing in
  the user accounts that had a new application created against them.
  If the application was edited instead of created that list would
  have been empty so when we try to resolve that application after
  updating it we would get a 403 since no user could be found with
  permision to access it