### PR TITLE
Improve Neo4jContentStore metrics

### DIFF
--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
@@ -16,8 +16,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Neo4jModule {
 
-    private static final String TIMER_PREFIX = "persistence.neo4j.";
-
     private final Neo4jSessionFactory sessionFactory;
 
     private Neo4jModule(Neo4jSessionFactory sessionFactory) {
@@ -35,36 +33,17 @@ public class Neo4jModule {
     }
 
     public Neo4jContentStore neo4jContentStore(MetricRegistry metricRegistry) {
-        ContentWriter contentWriter = ContentWriter.create(
-                metricRegistry.timer(TIMER_PREFIX + "contentWriter.writeResourceRef"),
-                metricRegistry.timer(TIMER_PREFIX + "contentWriter.writeContentRef"),
-                metricRegistry.timer(TIMER_PREFIX + "contentWriter.writeContent")
-        );
+        ContentWriter contentWriter = ContentWriter.create();
 
         return Neo4jContentStore.builder()
                 .withSessionFactory(sessionFactory)
-                .withGraphWriter(EquivalenceWriter.create(
-                        metricRegistry.timer(TIMER_PREFIX + "equivalenceWriter.writeEquivalence")
-                ))
+                .withGraphWriter(EquivalenceWriter.create())
                 .withContentWriter(contentWriter)
-                .withBroadcastWriter(BroadcastWriter.create(
-                        metricRegistry.timer(TIMER_PREFIX + "broadcastWriter.writeBroadcast")
-                ))
-                .withLocationWriter(LocationWriter.create(
-                        metricRegistry.timer(TIMER_PREFIX + "locationWriter.writeLocation")
-                ))
-                .withHierarchyWriter(HierarchyWriter.create(
-                        contentWriter,
-                        metricRegistry.timer(TIMER_PREFIX + "hierarchyWriter.writeHierarchy")
-                ))
+                .withBroadcastWriter(BroadcastWriter.create())
+                .withLocationWriter(LocationWriter.create())
+                .withHierarchyWriter(HierarchyWriter.create(contentWriter))
                 .withEquivalentSetResolver(EquivalentSetResolver.create())
-                .withTimers(
-                        metricRegistry.timer(TIMER_PREFIX + "contentStore.writeEquivalences"),
-                        metricRegistry.timer(TIMER_PREFIX + "contentStore.writeContent"),
-                        metricRegistry.histogram(
-                                TIMER_PREFIX + "contentStore.numOfAssertedEquivEdges"
-                        )
-                )
+                .withMetricsRegistry(metricRegistry)
                 .build();
     }
 

--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/writers/BroadcastWriter.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/writers/BroadcastWriter.java
@@ -2,28 +2,23 @@ package org.atlasapi.neo4j.service.writers;
 
 import org.atlasapi.content.Item;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementRunner;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.BROADCAST;
-import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.HAS_BROADCAST_RELATIONSHIP;
 import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.CHANNEL_ID;
 import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.END_DATE_TIME;
+import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.HAS_BROADCAST_RELATIONSHIP;
 import static org.atlasapi.neo4j.service.model.Neo4jBroadcast.START_DATE_TIME;
 import static org.atlasapi.neo4j.service.model.Neo4jContent.CONTENT_ID;
 
 public class BroadcastWriter extends Neo4jWriter {
 
-    private final Timer timer;
     private final Statement removeAllBroadcastsStatement;
     private final Statement addBroadcastStatement;
 
-    private BroadcastWriter(Timer timer) {
-        this.timer = checkNotNull(timer);
-
+    private BroadcastWriter() {
         this.removeAllBroadcastsStatement = new Statement(""
                 + "MATCH (content { " + CONTENT_ID + ": " + param(CONTENT_ID) + " })"
                 + "-[r:" + HAS_BROADCAST_RELATIONSHIP + "]->(broadcast:" + BROADCAST + ") "
@@ -46,13 +41,11 @@ public class BroadcastWriter extends Neo4jWriter {
                 + "})");
     }
 
-    public static BroadcastWriter create(Timer timer) {
-        return new BroadcastWriter(timer);
+    public static BroadcastWriter create() {
+        return new BroadcastWriter();
     }
 
     public void write(Item item, StatementRunner runner) {
-        Timer.Context time = timer.time();
-
         if (item.getBroadcasts().isEmpty()) {
             write(
                     removeAllBroadcastsStatement.withParameters(ImmutableMap.of(
@@ -71,7 +64,5 @@ public class BroadcastWriter extends Neo4jWriter {
                     )))
                     .forEach(statement -> write(statement, runner));
         }
-
-        time.stop();
     }
 }

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4JContentStoreTest.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/Neo4JContentStoreTest.java
@@ -19,9 +19,7 @@ import org.atlasapi.neo4j.service.writers.EquivalenceWriter;
 import org.atlasapi.neo4j.service.writers.HierarchyWriter;
 import org.atlasapi.neo4j.service.writers.LocationWriter;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Timer;
-import com.codahale.metrics.UniformReservoir;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -75,7 +73,7 @@ public class Neo4JContentStoreTest {
                 .withLocationWriter(locationWriter)
                 .withHierarchyWriter(hierarchyWriter)
                 .withEquivalentSetResolver(equivalentSetResolver)
-                .withTimers(new Timer(), new Timer(), new Histogram(new UniformReservoir()))
+                .withMetricsRegistry(new MetricRegistry())
                 .build();
 
         contentRefA = getContentRef(new Item(), 900L, Publisher.METABROADCAST);

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/resolvers/EquivalentSetResolverIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/resolvers/EquivalentSetResolverIT.java
@@ -12,7 +12,6 @@ import org.atlasapi.neo4j.service.writers.EquivalenceWriter;
 
 import com.metabroadcast.common.stream.MoreCollectors;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -34,8 +33,8 @@ public class EquivalentSetResolverIT extends AbstractNeo4jIT {
         super.setUp();
 
         equivalentSetResolver = EquivalentSetResolver.create();
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
-        equivalenceWriter = EquivalenceWriter.create(new Timer());
+        contentWriter = ContentWriter.create();
+        equivalenceWriter = EquivalenceWriter.create();
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/BroadcastWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/BroadcastWriterIT.java
@@ -6,7 +6,6 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.AbstractNeo4jIT;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
@@ -28,8 +27,8 @@ public class BroadcastWriterIT extends AbstractNeo4jIT {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
-        broadcastWriter = BroadcastWriter.create(new Timer());
+        contentWriter = ContentWriter.create();
+        broadcastWriter = BroadcastWriter.create();
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/ContentWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/ContentWriterIT.java
@@ -16,7 +16,6 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.AbstractNeo4jIT;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -36,7 +35,7 @@ public class ContentWriterIT extends AbstractNeo4jIT {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
+        contentWriter = ContentWriter.create();
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/EquivalenceWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/EquivalenceWriterIT.java
@@ -9,7 +9,6 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.AbstractNeo4jIT;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
@@ -38,8 +37,8 @@ public class EquivalenceWriterIT extends AbstractNeo4jIT {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        equivalenceWriter = EquivalenceWriter.create(new Timer());
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
+        equivalenceWriter = EquivalenceWriter.create();
+        contentWriter = ContentWriter.create();
 
         contentRefA = getContentRef(new Item(), 900L, Publisher.METABROADCAST);
         contentRefB = getContentRef(new Episode(), 901L, Publisher.BBC);

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/HierarchyWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/HierarchyWriterIT.java
@@ -14,7 +14,6 @@ import org.atlasapi.neo4j.AbstractNeo4jIT;
 
 import com.metabroadcast.common.stream.MoreCollectors;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
@@ -35,8 +34,8 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
-        hierarchyWriter = HierarchyWriter.create(contentWriter, new Timer());
+        contentWriter = ContentWriter.create();
+        hierarchyWriter = HierarchyWriter.create(contentWriter);
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/LocationWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/LocationWriterIT.java
@@ -10,7 +10,6 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.neo4j.AbstractNeo4jIT;
 
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
@@ -32,8 +31,8 @@ public class LocationWriterIT extends AbstractNeo4jIT {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        contentWriter = ContentWriter.create(new Timer(), new Timer(), new Timer());
-        locationWriter = LocationWriter.create(new Timer());
+        contentWriter = ContentWriter.create();
+        locationWriter = LocationWriter.create();
     }
 
     @Test


### PR DESCRIPTION
- Add metrics to every part of the Neo4jContentStore write pipelines
  to identify the bottleneck
- Move metric definition in the Neo4jContentStore constructor to
  simplify its builder
- Remove the metrics from the individual writers since they were not
  helpful in finding any bottleneck (individually they all appear to
  be fast)