### PR TITLE
Annotations access moved closer to persistence

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializer.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializer.java
@@ -2,6 +2,7 @@ package org.atlasapi.content;
 
 import java.util.Set;
 
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.entity.Serializer;
 import org.atlasapi.serialization.protobuf.ContentProtos;
 import org.atlasapi.serialization.protobuf.ContentProtos.Content.Builder;
@@ -61,6 +62,17 @@ public final class ContentSerializer implements Serializer<Content, ContentProto
             Class<? extends Content> cls = typeNameMap.get(type);
             Content content = cls.newInstance();
             return content.accept(new ContentDeserializationVisitor(p));
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public Content deserialize(ContentProtos.Content p, Set<Annotation> activeAnnotations) {
+        try {
+            String type = p.getType();
+            Class<? extends Content> cls = typeNameMap.get(type);
+            Content content = cls.newInstance();
+            return content.accept(new ContentDeserializationVisitor(p, activeAnnotations));
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }

--- a/atlas-core/src/main/java/org/atlasapi/content/Container.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Container.java
@@ -36,12 +36,17 @@ public abstract class Container extends Content {
     public Container() {
     }
 
+    @Nullable
     @FieldName("item_refs")
     public ImmutableList<ItemRef> getItemRefs() {
         return itemRefs;
     }
 
-    public void setItemRefs(Iterable<ItemRef> itemRefs) {
+    public void setItemRefs(@Nullable Iterable<ItemRef> itemRefs) {
+        if (itemRefs == null) {
+            this.itemRefs = null;
+            return;
+        }
         this.itemRefs = ImmutableList.copyOf(itemRefs);
     }
 
@@ -61,11 +66,16 @@ public abstract class Container extends Content {
         return accept((ContainerVisitor<V>) visitor);
     }
 
+    @Nullable
     public Map<ItemRef, Iterable<BroadcastRef>> getUpcomingContent() {
         return upcomingContent;
     }
 
-    public void setUpcomingContent(Map<ItemRef, Iterable<BroadcastRef>> upcomingContent) {
+    public void setUpcomingContent(@Nullable Map<ItemRef, Iterable<BroadcastRef>> upcomingContent) {
+        if (upcomingContent == null) {
+            this.upcomingContent = null;
+            return;
+        }
         this.upcomingContent = ImmutableMap.copyOf(
                 Maps.filterValues(
                         Maps.transformValues(
@@ -89,11 +99,16 @@ public abstract class Container extends Content {
         );
     }
 
+    @Nullable
     public Map<ItemRef, Iterable<LocationSummary>> getAvailableContent() {
         return availableContent;
     }
 
-    public void setAvailableContent(Map<ItemRef, Iterable<LocationSummary>> availableContent) {
+    public void setAvailableContent(@Nullable Map<ItemRef, Iterable<LocationSummary>> availableContent) {
+        if (availableContent == null) {
+            this.availableContent = null;
+            return;
+        }
         this.availableContent = ImmutableMap.copyOf(
                 Maps.filterValues(
                         Maps.transformValues(
@@ -117,11 +132,16 @@ public abstract class Container extends Content {
         );
     }
 
+    @Nullable
     public List<ItemSummary> getItemSummaries() {
         return itemSummaries;
     }
 
-    public void setItemSummaries(List<ItemSummary> itemSummaries) {
+    public void setItemSummaries(@Nullable List<ItemSummary> itemSummaries) {
+        if (itemSummaries == null) {
+            this.itemSummaries = null;
+            return;
+        }
         this.itemSummaries = itemSummaries.stream()
                 .sorted(ItemSummary.ORDERING)
                 .collect(MoreCollectors.toImmutableList());

--- a/atlas-core/src/main/java/org/atlasapi/content/Content.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Content.java
@@ -233,11 +233,12 @@ public abstract class Content extends Described
     }
 
     @FieldName("manifested_as")
+    @Nullable
     public Set<Encoding> getManifestedAs() {
         return manifestedAs;
     }
 
-    public void setManifestedAs(Set<Encoding> manifestedAs) {
+    public void setManifestedAs(@Nullable Set<Encoding> manifestedAs) {
         this.manifestedAs = manifestedAs;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Item.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Item.java
@@ -120,12 +120,13 @@ public class Item extends Content {
         return blackAndWhite;
     }
 
+    @Nullable
     @FieldName("broadcasts")
     public Set<Broadcast> getBroadcasts() {
         return broadcasts;
     }
 
-    public void setBroadcasts(Set<Broadcast> broadcasts) {
+    public void setBroadcasts(@Nullable Set<Broadcast> broadcasts) {
         this.broadcasts = broadcasts;
     }
 


### PR DESCRIPTION
-Added new deserialize method that accepts annotations that it can use after
-When deserializing check passed annotation when deserializing broadcasts, locations and sub_items
-Added new test to deserializing