### PR TITLE
Change Neo4j graph worker to get adjacents from LookupStore

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/messaging/Neo4jContentStoreGraphUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/Neo4jContentStoreGraphUpdateWorker.java
@@ -1,10 +1,16 @@
 package org.atlasapi.messaging;
 
+import org.atlasapi.content.Content;
+import org.atlasapi.content.ContentResolver;
+import org.atlasapi.entity.Id;
 import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.equivalence.EquivalenceAssertion;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
+import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.service.Neo4jContentStore;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
@@ -14,6 +20,11 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,27 +36,39 @@ public class Neo4jContentStoreGraphUpdateWorker
     private static final Logger log =
             LoggerFactory.getLogger(Neo4jContentStoreGraphUpdateWorker.class);
 
+    private final ContentResolver legacyResolver;
+    private final LookupEntryStore legacyEquivalenceStore;
     private final Neo4jContentStore neo4JContentStore;
     private final Timer timer;
     private final Meter failureMeter;
 
     private Neo4jContentStoreGraphUpdateWorker(
+            ContentResolver legacyResolver,
+            LookupEntryStore legacyEquivalenceStore,
             Neo4jContentStore neo4JContentStore,
             Timer timer,
             Meter failureMeter
     ) {
+        this.legacyResolver = checkNotNull(legacyResolver);
+        this.legacyEquivalenceStore = checkNotNull(legacyEquivalenceStore);
         this.neo4JContentStore = checkNotNull(neo4JContentStore);
         this.timer = checkNotNull(timer);
         this.failureMeter = checkNotNull(failureMeter);
     }
 
     public static Neo4jContentStoreGraphUpdateWorker create(
+            ContentResolver legacyResolver,
+            LookupEntryStore legacyEquivalenceStore,
             Neo4jContentStore neo4JContentStore,
             Timer timer,
             Meter failureMeter
     ) {
         return new Neo4jContentStoreGraphUpdateWorker(
-                neo4JContentStore, timer, failureMeter
+                legacyResolver,
+                legacyEquivalenceStore,
+                neo4JContentStore,
+                timer,
+                failureMeter
         );
     }
 
@@ -80,10 +103,16 @@ public class Neo4jContentStoreGraphUpdateWorker
         Timer.Context time = timer.time();
 
         try {
+            ImmutableSet<ResourceRef> adjacents = getAdjacents(
+                    assertion.getSubject()
+            );
+
+            // Since we are resolving the lookup entry from Mongo this assertion is on all
+            // sources, not just those in the message
             neo4JContentStore.writeEquivalences(
                     assertion.getSubject(),
-                    assertion.getAssertedAdjacents(),
-                    assertion.getSources()
+                    adjacents,
+                    Publisher.all()
             );
 
             time.stop();
@@ -91,6 +120,39 @@ public class Neo4jContentStoreGraphUpdateWorker
             failureMeter.mark();
             throw Throwables.propagate(e);
         }
