### PR TITLE
Optimise Neo4j writes to reduce number of updates needed

### DIFF
--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/Neo4jModule.java
@@ -33,15 +33,13 @@ public class Neo4jModule {
     }
 
     public Neo4jContentStore neo4jContentStore(MetricRegistry metricRegistry) {
-        ContentWriter contentWriter = ContentWriter.create();
-
         return Neo4jContentStore.builder()
                 .withSessionFactory(sessionFactory)
                 .withGraphWriter(EquivalenceWriter.create())
-                .withContentWriter(contentWriter)
+                .withContentWriter(ContentWriter.create())
                 .withBroadcastWriter(BroadcastWriter.create())
                 .withLocationWriter(LocationWriter.create())
-                .withHierarchyWriter(HierarchyWriter.create(contentWriter))
+                .withHierarchyWriter(HierarchyWriter.create())
                 .withEquivalentSetResolver(EquivalentSetResolver.create())
                 .withMetricsRegistry(metricRegistry)
                 .build();

--- a/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/writers/ContentWriter.java
+++ b/atlas-neo4j/src/main/java/org/atlasapi/neo4j/service/writers/ContentWriter.java
@@ -1,11 +1,9 @@
 package org.atlasapi.neo4j.service.writers;
 
 import org.atlasapi.content.Content;
-import org.atlasapi.content.ContentRef;
 import org.atlasapi.content.ContentType;
 import org.atlasapi.content.Episode;
 import org.atlasapi.content.Series;
-import org.atlasapi.entity.ResourceRef;
 
 import com.google.common.collect.ImmutableMap;
 import org.neo4j.driver.v1.Statement;
@@ -20,30 +18,17 @@ import static org.atlasapi.neo4j.service.model.Neo4jContent.CONTENT_TYPE;
 
 public class ContentWriter extends Neo4jWriter {
 
-    private final Statement writeResourceRefStatement;
-    private final Statement writeContentRefStatement;
     private final Statement writeContentStatement;
     private final Statement writeSeriesStatement;
     private final Statement writeEpisodeStatement;
 
     private ContentWriter() {
-        this.writeResourceRefStatement = new Statement(""
-                + "MERGE (content:" + CONTENT
-                + " { " + CONTENT_ID + ": " + param(CONTENT_ID) + " }) "
-                + "SET content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE));
-
-        this.writeContentRefStatement = new Statement(""
-                + "MERGE (content:" + CONTENT
-                + " { " + CONTENT_ID + ": " + param(CONTENT_ID) + " }) "
-                + "SET "
-                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + ", "
-                + "content." + CONTENT_TYPE + " = " + param(CONTENT_TYPE));
-
         this.writeContentStatement = new Statement(""
                 + "MERGE (content:" + CONTENT
                 + " { " + CONTENT_ID + ": " + param(CONTENT_ID) + " }) "
+                + "ON CREATE SET "
+                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + " "
                 + "SET "
-                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + ", "
                 + "content." + CONTENT_TYPE + " = " + param(CONTENT_TYPE) + " "
                 + "REMOVE "
                 + "content." + CONTENT_EPISODE_NUMBER + ", "
@@ -52,47 +37,24 @@ public class ContentWriter extends Neo4jWriter {
         this.writeSeriesStatement = new Statement(""
                 + "MERGE (content:" + CONTENT
                 + " { " + CONTENT_ID + ": " + param(CONTENT_ID) + " }) "
+                + "ON CREATE SET "
+                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + " "
                 + "SET "
-                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + ", "
                 + "content." + CONTENT_TYPE + " = " + param(CONTENT_TYPE) + ", "
                 + "content." + CONTENT_SERIES_NUMBER + " = " + param(CONTENT_SERIES_NUMBER));
 
         this.writeEpisodeStatement = new Statement(""
                 + "MERGE (content:" + CONTENT
                 + " { " + CONTENT_ID + ": " + param(CONTENT_ID) + " }) "
+                + "ON CREATE SET "
+                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + " "
                 + "SET "
-                + "content." + CONTENT_SOURCE + " = " + param(CONTENT_SOURCE) + ", "
                 + "content." + CONTENT_TYPE + " = " + param(CONTENT_TYPE) + ", "
                 + "content." + CONTENT_EPISODE_NUMBER + " = " + param(CONTENT_EPISODE_NUMBER));
     }
 
     public static ContentWriter create() {
         return new ContentWriter();
-    }
-
-    public void writeResourceRef(ResourceRef resourceRef, StatementRunner runner) {
-        ImmutableMap<String, Object> statementParameters = ImmutableMap.of(
-                CONTENT_ID, resourceRef.getId().longValue(),
-                CONTENT_SOURCE, resourceRef.getSource().key()
-        );
-
-        write(
-                writeResourceRefStatement.withParameters(statementParameters),
-                runner
-        );
-    }
-
-    public void writeContentRef(ContentRef contentRef, StatementRunner runner) {
-        ImmutableMap<String, Object> statementParameters = ImmutableMap.of(
-                CONTENT_ID, contentRef.getId().longValue(),
-                CONTENT_SOURCE, contentRef.getSource().key(),
-                CONTENT_TYPE, contentRef.getContentType().getKey()
-        );
-
-        write(
-                writeContentRefStatement.withParameters(statementParameters),
-                runner
-        );
     }
 
     public void writeSeries(Series series, StatementRunner runner) {

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/ContentWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/ContentWriterIT.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import org.atlasapi.content.Brand;
 import org.atlasapi.content.Content;
-import org.atlasapi.content.ContentRef;
 import org.atlasapi.content.ContentType;
 import org.atlasapi.content.Episode;
 import org.atlasapi.content.Film;
@@ -36,88 +35,6 @@ public class ContentWriterIT extends AbstractNeo4jIT {
     public void setUp() throws Exception {
         super.setUp();
         contentWriter = ContentWriter.create();
-    }
-
-    @Test
-    public void writeResourceRefSucceeds() throws Exception {
-        ContentRef contentRef = getContentRef(new Item(), 0L, Publisher.METABROADCAST);
-
-        contentWriter.writeResourceRef(contentRef, session);
-
-        StatementResult result = session.run(
-                "MATCH (n:Content { id: {id} }) "
-                        + "RETURN n.id as id, n.source AS source",
-                ImmutableMap.of("id", contentRef.getId().longValue())
-        );
-
-        assertThat(result.hasNext(), is(true));
-
-        Record record = result.next();
-        assertThat(record.get("id").asLong(), is(contentRef.getId().longValue()));
-        assertThat(record.get("source").asString(), is(contentRef.getSource().key()));
-    }
-
-    @Test
-    public void writeExistingResourceRefUpdatesFields() throws Exception {
-        ContentRef contentRef = getContentRef(new Item(), 0L, Publisher.METABROADCAST);
-        ContentRef updatedContentRef = getContentRef(new Episode(), 0L, Publisher.BBC);
-
-        contentWriter.writeResourceRef(contentRef, session);
-        contentWriter.writeResourceRef(updatedContentRef, session);
-
-        StatementResult result = session.run(
-                "MATCH (n:Content { id: {id} }) "
-                        + "RETURN n.id as id, n.source AS source",
-                ImmutableMap.of("id", contentRef.getId().longValue())
-        );
-
-        assertThat(result.hasNext(), is(true));
-
-        Record record = result.next();
-        assertThat(record.get("id").asLong(), is(updatedContentRef.getId().longValue()));
-        assertThat(record.get("source").asString(), is(updatedContentRef.getSource().key()));
-    }
-
-    @Test
-    public void writeContentRefSucceeds() throws Exception {
-        ContentRef contentRef = getContentRef(new Item(), 0L, Publisher.METABROADCAST);
-
-        contentWriter.writeContentRef(contentRef, session);
-
-        StatementResult result = session.run(
-                "MATCH (n:Content { id: {id} }) "
-                        + "RETURN n.id as id, n.source AS source, n.type AS type",
-                ImmutableMap.of("id", contentRef.getId().longValue())
-        );
-
-        assertThat(result.hasNext(), is(true));
-
-        Record record = result.next();
-        assertThat(record.get("id").asLong(), is(contentRef.getId().longValue()));
-        assertThat(record.get("source").asString(), is(contentRef.getSource().key()));
-        assertThat(record.get("type").asString(), is(contentRef.getContentType().getKey()));
-    }
-
-    @Test
-    public void writeExistingContentRefUpdatesFields() throws Exception {
-        ContentRef contentRef = getContentRef(new Item(), 0L, Publisher.METABROADCAST);
-        ContentRef updatedContentRef = getContentRef(new Episode(), 0L, Publisher.BBC);
-
-        contentWriter.writeContentRef(contentRef, session);
-        contentWriter.writeContentRef(updatedContentRef, session);
-
-        StatementResult result = session.run(
-                "MATCH (n:Content { id: {id} }) "
-                        + "RETURN n.id as id, n.source AS source, n.type AS type",
-                ImmutableMap.of("id", contentRef.getId().longValue())
-        );
-
-        assertThat(result.hasNext(), is(true));
-
-        Record record = result.next();
-        assertThat(record.get("id").asLong(), is(updatedContentRef.getId().longValue()));
-        assertThat(record.get("source").asString(), is(updatedContentRef.getSource().key()));
-        assertThat(record.get("type").asString(), is(updatedContentRef.getContentType().getKey()));
     }
 
     @Test
@@ -246,10 +163,6 @@ public class ContentWriterIT extends AbstractNeo4jIT {
                 is(ContentType.fromContent(content).get().getKey()));
 
         return record;
-    }
-
-    private ContentRef getContentRef(Content content, long id, Publisher source) {
-        return getContent(content, id, source).toRef();
     }
 
     private <T extends Content> T getContent(T content, long id, Publisher source) {

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/EquivalenceWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/EquivalenceWriterIT.java
@@ -27,7 +27,6 @@ public class EquivalenceWriterIT extends AbstractNeo4jIT {
     @Rule public ExpectedException exception = ExpectedException.none();
 
     private EquivalenceWriter equivalenceWriter;
-    private ContentWriter contentWriter;
 
     private ContentRef contentRefA;
     private ContentRef contentRefB;
@@ -38,15 +37,10 @@ public class EquivalenceWriterIT extends AbstractNeo4jIT {
     public void setUp() throws Exception {
         super.setUp();
         equivalenceWriter = EquivalenceWriter.create();
-        contentWriter = ContentWriter.create();
 
         contentRefA = getContentRef(new Item(), 900L, Publisher.METABROADCAST);
         contentRefB = getContentRef(new Episode(), 901L, Publisher.BBC);
         contentRefC = getContentRef(new Item(), 902L, Publisher.PA);
-
-        contentWriter.writeResourceRef(contentRefA, session);
-        contentWriter.writeResourceRef(contentRefB, session);
-        contentWriter.writeResourceRef(contentRefC, session);
     }
 
     @Test

--- a/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/HierarchyWriterIT.java
+++ b/atlas-neo4j/src/test/java/org/atlasapi/neo4j/service/writers/HierarchyWriterIT.java
@@ -35,7 +35,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
     public void setUp() throws Exception {
         super.setUp();
         contentWriter = ContentWriter.create();
-        hierarchyWriter = HierarchyWriter.create(contentWriter);
+        hierarchyWriter = HierarchyWriter.create();
     }
 
     @Test
@@ -45,7 +45,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Episode episodeA = getEpisode(2L);
         Episode episodeB = getEpisode(3L);
 
-        contentWriter.writeContentRef(brand.toRef(), session);
+        contentWriter.writeContent(brand, session);
 
         brand.setSeriesRefs(ImmutableList.of(series.toRef()));
         brand.setItemRefs(ImmutableList.of(
@@ -63,7 +63,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
     public void writeBrandWithNoHierarchy() throws Exception {
         Brand brand = getBrand(0L);
 
-        contentWriter.writeContentRef(brand.toRef(), session);
+        contentWriter.writeContent(brand, session);
 
         hierarchyWriter.writeBrand(brand, session);
 
@@ -78,7 +78,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         
         Brand oldParent = getBrand(1L);
         
-        contentWriter.writeContentRef(contentWithOldType.toRef(), session);
+        contentWriter.writeContent(contentWithOldType, session);
         
         contentWithOldType.setBrand(oldParent);
         hierarchyWriter.writeSeries(contentWithOldType, session);
@@ -95,8 +95,8 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
         
-        contentWriter.writeContentRef(series.toRef(), session);
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(series, session);
+        contentWriter.writeContent(episode, session);
 
         series.setBrand(brand);
         hierarchyWriter.writeSeries(series, session);
@@ -117,7 +117,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Episode episodeA = getEpisode(2L);
         Episode episodeB = getEpisode(3L);
 
-        contentWriter.writeContentRef(series.toRef(), session);
+        contentWriter.writeContent(series, session);
 
         series.setBrand(brand);
         series.setItemRefs(ImmutableList.of(
@@ -135,7 +135,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
     public void writeSeriesWithNoHierarchy() throws Exception {
         Series series = getSeries(0L);
 
-        contentWriter.writeContentRef(series.toRef(), session);
+        contentWriter.writeContent(series, session);
 
         series.setItemRefs(ImmutableList.of());
         hierarchyWriter.writeSeries(series, session);
@@ -150,7 +150,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Brand newParent = getBrand(2L);
         Series series = getSeries(3L);
         
-        contentWriter.writeContentRef(series.toRef(), session);
+        contentWriter.writeContent(series, session);
         
         series.setBrand(oldParent);
         hierarchyWriter.writeSeries(series, session);
@@ -167,8 +167,8 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
         
-        contentWriter.writeContentRef(series.toRef(), session);
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(series, session);
+        contentWriter.writeContent(episode, session);
 
         series.setBrand(parent);
         hierarchyWriter.writeSeries(series, session);
@@ -188,7 +188,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Brand brand = getBrand(0L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(brand);
 
@@ -202,7 +202,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(series);
 
@@ -215,7 +215,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
     public void writeEpisodeWithNoHierarchy() throws Exception {
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         hierarchyWriter.writeEpisode(episode, session);
 
@@ -227,7 +227,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(series);
 
@@ -246,7 +246,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series newParent = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainerRef(oldParent.toRef());
         hierarchyWriter.writeEpisode(episode, session);
@@ -263,7 +263,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(brand);
         episode.setSeries(series);
@@ -282,7 +282,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
 
         Brand newBrand = getBrand(3L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(oldBrand);
         episode.setSeries(series);
@@ -301,7 +301,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(oldBrand);
         episode.setSeries(series);
@@ -322,7 +322,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
 
         Series newSeries = getSeries(3L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(brand);
         episode.setSeries(oldSeries);
@@ -341,7 +341,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series oldSeries = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(brand);
         episode.setSeries(oldSeries);
@@ -361,7 +361,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
 
         Episode episode = getEpisode(1L);
 
-        contentWriter.writeContentRef(episode.toRef(), session);
+        contentWriter.writeContent(episode, session);
 
         episode.setContainer(contentWithOldType);
         hierarchyWriter.writeEpisode(episode, session);
@@ -379,7 +379,7 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
         Series series = getSeries(1L);
         Episode episode = getEpisode(2L);
 
-        contentWriter.writeContentRef(series.toRef(), session);
+        contentWriter.writeContent(series, session);
 
         series.setBrand(brand);
         hierarchyWriter.writeSeries(series, session);
@@ -391,6 +391,86 @@ public class HierarchyWriterIT extends AbstractNeo4jIT {
 
         checkNoParent(series);
         checkChildren(series, Episode.class, ImmutableList.of());
+    }
+
+    @Test
+    public void writingParentBrandWhenParentDoesNotExistWritesSourceAndType() throws Exception {
+        Brand parent = getBrand(0L);
+        Episode child = getEpisode(1L);
+
+        contentWriter.writeContent(child, session);
+
+        child.setContainer(parent);
+        hierarchyWriter.writeEpisode(child, session);
+
+        StatementResult result = session.run(
+                "MATCH (parent:Content)<-[:HAS_BRAND]-(child:Content { id: {id} }) "
+                        + "WHERE parent.type={type} AND parent.source={source}"
+                        + "RETURN parent.id AS id",
+                ImmutableMap.of(
+                        "id", child.getId().longValue(),
+                        "type", ContentType.fromContent(parent).get().getKey(),
+                        "source", parent.getSource().key()
+                )
+        );
+
+        assertThat(result.hasNext(), is(true));
+    }
+
+    @Test
+    public void writingBrandParentUpdatesParentType() throws Exception {
+        Series parentWithOldType = getSeries(0L);
+        Brand parentWithNewType = getBrand(0L);
+
+        Episode child = getEpisode(1L);
+
+        contentWriter.writeContent(parentWithOldType, session);
+        contentWriter.writeContent(child, session);
+
+        child.setContainer(parentWithNewType);
+        hierarchyWriter.writeEpisode(child, session);
+
+        checkParent(child, parentWithNewType);
+    }
+
+    @Test
+    public void writingParentSeriesWhenParentDoesNotExistWritesSourceAndType() throws Exception {
+        Series parent = getSeries(0L);
+        Episode child = getEpisode(1L);
+
+        contentWriter.writeContent(child, session);
+
+        child.setContainer(parent);
+        hierarchyWriter.writeEpisode(child, session);
+
+        StatementResult result = session.run(
+                "MATCH (parent:Content)<-[:HAS_SERIES]-(child:Content { id: {id} }) "
+                        + "WHERE parent.type={type} AND parent.source={source}"
+                        + "RETURN parent.id AS id",
+                ImmutableMap.of(
+                        "id", child.getId().longValue(),
+                        "type", ContentType.fromContent(parent).get().getKey(),
+                        "source", parent.getSource().key()
+                )
+        );
+
+        assertThat(result.hasNext(), is(true));
+    }
+
+    @Test
+    public void writingSeriesParentUpdatesParentType() throws Exception {
+        Brand parentWithOldType = getBrand(0L);
+        Series parentWithNewType = getSeries(0L);
+
+        Episode episode = getEpisode(1L);
+
+        contentWriter.writeContent(parentWithOldType, session);
+        contentWriter.writeContent(episode, session);
+
+        episode.setContainer(parentWithNewType);
+        hierarchyWriter.writeEpisode(episode, session);
+
+        checkParent(episode, parentWithNewType);
     }
 
     private void checkChildren(Container parent, Class<? extends Content> childClass,


### PR DESCRIPTION
- Change EquivalenceWriter writes to create resourceRef nodes where
  needed rather than executing a separate query to write them before
  writing equivalence assertions
- Change HierarchyWriter writes to create contentRef nodes where
  needed rather than delegating to ContentWriter to create them
- Use ON CREATE SET clauses in ContentWriter to avoid repeatedly
  updating data that cannot change
- Remove unnecessary metrics from Neo4jContentStore. The Neo4j driver
  does most of the work when the transaction is closed so that is where
  most of the execution time is concentrated. The metrics of the
  other execution steps are showing unrealistic low values that are
  not useful
- Remove methods to write contentRef and resourceRef from
  ContentWriter as they are no longer needed