### PR TITLE
Change partition key for update content messages to equiv set ID

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/DatastaxCassandraContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/DatastaxCassandraContentStore.java
@@ -13,6 +13,7 @@ import org.atlasapi.entity.AliasIndex;
 import org.atlasapi.entity.CassandraPersistenceException;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.equivalence.EquivalenceGraphStore;
 import org.atlasapi.hashing.content.ContentHasher;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.messaging.ResourceUpdatedMessage;
@@ -74,13 +75,14 @@ public class DatastaxCassandraContentStore extends AbstractContentStore {
             ContentHasher hasher,
             IdGenerator idGenerator,
             MessageSender<ResourceUpdatedMessage> sender,
+            EquivalenceGraphStore graphStore,
             Clock clock,
             Session session,
             ConsistencyLevel writeConsistency,
             ConsistencyLevel readConsistency,
             AliasIndex<Content> aliasIndex
     ) {
-        super(hasher, idGenerator, sender, clock);
+        super(hasher, idGenerator, sender, graphStore, clock);
         this.aliasIndex = checkNotNull(aliasIndex);
         this.session = checkNotNull(session);
         this.marshaller = new DatastaxProtobufContentMarshaller(new ContentSerializer(new ContentSerializationVisitor(

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/AstyanaxCassandraContentStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/AstyanaxCassandraContentStoreIT.java
@@ -10,7 +10,7 @@ public class AstyanaxCassandraContentStoreIT extends CassandraContentStoreIT {
     @Override
     protected ContentStore provideContentStore() {
         return AstyanaxCassandraContentStore
-                .builder(context, CONTENT_TABLE, hasher, sender, idGenerator)
+                .builder(context, CONTENT_TABLE, hasher, sender, idGenerator, graphStore)
                 .withReadConsistency(ConsistencyLevel.CL_ONE)
                 .withWriteConsistency(ConsistencyLevel.CL_ONE)
                 .withClock(clock)

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/DatastaxCassandraContentStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/DatastaxCassandraContentStoreIT.java
@@ -27,6 +27,7 @@ public class DatastaxCassandraContentStoreIT extends CassandraContentStoreIT {
                 hasher,
                 idGenerator,
                 sender,
+                graphStore,
                 clock,
                 session,
                 writeConsistency,


### PR DESCRIPTION
- Workers downstream of the content store operate on the entire
  equivalence set for each updated content at once. Changing the
  partition key to the set ID ensures that all messages of the same
  set are always processed by the same worker.
- This is motivated by an issue where multiple updates on different
  content belonging to the same equiv set could result in many/all
  downstream workers processing the same equiv set at the same time
  and therefore competing for the same locks. This would then slow
  processing down and cause a backlog.