### PR TITLE
Change channel_group endpoint to not show channel groups of channels

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -561,12 +561,24 @@ public class QueryWebModule {
         );
     }
 
-    private ChannelWriter channelWriter() {
-        return new ChannelWriter(
+    private ChannelWriter channelWriterGroupSummaryAnnotationSupported() {
+        return ChannelWriter.create(
                 channelGroupResolver,
                 "channels",
                 "channel",
-                new ChannelGroupSummaryWriter(idCodec())
+                new ChannelGroupSummaryWriter(idCodec()),
+                true
+
+        );
+    }
+
+    private ChannelWriter channelWriterGroupSummaryAnnotationNotSupported() {
+        return ChannelWriter.create(
+                channelGroupResolver,
+                "channels",
+                "channel",
+                new ChannelGroupSummaryWriter(idCodec()),
+                false
         );
     }
 
@@ -577,7 +589,7 @@ public class QueryWebModule {
                         CHANNELS,
                         new ChannelGroupChannelsAnnotation(
                                 new ChannelGroupChannelWriter(
-                                        channelWriter()
+                                        channelWriterGroupSummaryAnnotationNotSupported()
                                 ),
                                 channelResolver
                         ),
@@ -594,7 +606,7 @@ public class QueryWebModule {
                 .register(
                         ADVERTISED_CHANNELS,
                         new ChannelGroupAdvertisedChannelsAnnotation(new ChannelGroupChannelWriter(
-                                channelWriter()), channelResolver)
+                                channelWriterGroupSummaryAnnotationNotSupported()), channelResolver)
                 )
                 .build());
     }
@@ -1112,7 +1124,12 @@ public class QueryWebModule {
     protected EntityListWriter<Channel> channelListWriter() {
         return new ChannelListWriter(
                 AnnotationRegistry.<Channel>builder()
-                        .registerDefault(CHANNEL, new ChannelAnnotation(channelWriter()))
+                        .registerDefault(
+                                CHANNEL,
+                                new ChannelAnnotation(
+                                        channelWriterGroupSummaryAnnotationSupported()
+                                )
+                        )
                         .register(ID_SUMMARY, new IdentificationSummaryAnnotation(idCodec()))
                         .register(
                                 CHANNEL_GROUPS,
@@ -1127,12 +1144,18 @@ public class QueryWebModule {
                         )
                         .register(
                                 PARENT,
-                                new ParentChannelAnnotation(channelWriter(), channelResolver),
+                                new ParentChannelAnnotation(
+                                        channelWriterGroupSummaryAnnotationSupported(),
+                                        channelResolver
+                                ),
                                 CHANNEL
                         )
                         .register(
                                 VARIATIONS,
-                                new ChannelVariationAnnotation(channelResolver, channelWriter()),
+                                new ChannelVariationAnnotation(
+                                        channelResolver,
+                                        channelWriterGroupSummaryAnnotationSupported()
+                                ),
                                 CHANNEL
                         )
                         .build());

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -562,24 +562,21 @@ public class QueryWebModule {
     }
 
     private ChannelWriter channelWriterGroupSummaryAnnotationSupported() {
-        return ChannelWriter.create(
-                channelGroupResolver,
-                "channels",
-                "channel",
-                new ChannelGroupSummaryWriter(idCodec()),
-                true
-
-        );
+        return ChannelWriter.builder()
+                .channelGroupResolver(channelGroupResolver)
+                .listName("channels")
+                .fieldName("channel")
+                .channelGroupSummaryWriter(new ChannelGroupSummaryWriter(idCodec()))
+                .buildWithGroupSummaryAnnotationSupported();
     }
 
     private ChannelWriter channelWriterGroupSummaryAnnotationNotSupported() {
-        return ChannelWriter.create(
-                channelGroupResolver,
-                "channels",
-                "channel",
-                new ChannelGroupSummaryWriter(idCodec()),
-                false
-        );
+        return ChannelWriter.builder()
+                .channelGroupResolver(channelGroupResolver)
+                .listName("channels")
+                .fieldName("channel")
+                .channelGroupSummaryWriter(new ChannelGroupSummaryWriter(idCodec()))
+                .buildWithGroupSummaryAnnotationNotSupported();
     }
 
     private ChannelGroupListWriter channelGroupListWriter() {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
@@ -1,6 +1,7 @@
 package org.atlasapi.query.v4.channel;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
@@ -31,6 +32,9 @@ import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
 
 import static org.atlasapi.output.writers.SourceWriter.sourceListWriter;
 import static org.atlasapi.output.writers.SourceWriter.sourceWriter;
@@ -67,18 +71,8 @@ public class ChannelWriter implements EntityListWriter<Channel> {
         this.channelGroupsSummaryAnnotationSupported = channelGroupsSummaryAnnotationSupported;
     }
 
-    public static ChannelWriter create(ChannelGroupResolver channelGroupResolver,
-            String listName,
-            String fieldName,
-            ChannelGroupSummaryWriter channelGroupSummaryWriter,
-            boolean channelGroupSummaryAnnotationSupported
-    ) {
-        return new ChannelWriter(channelGroupResolver,
-                listName,
-                fieldName,
-                channelGroupSummaryWriter,
-                channelGroupSummaryAnnotationSupported
-        );
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Nonnull
@@ -143,5 +137,61 @@ public class ChannelWriter implements EntityListWriter<Channel> {
                         .splitToList(
                                 ctxt.getRequest().getParameter("annotations")
                         ).contains(Annotation.CHANNEL_GROUPS_SUMMARY.toKey());
+    }
+
+    public static class Builder {
+
+        private ChannelGroupResolver channelGroupResolver;
+        private String listName;
+        private String fieldName;
+        private ChannelGroupSummaryWriter channelGroupSummaryWriter;
+        private boolean channelGroupSummaryAnnotationSupported;
+
+        public Builder() {
+        }
+
+        public Builder channelGroupResolver(
+                ChannelGroupResolver channelGroupResolver
+        ) {
+            this.channelGroupResolver = channelGroupResolver;
+            return this;
+        }
+
+        public Builder listName(String listName) {
+            this.listName = listName;
+            return this;
+        }
+
+        public Builder fieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public Builder channelGroupSummaryWriter(
+                ChannelGroupSummaryWriter channelGroupSummaryWriter
+        ) {
+            this.channelGroupSummaryWriter = channelGroupSummaryWriter;
+            return this;
+        }
+
+        public ChannelWriter buildWithGroupSummaryAnnotationNotSupported() {
+            this.channelGroupSummaryAnnotationSupported = false;
+            return this.build();
+        }
+
+        public ChannelWriter buildWithGroupSummaryAnnotationSupported() {
+            this.channelGroupSummaryAnnotationSupported = true;
+            return this.build();
+        }
+
+        private ChannelWriter build() {
+            return new ChannelWriter(
+                    channelGroupResolver,
+                    listName,
+                    fieldName,
+                    channelGroupSummaryWriter,
+                    channelGroupSummaryAnnotationSupported
+            );
+        }
     }
 }


### PR DESCRIPTION
Currently this call is very expensive when used with the 'channel_groups_summary' annotation.

It returns all channels belonging to each returned channel group and also for each channel, every channel group that it belongs to.
This change removes the writing of the last part when the /channel_group/ endpoint is called.

The previous behaviour has been retained for the /channel/ endpoint.