### PR TITLE
Fix for new constructor syntax

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/writers/BroadcastWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/BroadcastWriter.java
@@ -52,12 +52,16 @@ public final class BroadcastWriter implements EntityListWriter<Broadcast> {
         this.listName = checkNotNull(listName);
         this.codec = checkNotNull(codec);
         this.channelResolver = checkNotNull(channelResolver);
-        this.channelWriter = new ChannelWriter(
-                channelGroupResolver,
-                "channels",
-                "channel",
-                new ChannelGroupSummaryWriter(new SubstitutionTableNumberCodec())
-        );
+        this.channelWriter = ChannelWriter.builder()
+                .channelGroupResolver(channelGroupResolver)
+                .listName("channels")
+                .fieldName("channel")
+                .channelGroupSummaryWriter(
+                        new ChannelGroupSummaryWriter(
+                                new SubstitutionTableNumberCodec()
+                        )
+                )
+                .buildWithGroupSummaryAnnotationSupported();
     }
 
     public static BroadcastWriter create(


### PR DESCRIPTION
A class was not changed for new ChannelWriter constructor. It has now been fixed to use the new version.