### PR TITLE
Remove logic that generates Neo4j indices on boot

### DIFF
--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
@@ -34,7 +34,7 @@ public class Neo4jModule {
     public Neo4jContentStore neo4jContentStore() {
         ContentWriter contentWriter = ContentWriter.create();
 
-        Neo4jContentStore neo4jContentStore = Neo4jContentStore.builder()
+        return Neo4jContentStore.builder()
                 .withSessionFactory(sessionFactory)
                 .withGraphWriter(EquivalenceWriter.create())
                 .withContentWriter(contentWriter)
@@ -43,10 +43,6 @@ public class Neo4jModule {
                 .withHierarchyWriter(HierarchyWriter.create(contentWriter))
                 .withEquivalentSetResolver(EquivalentSetResolver.create())
                 .build();
-
-        neo4jContentStore.createIndicesAndConstraints();
-
-        return neo4jContentStore;
     }
 
     @VisibleForTesting

--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/Neo4jContentStore.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/Neo4jContentStore.java
@@ -31,9 +31,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.atlasapi.neo4j.service.model.Neo4jContent.CONTENT;
-import static org.atlasapi.neo4j.service.model.Neo4jContent.CONTENT_ID;
 
+/**
+ * This stores requires the following index/constraint to be manually generated on the Neo4j
+ * cluster if it does not exist:
+ * <p>
+ * {@code CREATE CONSTRAINT ON (c:Content) ASSERT c.id IS UNIQUE}
+ */
 public class Neo4jContentStore {
 
     private static final Logger log = LoggerFactory.getLogger(Neo4jContentStore.class);
@@ -68,21 +72,6 @@ public class Neo4jContentStore {
 
     public static SessionFactoryStep builder() {
         return new Builder();
-    }
-
-    public void createIndicesAndConstraints() {
-        try (Session session = sessionFactory.getSession()) {
-            // This will also create a unique index on the same property
-            session.run(
-                    "CREATE CONSTRAINT ON (c:" + CONTENT + ") "
-                            + "ASSERT c." + CONTENT_ID + " IS UNIQUE"
-            )
-                    .consume();
-        } catch (Exception e) {
-            // Given Neo4j is not part of the critical infrastructure yet we swallow any
-            // exceptions here to ensure Neo4j failures do not keep Atlas Deer from initialising
-            log.error("Failed to create indices/constraints on Neo4j", e);
-        }
     }
 
     public void writeEquivalences(ResourceRef subject, Set<ResourceRef> assertedAdjacents,

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4JContentStoreTest.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4JContentStoreTest.java
@@ -30,12 +30,10 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.Transaction;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -81,13 +79,6 @@ public class Neo4JContentStoreTest {
 
         when(sessionFactory.getSession()).thenReturn(session);
         when(session.beginTransaction()).thenReturn(transaction);
-    }
-
-    @Test
-    public void failingToWriteIndicesAndConstraintsDoesNotPropagateException() throws Exception {
-        when(session.run(any(Statement.class))).thenThrow(new RuntimeException());
-
-        contentStore.createIndicesAndConstraints();
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4jContentStoreIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4jContentStoreIT.java
@@ -21,20 +21,7 @@ public class Neo4jContentStoreIT extends AbstractNeo4jIT {
     }
 
     @Test
-    public void creatingIndicesAndConstraintsDoesNotFail() throws Exception {
-        contentStore.createIndicesAndConstraints();
-    }
-
-    @Test
-    public void creatingIndicesAndConstraintsMultipleTimeDoesNotFail() throws Exception {
-        contentStore.createIndicesAndConstraints();
-        contentStore.createIndicesAndConstraints();
-    }
-
-    @Test
     public void createGraphAndResolveEquivalentSet() throws Exception {
-        contentStore.createIndicesAndConstraints();
-
         contentStore.writeEquivalences(
                 new ItemRef(Id.valueOf(0L), Publisher.METABROADCAST, "", DateTime.now()),
                 ImmutableSet.of(


### PR DESCRIPTION
- This query is quite expensive for Neo4j even if the index and
  constraint already exist