### PR TITLE
Adding reporting to Columbus Telescope for content migration

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/entity/Id.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/Id.java
@@ -4,6 +4,10 @@ import java.math.BigInteger;
 
 import org.atlasapi.hashing.Hashable;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Function;
 import com.google.common.primitives.Longs;
 
@@ -58,10 +62,13 @@ public final class Id implements Comparable<Id>, Hashable {
         this.longValue = longValue;
     }
 
+    @JsonCreator
     private Id(long longValue) {
         this.longValue = longValue;
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    @JsonSubTypes.Type(value = Long.class)
     public long longValue() {
         return longValue;
     }

--- a/atlas-core/src/main/java/org/atlasapi/entity/ResourceRef.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/ResourceRef.java
@@ -3,27 +3,37 @@ package org.atlasapi.entity;
 import org.atlasapi.hashing.Hashable;
 import org.atlasapi.media.entity.Publisher;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public abstract class ResourceRef implements Identifiable, Sourced, Hashable {
 
     protected final Id id;
     protected final Publisher source;
 
-    public ResourceRef(Id id, Publisher source) {
+    @JsonCreator
+    public ResourceRef(
+            @JsonProperty("id") Id id,
+            @JsonProperty("source") Publisher source
+    ) {
         this.id = checkNotNull(id);
         this.source = checkNotNull(source);
     }
 
     public abstract ResourceType getResourceType();
 
+    @JsonProperty("id")
     public Id getId() {
         return id;
     }
 
+    @JsonProperty("source")
     public Publisher getSource() {
         return source;
     }

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraph.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraph.java
@@ -15,6 +15,8 @@ import org.atlasapi.media.entity.Publisher;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.time.DateTimeZones;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -124,11 +126,12 @@ public final class EquivalenceGraph implements Identifiable {
         private final ImmutableMap<Id, ResourceRef> outgoingEdges;
         private final ImmutableMap<Id, ResourceRef> incomingEdges;
 
+        @JsonCreator
         public Adjacents(
-                ResourceRef subject,
-                DateTime created,
-                Set<ResourceRef> outgoingEdges,
-                Set<ResourceRef> incomingEdges
+                @JsonProperty("subject") ResourceRef subject,
+                @JsonProperty("created") DateTime created,
+                @JsonProperty("outgoingEdges") Set<ResourceRef> outgoingEdges,
+                @JsonProperty("incomingEdges") Set<ResourceRef> incomingEdges
         ) {
             this.subject = checkNotNull(subject);
             this.created = checkNotNull(created);
@@ -168,10 +171,12 @@ public final class EquivalenceGraph implements Identifiable {
             return subject.getSource();
         }
 
+        @JsonProperty("subject")
         public ResourceRef getRef() {
             return subject;
         }
 
+        @JsonProperty("created")
         public DateTime getCreated() {
             return created;
         }
@@ -183,10 +188,12 @@ public final class EquivalenceGraph implements Identifiable {
             );
         }
 
+        @JsonProperty("outgoingEdges")
         public ImmutableSet<ResourceRef> getOutgoingEdges() {
             return ImmutableSet.copyOf(outgoingEdges.values());
         }
 
+        @JsonProperty("incomingEdges")
         public ImmutableSet<ResourceRef> getIncomingEdges() {
             return ImmutableSet.copyOf(incomingEdges.values());
         }

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphUpdateMessage.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphUpdateMessage.java
@@ -3,16 +3,24 @@ package org.atlasapi.equivalence;
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class EquivalenceGraphUpdateMessage extends AbstractMessage {
 
     private final EquivalenceGraphUpdate update;
 
-    public EquivalenceGraphUpdateMessage(String messageId, Timestamp timestamp,
-            EquivalenceGraphUpdate updatedGraphs) {
+    @JsonCreator
+    public EquivalenceGraphUpdateMessage(
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("update") EquivalenceGraphUpdate update
+    ) {
         super(messageId, timestamp);
-        this.update = updatedGraphs;
+        this.update = update;
     }
 
+    @JsonProperty("update")
     public EquivalenceGraphUpdate getGraphUpdate() {
         return update;
     }

--- a/atlas-core/src/main/java/org/atlasapi/messaging/EquivalenceAssertionMessage.java
+++ b/atlas-core/src/main/java/org/atlasapi/messaging/EquivalenceAssertionMessage.java
@@ -8,6 +8,8 @@ import org.atlasapi.media.entity.Publisher;
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -55,8 +57,14 @@ public class EquivalenceAssertionMessage extends AbstractMessage {
     private final ImmutableSet<ResourceRef> assertedAdjacents;
     private final ImmutableSet<Publisher> publishers;
 
-    public EquivalenceAssertionMessage(String messageId, Timestamp timestamp, ResourceRef subject,
-            Set<? extends ResourceRef> assertedAdjacents, Set<Publisher> publishers) {
+    @JsonCreator
+    public EquivalenceAssertionMessage(
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("subject") ResourceRef subject,
+            @JsonProperty("assertedAdjacents") Set<? extends ResourceRef> assertedAdjacents,
+            @JsonProperty("publishers") Set<Publisher> publishers
+    ) {
         super(messageId, timestamp);
         this.subject = subject;
         this.assertedAdjacents = ImmutableSet.copyOf(assertedAdjacents);

--- a/atlas-core/src/main/java/org/atlasapi/messaging/EquivalentContentUpdatedMessage.java
+++ b/atlas-core/src/main/java/org/atlasapi/messaging/EquivalentContentUpdatedMessage.java
@@ -5,6 +5,8 @@ import org.atlasapi.content.ContentRef;
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
 public class EquivalentContentUpdatedMessage extends AbstractMessage {
@@ -12,21 +14,24 @@ public class EquivalentContentUpdatedMessage extends AbstractMessage {
     private final Long equivalentSetId;
     private final ContentRef contentRef;
 
+    @JsonCreator
     public EquivalentContentUpdatedMessage(
-            String messageId,
-            Timestamp timestamp,
-            Long equivalentSetId,
-            ContentRef contentRef
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("equivalentSetId") Long equivalentSetId,
+            @JsonProperty("contentRef") ContentRef contentRef
     ) {
         super(messageId, timestamp);
         this.equivalentSetId = equivalentSetId;
         this.contentRef = contentRef;
     }
 
+    @JsonProperty("equivalentSetId")
     public Long getEquivalentSetId() {
         return equivalentSetId;
     }
 
+    @JsonProperty("contentRef")
     public ContentRef getContentRef() {
         return contentRef;
     }

--- a/atlas-core/src/main/java/org/atlasapi/messaging/JacksonMessageSerializer.java
+++ b/atlas-core/src/main/java/org/atlasapi/messaging/JacksonMessageSerializer.java
@@ -1,6 +1,7 @@
 package org.atlasapi.messaging;
 
 import java.io.IOException;
+import java.util.TimeZone;
 
 import org.atlasapi.content.BrandRef;
 import org.atlasapi.content.BroadcastRef;
@@ -11,6 +12,7 @@ import org.atlasapi.content.ItemRef;
 import org.atlasapi.content.SeriesRef;
 import org.atlasapi.content.SongRef;
 import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
@@ -27,13 +29,19 @@ import com.metabroadcast.common.time.Timestamp;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.base.Objects;
@@ -176,6 +184,7 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
         mapper.setVisibility(PropertyAccessor.GETTER, Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.IS_GETTER, Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.SETTER, Visibility.NONE);
+
         return mapper;
     }
 
@@ -215,5 +224,4 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
                 .addValue(cls.getSimpleName())
                 .toString();
     }
-
 }

--- a/atlas-core/src/main/java/org/atlasapi/messaging/ResourceUpdatedMessage.java
+++ b/atlas-core/src/main/java/org/atlasapi/messaging/ResourceUpdatedMessage.java
@@ -5,6 +5,8 @@ import org.atlasapi.entity.ResourceRef;
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
 /**
@@ -14,12 +16,17 @@ public class ResourceUpdatedMessage extends AbstractMessage {
 
     private ResourceRef updatedResource;
 
-    public ResourceUpdatedMessage(String messageId, Timestamp timestamp,
-            ResourceRef updatedResource) {
+    @JsonCreator
+    public ResourceUpdatedMessage(
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("updatedResource") ResourceRef updatedResource
+    ) {
         super(messageId, timestamp);
         this.updatedResource = updatedResource;
     }
 
+    @JsonProperty("updatedResource")
     public ResourceRef getUpdatedResource() {
         return updatedResource;
     }

--- a/atlas-core/src/main/java/org/atlasapi/schedule/ScheduleUpdateMessage.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/ScheduleUpdateMessage.java
@@ -3,17 +3,26 @@ package org.atlasapi.schedule;
 import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ScheduleUpdateMessage extends AbstractMessage {
 
     private final ScheduleUpdate update;
 
-    public ScheduleUpdateMessage(String mid, Timestamp ts, ScheduleUpdate update) {
-        super(mid, ts);
+    @JsonCreator
+    public ScheduleUpdateMessage(
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("update") ScheduleUpdate update
+    ) {
+        super(messageId, timestamp);
         this.update = checkNotNull(update);
     }
 
+    @JsonProperty("update")
     public ScheduleUpdate getScheduleUpdate() {
         return update;
     }

--- a/atlas-core/src/test/java/org/atlasapi/equivalence/EquivalenceGraphUpdateMessageTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/equivalence/EquivalenceGraphUpdateMessageTest.java
@@ -133,10 +133,9 @@ public class EquivalenceGraphUpdateMessageTest {
     private void testSerializingMessageWith(EquivalenceGraphUpdate update)
             throws MessagingException {
         EquivalenceGraphUpdateMessage egum =
-                new EquivalenceGraphUpdateMessage("message", Timestamp.of(0), update);
+                new EquivalenceGraphUpdateMessage("message", Timestamp.of(DateTime.now().getMillisOfDay()), update);
 
         byte[] serialized = serializer.serialize(egum);
-
         EquivalenceGraphUpdateMessage deserialized = serializer.deserialize(serialized);
 
         assertThat(deserialized, is(egum));

--- a/atlas-core/src/test/java/org/atlasapi/schedule/ScheduleUpdateMessageTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/schedule/ScheduleUpdateMessageTest.java
@@ -11,9 +11,12 @@ import com.metabroadcast.common.time.Timestamp;
 
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 
 public class ScheduleUpdateMessageTest {
@@ -26,13 +29,13 @@ public class ScheduleUpdateMessageTest {
 
         ScheduleUpdate update = new ScheduleUpdate(
                 Publisher.METABROADCAST,
-                ScheduleRef.forChannel(Id.valueOf(1), new Interval(1, 2))
+                ScheduleRef.forChannel(Id.valueOf(1), new Interval(1, 2, DateTimeZone.UTC))
                         .addEntry(
                                 Id.valueOf(1),
-                                new BroadcastRef("a", Id.valueOf(1), new Interval(1, 2))
+                                new BroadcastRef("a", Id.valueOf(1), new Interval(1, 2, DateTimeZone.UTC))
                         )
                         .build(),
-                ImmutableSet.of(new BroadcastRef("b", Id.valueOf(2), new Interval(1, 2)))
+                ImmutableSet.of(new BroadcastRef("b", Id.valueOf(2), new Interval(1, 2, DateTimeZone.UTC)))
         );
         ScheduleUpdateMessage msg
                 = new ScheduleUpdateMessage(
@@ -70,10 +73,10 @@ public class ScheduleUpdateMessageTest {
 
         ScheduleUpdate update = new ScheduleUpdate(
                 Publisher.METABROADCAST,
-                ScheduleRef.forChannel(Id.valueOf(1), new Interval(1, 2))
+                ScheduleRef.forChannel(Id.valueOf(1), new Interval(1, 2, DateTimeZone.UTC))
                         .addEntry(
                                 Id.valueOf(1),
-                                new BroadcastRef("a", Id.valueOf(1), new Interval(1, 2))
+                                new BroadcastRef("a", Id.valueOf(1), new Interval(1, 2, DateTimeZone.UTC))
                         )
                         .build(),
                 ImmutableSet.<BroadcastRef>of()

--- a/atlas-processing/pom.xml
+++ b/atlas-processing/pom.xml
@@ -110,6 +110,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.metabroadcast.columbus.telescope</groupId>
+      <artifactId>telescope-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ColumbusTelescopeReporter.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ColumbusTelescopeReporter.java
@@ -1,0 +1,91 @@
+package org.atlasapi.system.bootstrap;
+
+import java.time.LocalDateTime;
+
+import org.atlasapi.content.Content;
+
+import com.metabroadcast.columbus.telescope.api.EntityState;
+import com.metabroadcast.columbus.telescope.api.Environment;
+import com.metabroadcast.columbus.telescope.api.Event;
+import com.metabroadcast.columbus.telescope.api.Process;
+import com.metabroadcast.columbus.telescope.client.TelescopeClientImpl;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.media.MimeType;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ColumbusTelescopeReporter {
+
+    private final Logger log = LoggerFactory.getLogger(ColumbusTelescopeReporter.class);
+    private final SubstitutionTableNumberCodec codec;
+    private final ObjectMapper mapper;
+    private final TelescopeClientImpl telescopeClient;
+    private final Process process;
+
+    private ColumbusTelescopeReporter(
+            TelescopeClientImpl telescopeClient,
+            String reportingEnvironment,
+            ObjectMapper mapper
+    ) {
+        this.mapper = checkNotNull(mapper);
+        this.codec = SubstitutionTableNumberCodec.lowerCaseOnly();
+        this.telescopeClient = checkNotNull(telescopeClient);
+
+        this.process = Process.create(
+                "Atlas Owl to Atlas Deer Content migration",
+                "atlas-owl-to-atlas-deer-content-migration",
+                (checkNotNull(reportingEnvironment).equals("prod")) ?
+                Environment.PRODUCTION :
+                Environment.STAGE
+        );
+    }
+
+    public static ColumbusTelescopeReporter create(
+            TelescopeClientImpl telescopeClient,
+            String reportingEnvironment,
+            ObjectMapper mapper
+    ) {
+        return new ColumbusTelescopeReporter(telescopeClient, reportingEnvironment, mapper);
+    }
+
+    public void reportSuccessfulMigration(
+            Content content
+    ) {
+        EntityState entityState = EntityState.builder()
+                .withAtlasId(codec.encode(content.getId().toBigInteger()))
+                .withRaw(getContentJsonString(content))
+                .withRawMime(MimeType.APPLICATION_JSON.toString())
+                .build();
+
+        Event event = createEvent(entityState, Event.Status.SUCCESS);
+
+        telescopeClient.createEvent(event);
+    }
+
+    private Event createEvent(
+            EntityState entityState,
+            Event.Status eventStatus
+    ) {
+        return Event.builder()
+                .withProcess(process)
+                .withType(Event.Type.MIGRATION)
+                .withStatus(eventStatus)
+                .withEntityState(entityState)
+                .withTimestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public String getContentJsonString(Content content) {
+        try {
+            return mapper.writeValueAsString(content);
+        } catch (JsonProcessingException e) {
+            log.error("Couldn't convert content to a JSON string.", e);
+            return e.getMessage();
+        }
+    }
+}

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/ContentBootstrapWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/ContentBootstrapWorkerTest.java
@@ -1,0 +1,147 @@
+package org.atlasapi.system.bootstrap.workers;
+
+import java.util.Collection;
+
+import org.atlasapi.content.Content;
+import org.atlasapi.content.ContentResolver;
+import org.atlasapi.content.ContentWriter;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
+import org.atlasapi.entity.ResourceType;
+import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.entity.util.WriteException;
+import org.atlasapi.entity.util.WriteResult;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.messaging.ResourceUpdatedMessage;
+import org.atlasapi.system.bootstrap.ColumbusTelescopeReporter;
+
+import com.metabroadcast.columbus.telescope.api.Event;
+import com.metabroadcast.columbus.telescope.client.TelescopeClientImpl;
+import com.metabroadcast.common.media.MimeType;
+import com.metabroadcast.common.queue.RecoverableException;
+import com.metabroadcast.common.time.Timestamp;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentBootstrapWorkerTest {
+
+    @Mock private ContentResolver contentResolver;
+    @Mock private ContentWriter writer;
+    @Mock private Timer metricsTimer;
+    @Mock private Meter contentNotWrittenMeter;
+    @Mock private Meter failureMeter;
+    @Mock private TelescopeClientImpl telescopeClient;
+    @Mock private ResourceRef resourceRef;
+    @Mock private Timer.Context timerContext;
+    @Mock private ResourceUpdatedMessage resourceUpdatedMessage;
+    @Mock private ListenableFuture<Resolved<Content>> listenableFuture;
+    @Mock private ObjectMapper objectMapper;
+    @Captor private ArgumentCaptor<Event> columbusTelescopeEventCaptor;
+
+    private ColumbusTelescopeReporter columbusTelescopeReporter;
+    private ContentBootstrapWorker bootstrapWorker;
+    private WriteResult<Content, Content> successfulWriteResult;
+    private Content content;
+    private String environment = "PRODUCTION";
+    private static final String TEST_RAW_STRING = "{ \"test\":\"test\"}";
+
+    @Before
+    public void setUp() throws Exception {
+        this.columbusTelescopeReporter = ColumbusTelescopeReporter.create(
+                telescopeClient,
+                environment,
+                objectMapper
+        );
+
+        this.bootstrapWorker = ContentBootstrapWorker.create(
+                contentResolver,
+                writer,
+                metricsTimer,
+                contentNotWrittenMeter,
+                failureMeter,
+                columbusTelescopeReporter
+        );
+        this.content = new org.atlasapi.content.Item("panda.com", "panda", Publisher.PA);
+        this.content.setId(Id.valueOf(1L));
+        this.successfulWriteResult = new WriteResult<>(content, true, DateTime.now(), null);
+    }
+
+    @Test
+    public void testReportingSuccessfulMigrationEvent() throws RecoverableException, WriteException {
+        ResourceUpdatedMessage updatedMessage = createUpdatedMessage();
+
+        when(resourceRef.getId()).thenReturn(Id.valueOf(1));
+        when(contentResolver.resolveIds(any(Collection.class))).thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
+        when(writer.writeContent(content)).thenReturn(successfulWriteResult);
+        when(metricsTimer.time()).thenReturn(timerContext);
+
+        bootstrapWorker.process(updatedMessage);
+
+        verify(telescopeClient, times(1)).createEvent(any(Event.class));
+        verify(telescopeClient).createEvent(columbusTelescopeEventCaptor.capture());
+
+        Event event = columbusTelescopeEventCaptor.getValue();
+
+        assertThat(event.getStatus(), is(Event.Status.SUCCESS));
+        assertThat(event.getType(), is(Event.Type.MIGRATION));
+    }
+
+    @Test
+    public void testReportingMigrationCorrectRawObjectIsSentAsPartOfTheEventReport()
+            throws RecoverableException, WriteException, JsonProcessingException {
+        this.content.setLastFetched(DateTime.parse("2016-08-28T00:00:00Z"));
+        ResourceUpdatedMessage updatedMessage = createUpdatedMessage();
+
+        when(resourceRef.getId()).thenReturn(Id.valueOf(1));
+        when(contentResolver.resolveIds(any(Collection.class))).thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
+        when(writer.writeContent(content)).thenReturn(successfulWriteResult);
+        when(metricsTimer.time()).thenReturn(timerContext);
+        when(objectMapper.writeValueAsString(any(Content.class))).thenReturn(TEST_RAW_STRING);
+
+        bootstrapWorker.process(updatedMessage);
+
+        verify(telescopeClient, times(1)).createEvent(any(Event.class));
+        verify(telescopeClient).createEvent(columbusTelescopeEventCaptor.capture());
+
+        Event event = columbusTelescopeEventCaptor.getValue();
+        assertThat(event.getEntityState().get().getRaw().get(), is(TEST_RAW_STRING));
+        assertThat(event.getEntityState().get().getRawMime().get(), is(MimeType.APPLICATION_JSON.toString()));
+        assertThat(event.getEntityState().get().getAtlasId().get(), is("c"));
+    }
+
+    private ResourceUpdatedMessage createUpdatedMessage() {
+        return new ResourceUpdatedMessage(
+                    "panda",
+                    Timestamp.of(DateTime.now()),
+                    new ResourceRef(Id.valueOf(1L), Publisher.PA) {
+
+                        @Override
+                        public ResourceType getResourceType() {
+                            return ResourceType.CONTENT;
+                        }
+                    }
+            );
+    }
+}

--- a/atlas-processing/src/test/java/org/atlasapi/system/debug/EventDebugControllerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/debug/EventDebugControllerTest.java
@@ -12,50 +12,28 @@ import org.atlasapi.event.Event;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.system.legacy.LegacyEventResolver;
 
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializer;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventDebugControllerTest {
 
-    @Mock
-    private LegacyEventResolver legacyEventResolver;
-    @Mock
-    private AtlasPersistenceModule atlasPersistenceModule;
-    @Mock
-    private LegacyEventResolver resolver;
-    private NumberToShortStringCodec lowercaseDecoder;
-    private Gson gson = new GsonBuilder().registerTypeAdapter(
-            DateTime.class,
-            (JsonSerializer<DateTime>) (src, typeOfSrc, context) ->
-                    new JsonPrimitive(src.toString())
-    )
-            .create();;
-
+    @Mock private LegacyEventResolver legacyEventResolver;
+    @Mock private AtlasPersistenceModule atlasPersistenceModule;
+    @Mock private LegacyEventResolver resolver;
     private EventDebugController controller;
-
-
 
     @Before
     public void setUp() {
-        lowercaseDecoder = SubstitutionTableNumberCodec.lowerCaseOnly();
         when(atlasPersistenceModule.eventResolver()).thenReturn(resolver);
         controller = new EventDebugController(legacyEventResolver, atlasPersistenceModule);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -226,17 +226,22 @@
       <dependency>
         <groupId>com.metabroadcast.common.webapp</groupId>
         <artifactId>common-webapp</artifactId>
-        <version>${common.version}</version>
+        <version>${common.webapp.version}</version>
       </dependency>
       <dependency>
         <groupId>com.metabroadcast.common.social</groupId>
         <artifactId>common-social</artifactId>
-        <version>${common.version}</version>
+        <version>${common.social.version}</version>
       </dependency>
       <dependency>
         <groupId>com.metabroadcast.common.queue</groupId>
         <artifactId>common-queue</artifactId>
-        <version>${common.version}</version>
+        <version>${common.queue.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.metabroadcast.columbus.telescope</groupId>
+        <artifactId>telescope-client</artifactId>
+        <version>${telescope-client.version}</version>
       </dependency>
       <dependency>
         <groupId>org.atlasapi</groupId>
@@ -445,17 +450,21 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <atlas.version>${project.version}</atlas.version>
     <atlas.legacy.version>5.0-SNAPSHOT</atlas.legacy.version>
+    <telescope-client.version>1.0-SNAPSHOT</telescope-client.version>
     <guava.version>16.0.1</guava.version>
     <protonpack.version>1.7</protonpack.version>
     <jetty.version>9.0.6.v20130930</jetty.version>
     <slf4j.version>1.7.5</slf4j.version>
     <astyanax.version>2.0.2</astyanax.version>
-    <common.version>1.0-SNAPSHOT</common.version>
+    <common.version>2.0-SNAPSHOT</common.version>
+    <common.webapp.version>1.0-SNAPSHOT</common.webapp.version>
+    <common.social.version>1.0-SNAPSHOT</common.social.version>
+    <common.queue.version>2.0-SNAPSHOT</common.queue.version>
     <metrics.version>3.0.1</metrics.version>
     <amq.version>5.9.0</amq.version>
     <spring.version>4.2.1.RELEASE</spring.version>
     <datastax.version>3.1.0</datastax.version>
-    <jackson.version>2.3.0</jackson.version>
+    <jackson.version>2.8.0</jackson.version>
 
     <sonar.jacoco.itReportPath>${project.basedir}/target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.jacoco.reportPath>${project.basedir}/target/jacoco.exec</sonar.jacoco.reportPath>


### PR DESCRIPTION
This has been done so that we know more about content migration.

Updating the Jackson version to 2.8

Adding annotations to Id class so that we can get id as long and Long. Updated common dependency to the new version 2 as Timestamp millis method now also have Jackson annotations that we need in the deserialization logic.

Fixing failing tests as the deserialization logic for Joda intervals has changed and when deserializing interval, it's automatically converted to UTC.