### PR TITLE
Simplify result reporting in ContentBootstrapListener

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/content/Content.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Content.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.Aliased;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Sourced;
@@ -179,7 +181,7 @@ public abstract class Content extends Described implements Aliased, Sourced, Equ
         to.eventRefs = from.eventRefs;
     }
 
-    public void setReadHash(String readHash) {
+    public void setReadHash(@Nullable String readHash) {
         this.readHash = readHash;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Item.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Item.java
@@ -80,6 +80,7 @@ public class Item extends Content {
         setContainerRef(container.toRef());
     }
 
+    @Nullable
     @FieldName("container_ref")
     public ContainerRef getContainerRef() {
         return containerRef;

--- a/atlas-core/src/main/java/org/atlasapi/content/Series.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Series.java
@@ -1,5 +1,7 @@
 package org.atlasapi.content;
 
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
@@ -46,6 +48,7 @@ public class Series extends Container {
         this.brandRef = brandRef;
     }
 
+    @Nullable
     @FieldName("brand_ref")
     public BrandRef getBrandRef() {
         return this.brandRef;

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapController.java
@@ -177,13 +177,13 @@ public class ContentBootstrapController {
 
         ContentBootstrapListener.Result result = content.accept(contentBootstrapListener);
 
-        if (result.isSucceeded()) {
+        if (result.getSucceeded()) {
             resp.setStatus(HttpStatus.OK.value());
         } else {
             resp.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         }
 
-        resp.getWriter().println(result.getMessage());
+        resp.getWriter().println(result.toString());
         resp.getWriter().flush();
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 
 import org.atlasapi.AtlasPersistenceModule;
-import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.content.Container;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.ContentIndex;
@@ -298,7 +297,7 @@ public class ContentDebugController {
             ContentBootstrapListener.Result result = content.accept(listener);
 
             response.setStatus(HttpStatus.OK.value());
-            response.getWriter().println(result.getMessage());
+            response.getWriter().println(result.toString());
             response.flushBuffer();
         } catch (Throwable t) {
             t.printStackTrace(response.getWriter());

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ContentBootstrapListenerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/ContentBootstrapListenerTest.java
@@ -94,7 +94,7 @@ public class ContentBootstrapListenerTest {
 
         ContentBootstrapListener.Result result = contentBootstrapListener.visit(item);
 
-        assertThat(result.isSucceeded(), is(true));
+        assertThat(result.getSucceeded(), is(true));
 
         verifyContentMigration(item, itemRef, graphUpdate);
         verify(legacySegmentMigrator).migrateLegacySegment(segmentRef.getId());
@@ -115,7 +115,9 @@ public class ContentBootstrapListenerTest {
 
         ContentBootstrapListener.Result result = contentBootstrapListener.visit(brand);
 
-        assertThat(result.isSucceeded(), is(true));
+        assertThat(result.getSucceeded(), is(true));
+
+        System.out.println(result);
 
         verifyContentMigration(brand, brandRef, brandGraphUpdate);
         verifyContentMigration(series, seriesRef, seriesGraphUpdate);
@@ -157,7 +159,7 @@ public class ContentBootstrapListenerTest {
 
         ContentBootstrapListener.Result result = contentBootstrapListener.visit(item);
 
-        assertThat(result.isSucceeded(), is(true));
+        assertThat(result.getSucceeded(), is(true));
 
         verifyContentMigration(seriesItem, seriesItemRef, seriesItemGraphUpdate);
     }


### PR DESCRIPTION
- The bootstrap process is fairly deeply nested. As a result the code
  that was recording success/failure messages for each step of the
  process ended up being very convoluted and hard to follow. Replace
  all that code with a graph that allows parts of the process to
  push/pop arbitrary paths in the graph and add success/failure
  messages under those paths.