+    }
+
+    private ImmutableSet<ResourceRef> getAdjacents(
+            ResourceRef subject
+    ) {
+        LookupEntry lookupEntry = getLookupEntry(subject.getId());
+        return getAdjacents(lookupEntry);
+    }
+
+    private LookupEntry getLookupEntry(Id id) {
+        return Iterables.getOnlyElement(
+                legacyEquivalenceStore.entriesForIds(ImmutableList.of(id.longValue()))
+        );
+    }
+
+    private ImmutableSet<ResourceRef> getAdjacents(LookupEntry lookupEntry) {
+        ImmutableSet<Id> adjacentIds = Sets.union(
+                lookupEntry.explicitEquivalents(),
+                lookupEntry.directEquivalents()
+        )
+                .stream()
+                .map(LookupRef::id)
+                .map(Id::valueOf)
+                .collect(MoreCollectors.toImmutableSet());
+
+        return Futures.getUnchecked(
+                legacyResolver.resolveIds(adjacentIds)
+        )
+                .getResources()
+                .toList()
+                .stream()
+                .map(Content::toRef)
+                .collect(MoreCollectors.toImmutableSet());
     }
 
     private long getTimeToProcessInSeconds(AbstractMessage message) {

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/WorkersModule.java
@@ -382,6 +382,8 @@ public class WorkersModule {
 
         Neo4jContentStoreGraphUpdateWorker worker = Neo4jContentStoreGraphUpdateWorker
                 .create(
+                        persistence.legacyContentResolver(),
+                        persistence.legacyEquivalenceStore(),
                         persistence.neo4jContentStore(),
                         metricsModule.metrics().timer(workerName),
                         metricsModule.metrics().meter(workerName + "-failure")

--- a/atlas-processing/src/test/java/org/atlasapi/messaging/Neo4jContentStoreGraphUpdateWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/messaging/Neo4jContentStoreGraphUpdateWorkerTest.java
@@ -1,18 +1,28 @@
 package org.atlasapi.messaging;
 
+import org.atlasapi.content.ContentResolver;
+import org.atlasapi.content.Item;
 import org.atlasapi.content.ItemRef;
 import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
+import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.equivalence.EquivalenceAssertion;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
+import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.service.Neo4jContentStore;
+import org.atlasapi.persistence.content.ContentCategory;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
 import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,23 +31,32 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class Neo4jContentStoreGraphUpdateWorkerTest {
 
+    @Mock private ContentResolver legacyResolver;
+    @Mock private LookupEntryStore legacyEquivalenceStore;
     @Mock private Neo4jContentStore neo4JContentStore;
     @Mock private Timer timer;
     @Mock private Meter failureMeter;
     @Mock private Timer.Context timerContext;
 
     @Mock private EquivalenceGraphUpdate graphUpdate;
+    @Mock private LookupEntry lookupEntry;
 
     private EquivalenceGraphUpdateMessage message;
     private EquivalenceAssertion assertion;
 
     private Neo4jContentStoreGraphUpdateWorker worker;
+    private Item explicitEquivalentItem;
+    private Item directEquivalentItem;
 
     @Before
     public void setUp() throws Exception {
@@ -61,20 +80,106 @@ public class Neo4jContentStoreGraphUpdateWorkerTest {
 
         when(timer.time()).thenReturn(timerContext);
 
-        worker = Neo4jContentStoreGraphUpdateWorker.create(neo4JContentStore, timer, failureMeter);
+        when(
+                legacyEquivalenceStore.entriesForIds(
+                        ImmutableList.of(assertion.getSubject().getId().longValue())
+                )
+        )
+                .thenReturn(ImmutableList.of(lookupEntry));
+
+        LookupRef explicitEquivalent = new LookupRef(
+                "uriA", 0L, Publisher.BBC, ContentCategory.TOP_LEVEL_ITEM
+        );
+        LookupRef directEquivalent = new LookupRef(
+                "uriB", 1L, Publisher.METABROADCAST, ContentCategory.TOP_LEVEL_ITEM
+        );
+
+        when(lookupEntry.explicitEquivalents()).thenReturn(ImmutableSet.of(explicitEquivalent));
+        when(lookupEntry.directEquivalents()).thenReturn(ImmutableSet.of(directEquivalent));
+
+        explicitEquivalentItem = new Item(
+                Id.valueOf(explicitEquivalent.id()), Publisher.BBC
+        );
+        explicitEquivalentItem.setThisOrChildLastUpdated(DateTime.now());
+        directEquivalentItem = new Item(
+                Id.valueOf(directEquivalent.id()), Publisher.METABROADCAST
+        );
+        directEquivalentItem.setThisOrChildLastUpdated(DateTime.now());
+
+        when(legacyResolver.resolveIds(ImmutableSet.of(
+                Id.valueOf(explicitEquivalent.id()), Id.valueOf(directEquivalent.id()))
+        ))
+                .thenReturn(Futures.immediateFuture(
+                        Resolved.valueOf(ImmutableList.of(
+                                explicitEquivalentItem,
+                                directEquivalentItem
+                        ))
+                ));
+
+        worker = Neo4jContentStoreGraphUpdateWorker.create(
+                legacyResolver,
+                legacyEquivalenceStore,
+                neo4JContentStore,
+                timer,
+                failureMeter
+        );
     }
 
     @Test
     public void processMessageCallsDependenciesInOrder() throws Exception {
+        when(
+                legacyEquivalenceStore.entriesForIds(
+                        ImmutableList.of(assertion.getSubject().getId().longValue())
+                )
+        )
+                .thenReturn(ImmutableList.of(lookupEntry));
+
         worker.process(message);
 
         InOrder order = inOrder(timer, timerContext, neo4JContentStore);
         order.verify(timer).time();
+        //noinspection unchecked
         order.verify(neo4JContentStore).writeEquivalences(
+                any(ResourceRef.class),
+                anySet(),
+                anySet()
+        );
+        order.verify(timerContext).stop();
+    }
+
+    @Test
+    public void processMessageResolvedAdjacentsFromLookupStore() throws Exception {
+        when(
+                legacyEquivalenceStore.entriesForIds(
+                        ImmutableList.of(assertion.getSubject().getId().longValue())
+                )
+        )
+                .thenReturn(ImmutableList.of(lookupEntry));
+
+        worker.process(message);
+
+        verify(neo4JContentStore).writeEquivalences(
+                assertion.getSubject(),
+                ImmutableSet.of(explicitEquivalentItem.toRef(), directEquivalentItem.toRef()),
+                Publisher.all()
+        );
+    }
+
+    @Test
+    public void processMessageIgnoresAdjacentsAndSourcesInMessage() throws Exception {
+        when(
+                legacyEquivalenceStore.entriesForIds(
+                        ImmutableList.of(assertion.getSubject().getId().longValue())
+                )
+        )
+                .thenReturn(ImmutableList.of(lookupEntry));
+
+        worker.process(message);
+
+        verify(neo4JContentStore, never()).writeEquivalences(
                 assertion.getSubject(),
                 assertion.getAssertedAdjacents(),
                 assertion.getSources()
         );
-        order.verify(timerContext).stop();
     }
 }


### PR DESCRIPTION
- Not all equivalence graph changes in Owl will generate a Kafka
  message therefore if we only update according to what is in the
  message we will miss some adjacents
- Also resolving the adjacents as it arrives means we are more
  resilient to getting backlogged and less vulnerable to missing
  individual messages as we will always write the most up-to-date
  view of the equivalence graph with respect to the subject resourceRef