### PR TITLE
Do not allow modifying of application access roles via the API

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/application/ApplicationsController.java
+++ b/atlas-api/src/main/java/org/atlasapi/application/ApplicationsController.java
@@ -248,9 +248,22 @@ public class ApplicationsController {
             Optional<Application> existing = applicationStore.applicationFor(application.getId());
             checkSourceStatusChanges(userAccounts, application, existing);
 
+            Application existingApplication = existing.get();
+
+            ApplicationSources existingApplicationSources = existingApplication.getSources();
+            ApplicationSources applicationSources = application.getSources();
+
+            // Disallow modification of access roles
+            ApplicationSources updatedApplicationSources = applicationSources.copy()
+                    .withAccessRoles(existingApplicationSources.getAccessRoles())
+                    .build();
+
             // Copy across slug and disallow modification of credentials
-            application = application.copy().withSlug(existing.get().getSlug())
-                    .withCredentials(existing.get().getCredentials()).build();
+            application = application.copy()
+                    .withSlug(existingApplication.getSlug())
+                    .withCredentials(existingApplication.getCredentials())
+                    .withSources(updatedApplicationSources)
+                    .build();
 
             application = applicationStore.updateApplication(application);
 

--- a/atlas-core/src/main/java/org/atlasapi/application/ApplicationAccessRole.java
+++ b/atlas-core/src/main/java/org/atlasapi/application/ApplicationAccessRole.java
@@ -1,0 +1,57 @@
+package org.atlasapi.application;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Defines roles for application Role Based Access Control.
+ */
+public enum ApplicationAccessRole {
+    /**
+     * Allows access to the the Owl APIs
+     */
+    OWL_ACCESS("owl-access"),
+
+    /**
+     * Allows access to the Deer APIs
+     */
+    DEER_ACCESS("deer-access"),
+
+    /**
+     * Allows access to API features that have been sunsetted and are scheduled for removal.
+     * This role is intended to allow privileged applications an extended grace period to
+     * adjust to the API changes before their access is cut-off as well.
+     */
+    SUNSETTED_API_FEATURES_ACCESS("sunsetted-api-features-access");
+
+    private final String role;
+
+    ApplicationAccessRole(String role) {
+        this.role = checkNotNull(role);
+    }
+
+    public static ApplicationAccessRole from(String role) {
+        Optional<ApplicationAccessRole> roleOptional = Arrays.stream(ApplicationAccessRole.values())
+                .filter(applicationRole -> applicationRole.getRole().equals(role))
+                .findFirst();
+
+        return roleOptional.orElseThrow(
+                () -> new IllegalArgumentException("Invalid role " + role)
+        );
+    }
+
+    /**
+     * Get the roles that all applications have access to by default
+     */
+    public static ImmutableSet<ApplicationAccessRole> getDefaultRoles() {
+        return ImmutableSet.of(DEER_ACCESS);
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/atlas-core/src/main/java/org/atlasapi/application/ApplicationSources.java
+++ b/atlas-core/src/main/java/org/atlasapi/application/ApplicationSources.java
@@ -28,6 +28,7 @@ public class ApplicationSources {
     private final Optional<List<Publisher>> contentHierarchyPrecedence;
     private final ImmutableSet<Publisher> enabledReadSources;
     private final Boolean imagePrecedenceEnabled;
+    private final ImmutableSet<ApplicationAccessRole> accessRoles;
 
     private static final Comparator<SourceReadEntry> SORT_READS_BY_PUBLISHER =
             (a, b) -> a.getPublisher().compareTo(b.getPublisher());
@@ -45,6 +46,7 @@ public class ApplicationSources {
                 .filter(input -> input.getSourceStatus().isEnabled())
                 .map(SourceReadEntry::getPublisher)
                 .collect(MoreCollectors.toImmutableSet());
+        this.accessRoles = ImmutableSet.copyOf(builder.accessRoles);
     }
 
     public boolean isPrecedenceEnabled() {
@@ -149,6 +151,10 @@ public class ApplicationSources {
         return Optional.of(ordering.onResultOf(Sourceds.toPublisher()));
     }
 
+    public ImmutableSet<ApplicationAccessRole> getAccessRoles() {
+        return accessRoles;
+    }
+
     private static final ApplicationSources dflts = createDefaults();
 
     private static ApplicationSources createDefaults() {
@@ -228,7 +234,8 @@ public class ApplicationSources {
                 .withReadableSources(this.getReads())
                 .withImagePrecedenceEnabled(this.imagePrecedenceEnabled)
                 .withContentHierarchyPrecedence(this.contentHierarchyPrecedence().orNull())
-                .withWritableSources(this.getWrites());
+                .withWritableSources(this.getWrites())
+                .withAccessRoles(this.getAccessRoles());
     }
 
     public static Builder builder() {
@@ -242,6 +249,7 @@ public class ApplicationSources {
         private Boolean imagePrecedenceEnabled = true;
         private List<SourceReadEntry> reads = Lists.newLinkedList();
         private List<Publisher> writes = Lists.newLinkedList();
+        private Set<ApplicationAccessRole> accessRoles;
 
         public Builder withPrecedence(boolean precedence) {
             this.precedence = precedence;
@@ -252,8 +260,9 @@ public class ApplicationSources {
                 @Nullable List<Publisher> contentHierarchyPrecedence
         ) {
             if (contentHierarchyPrecedence != null) {
-                this.contentHierarchyPrecedence = Optional.of(ImmutableList.copyOf(
-                        contentHierarchyPrecedence));
+                this.contentHierarchyPrecedence = Optional.of(
+                        ImmutableList.copyOf(contentHierarchyPrecedence)
+                );
             } else {
                 this.contentHierarchyPrecedence = Optional.absent();
             }
@@ -272,6 +281,11 @@ public class ApplicationSources {
 
         public Builder withImagePrecedenceEnabled(Boolean imagePrecedenceEnabled) {
             this.imagePrecedenceEnabled = imagePrecedenceEnabled;
+            return this;
+        }
+
+        public Builder withAccessRoles(Set<ApplicationAccessRole> accessRoles) {
+            this.accessRoles = accessRoles;
             return this;
         }
 


### PR DESCRIPTION
- The existing code was losing the existing access roles every time
  an application was updated. This was because Deer duplicates the
  application model and its version of the model did not have the
  access roles field so it was always empty.