### PR TITLE
Standardise metric naming

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
@@ -230,8 +230,8 @@ public class AtlasPersistenceModule {
                 idGeneratorBuilder(),
                 ContentHashGenerator.create(
                         HashGenerator.create(),
-                        metricsModule.metrics().meter("ContentHashGenerated"),
-                        metricsModule.metrics().meter("ContentHashGenerationFailed")
+                        "persistence.util.",
+                        metricsModule.metrics()
                 ),
                 eventV2 -> UUID.randomUUID().toString(),
                 seeds,

--- a/atlas-core/src/main/java/org/atlasapi/hashing/content/ContentHashGenerator.java
+++ b/atlas-core/src/main/java/org/atlasapi/hashing/content/ContentHashGenerator.java
@@ -7,6 +7,7 @@ import org.atlasapi.content.Content;
 import org.atlasapi.hashing.HashGenerator;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,22 +27,25 @@ public class ContentHashGenerator implements ContentHasher {
 
     private ContentHashGenerator(
             HashGenerator hashGenerator,
-            Meter hashGeneratedMeter,
-            Meter hashGenerationFailedMeter
+            String metricPrefix,
+            MetricRegistry metricRegistry
     ) {
         this.hashGenerator = checkNotNull(hashGenerator);
-        this.hashGeneratedMeter = checkNotNull(hashGeneratedMeter);
-        this.hashGenerationFailedMeter = checkNotNull(hashGenerationFailedMeter);
+
+        this.hashGeneratedMeter = metricRegistry.meter(
+                metricPrefix + "contentHashGenerator.meter.generated"
+        );
+        this.hashGenerationFailedMeter = metricRegistry.meter(
+                metricPrefix + "contentHashGenerator.meter.failed"
+        );
     }
 
     public static ContentHashGenerator create(
             HashGenerator hashGenerator,
-            Meter hashGeneratedMeter,
-            Meter hashGenerationFailedMeter
+            String metricPrefix,
+            MetricRegistry metricRegistry
     ) {
-        return new ContentHashGenerator(
-                hashGenerator, hashGeneratedMeter, hashGenerationFailedMeter
-        );
+        return new ContentHashGenerator(hashGenerator, metricPrefix, metricRegistry);
     }
 
     @Override

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/ContentEquivalenceUpdatingWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/ContentEquivalenceUpdatingWorker.java
@@ -1,9 +1,6 @@
 package org.atlasapi.messaging;
 
-import javax.annotation.Nullable;
-
 import org.atlasapi.entity.ResourceRef;
-import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraphStore;
 import org.atlasapi.system.bootstrap.workers.DirectAndExplicitEquivalenceMigrator;
 
@@ -15,6 +12,7 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,24 +25,40 @@ public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAsser
 
     private final EquivalenceGraphStore graphStore;
     private final DirectAndExplicitEquivalenceMigrator equivMigrator;
-    @Nullable private final Timer messageTimer;
-    @Nullable private final Meter meter;
 
-    public ContentEquivalenceUpdatingWorker(EquivalenceGraphStore graphStore,
-            @Nullable MetricRegistry metrics,
-            DirectAndExplicitEquivalenceMigrator equivMigrator) {
+    private final Timer executionTimer;
+    private final Meter messageReceivedMeter;
+    private final Meter failureMeter;
+
+    private ContentEquivalenceUpdatingWorker(
+            EquivalenceGraphStore graphStore,
+            DirectAndExplicitEquivalenceMigrator equivMigrator,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
         this.graphStore = checkNotNull(graphStore);
-        this.messageTimer = (metrics != null ?
-                             checkNotNull(metrics.timer("ContentEquivalenceUpdatingWorker")) :
-                             null);
-        this.meter = (metrics != null ?
-                      checkNotNull(metrics.meter("ContentEquivalenceUpdatingWorker.errorRate")) :
-                      null);
         this.equivMigrator = checkNotNull(equivMigrator);
+
+        this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
+        this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
+        this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+    }
+
+    public static ContentEquivalenceUpdatingWorker create(
+            EquivalenceGraphStore graphStore,
+            DirectAndExplicitEquivalenceMigrator equivMigrator,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
+        return new ContentEquivalenceUpdatingWorker(
+                graphStore, equivMigrator, metricPrefix, metricRegistry
+        );
     }
 
     @Override
     public void process(EquivalenceAssertionMessage message) throws RecoverableException {
+        messageReceivedMeter.mark();
+
         if (LOG.isDebugEnabled()) {
             LOG.debug(
                     "Processing message on id {}, took: PT{}S, asserted adjacents: {}, message: {}",
@@ -57,32 +71,15 @@ public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAsser
             );
         }
 
+        Timer.Context time = executionTimer.time();
+
         try {
-            if (messageTimer != null) {
-                Timer.Context timer = messageTimer.time();
-                graphStore.updateEquivalences(message.getSubject(), message.getAssertedAdjacents(),
-                        message.getPublishers()
-                );
-                equivMigrator.migrateEquivalence(message.getSubject());
-                timer.stop();
-            } else {
-                graphStore.updateEquivalences(message.getSubject(), message.getAssertedAdjacents(),
-                        message.getPublishers()
-                );
-                equivMigrator.migrateEquivalence(message.getSubject());
-            }
-            LOG.debug("Successfully processed message {}", message.toString());
-        } catch (WriteException e) {
-            LOG.warn(
-                    "Failed to process message on id {}, asserted adjacents: {}, message: {}. "
-                            + "Retrying...",
-                    message.getSubject().getId(),
-                    message.getAssertedAdjacents().stream()
-                            .map(ResourceRef::getId)
-                            .collect(MoreCollectors.toImmutableList()),
-                    message
+            graphStore.updateEquivalences(message.getSubject(), message.getAssertedAdjacents(),
+                    message.getPublishers()
             );
-            throw new RecoverableException("update failed for " + message.toString(), e);
+            equivMigrator.migrateEquivalence(message.getSubject());
+
+            LOG.debug("Successfully processed message {}", message.toString());
         } catch (Exception e) {
             LOG.warn(
                     "Failed to process message on id {}, asserted adjacents: {}, message: {}",
@@ -92,9 +89,11 @@ public class ContentEquivalenceUpdatingWorker implements Worker<EquivalenceAsser
                             .collect(MoreCollectors.toImmutableList()),
                     message
             );
-            if (meter != null) {
-                meter.mark();
-            }
+            failureMeter.mark();
+
+            throw Throwables.propagate(e);
+        } finally {
+            time.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
@@ -9,6 +9,7 @@ import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 import com.metabroadcast.common.stream.MoreCollectors;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableSet;
@@ -19,38 +20,46 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceGraphUpdateMessage> {
 
-    private static final String METRICS_TIMER = "EquivalentContentIndexingGraphWorker";
-
     private static final Logger LOG =
             LoggerFactory.getLogger(EquivalentContentIndexingContentWorker.class);
 
     private final ContentIndex contentIndex;
-    private final Timer timer;
-
     private final EquivalenceGraphUpdateResolver graphUpdateResolver;
+
+    private final Timer executionTimer;
+    private final Meter messageReceivedMeter;
+    private final Meter failureMeter;
+
 
     private EquivalentContentIndexingGraphWorker(
             ContentIndex contentIndex,
-            MetricRegistry metricRegistry,
-            EquivalenceGraphUpdateResolver graphUpdateResolver
+            EquivalenceGraphUpdateResolver graphUpdateResolver,
+            String metricPrefix,
+            MetricRegistry metricRegistry
     ) {
         this.contentIndex = checkNotNull(contentIndex);
-        this.timer = checkNotNull(metricRegistry.timer(METRICS_TIMER));
         this.graphUpdateResolver = checkNotNull(graphUpdateResolver);
+
+        this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
+        this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
+        this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
     }
 
     public static EquivalentContentIndexingGraphWorker create(
             ContentIndex contentIndex,
-            MetricRegistry metricRegistry,
-            EquivalenceGraphUpdateResolver graphUpdateResolver
+            EquivalenceGraphUpdateResolver graphUpdateResolver,
+            String metricPrefix,
+            MetricRegistry metricRegistry
     ) {
         return new EquivalentContentIndexingGraphWorker(
-                contentIndex, metricRegistry, graphUpdateResolver
+                contentIndex, graphUpdateResolver, metricPrefix, metricRegistry
         );
     }
 
     @Override
     public void process(EquivalenceGraphUpdateMessage message) throws RecoverableException {
+        messageReceivedMeter.mark();
+
         LOG.debug(
                 "Processing message on ids {}, took: PT{}S, message: {}",
                 message.getGraphUpdate().getAllGraphs().stream()
@@ -60,7 +69,8 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
                 message
         );
 
-        Timer.Context time = timer.time();
+        Timer.Context time = executionTimer.time();
+
         try {
             ImmutableSet<EquivalenceGraph> graphs =
                     graphUpdateResolver.resolve(message.getGraphUpdate());
@@ -68,10 +78,12 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
             for (EquivalenceGraph graph : graphs) {
                 contentIndex.updateCanonicalIds(graph.getId(), graph.getEquivalenceSet());
             }
-            time.stop();
         } catch (Exception e) {
+            failureMeter.mark();
             throw new RecoverableException("Failed to update canonical IDs for set"
                     + message.getGraphUpdate().getUpdated().getId(), e);
+        } finally {
+            time.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreContentUpdateWorker.java
@@ -1,6 +1,5 @@
 package org.atlasapi.messaging;
 
-import org.atlasapi.content.ContentResolver;
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.entity.util.WriteException;
 
@@ -8,6 +7,7 @@ import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
@@ -20,35 +20,55 @@ public class EquivalentContentStoreContentUpdateWorker implements Worker<Resourc
     private static final Logger LOG =
             LoggerFactory.getLogger(EquivalentContentStoreContentUpdateWorker.class);
 
-    private final ContentResolver contentResolver;
-
     private final EquivalentContentStore equivalentContentStore;
-    private final Timer messageTimer;
 
-    public EquivalentContentStoreContentUpdateWorker(
+    private final Timer executionTimer;
+    private final Meter messageReceivedMeter;
+    private final Meter failureMeter;
+
+    private EquivalentContentStoreContentUpdateWorker(
             EquivalentContentStore equivalentContentStore,
-            ContentResolver contentResolver,
-            MetricRegistry metrics
+            String metricPrefix,
+            MetricRegistry metricRegistry
     ) {
         this.equivalentContentStore = checkNotNull(equivalentContentStore);
-        this.contentResolver = checkNotNull(contentResolver);
-        this.messageTimer = (metrics != null ? checkNotNull(metrics.timer(
-                "EquivalentContentStoreContentUpdateWorker")) : null);
+
+        this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
+        this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
+        this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+    }
+
+    public static EquivalentContentStoreContentUpdateWorker create(
+            EquivalentContentStore equivalentContentStore,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
+        return new EquivalentContentStoreContentUpdateWorker(
+                equivalentContentStore,
+                metricPrefix,
+                metricRegistry
+        );
     }
 
     @Override
     public void process(ResourceUpdatedMessage message) throws RecoverableException {
+        messageReceivedMeter.mark();
+
         LOG.debug("Processing message on id {}, took: PT{}S, message: {}",
                 message.getUpdatedResource().getId(), getTimeToProcessInSeconds(message), message
         );
 
+        Timer.Context time = executionTimer.time();
+
         try {
-            Timer.Context timer = messageTimer.time();
             equivalentContentStore.updateContent(message.getUpdatedResource().getId());
-            timer.stop();
         } catch (WriteException e) {
+            failureMeter.mark();
+
             throw new RecoverableException("update failed for content "
                     + message.getUpdatedResource(), e);
+        } finally {
+            time.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
@@ -1,7 +1,5 @@
 package org.atlasapi.messaging;
 
-import javax.annotation.Nullable;
-
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph;
@@ -12,6 +10,7 @@ import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 import com.metabroadcast.common.stream.MoreCollectors;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
@@ -26,18 +25,39 @@ public class EquivalentContentStoreGraphUpdateWorker
             LoggerFactory.getLogger(EquivalentContentStoreGraphUpdateWorker.class);
 
     private final EquivalentContentStore equivalentContentStore;
-    private final Timer messageTimer;
 
-    public EquivalentContentStoreGraphUpdateWorker(EquivalentContentStore equivalentContentStore,
-            @Nullable
-            MetricRegistry metrics) {
+    private final Timer executionTimer;
+    private final Meter messageReceivedMeter;
+    private final Meter failureMeter;
+
+    private EquivalentContentStoreGraphUpdateWorker(
+            EquivalentContentStore equivalentContentStore,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
         this.equivalentContentStore = checkNotNull(equivalentContentStore);
-        this.messageTimer = (metrics != null ? checkNotNull(metrics.timer(
-                "EquivalentContentStoreGraphUpdateWorker")) : null);
+
+        this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
+        this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
+        this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+    }
+
+    public static EquivalentContentStoreGraphUpdateWorker create(
+            EquivalentContentStore equivalentContentStore,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
+        return new EquivalentContentStoreGraphUpdateWorker(
+                equivalentContentStore,
+                metricPrefix,
+                metricRegistry
+        );
     }
 
     @Override
     public void process(EquivalenceGraphUpdateMessage message) throws RecoverableException {
+        messageReceivedMeter.mark();
+
         if (LOG.isDebugEnabled()) {
             LOG.debug(
                     "Processing message on updated graph: {}, took: PT{}S, "
@@ -52,14 +72,10 @@ public class EquivalentContentStoreGraphUpdateWorker
             );
         }
 
+        Timer.Context time = executionTimer.time();
+
         try {
-            if (messageTimer != null) {
-                Timer.Context timer = messageTimer.time();
-                equivalentContentStore.updateEquivalences(message.getGraphUpdate());
-                timer.stop();
-            } else {
-                equivalentContentStore.updateEquivalences(message.getGraphUpdate());
-            }
+            equivalentContentStore.updateEquivalences(message.getGraphUpdate());
         } catch (WriteException e) {
             LOG.warn(
                     "Failed to process message on updated graph: {}, created graph(s): {},"
@@ -71,7 +87,11 @@ public class EquivalentContentStoreGraphUpdateWorker
                     message.getGraphUpdate().getDeleted(),
                     message
             );
+            failureMeter.mark();
+
             throw new RecoverableException("update failed for " + message.getGraphUpdate(), e);
+        } finally {
+            time.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
@@ -1,7 +1,5 @@
 package org.atlasapi.messaging;
 
-import javax.annotation.Nullable;
-
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
 import org.atlasapi.schedule.ScheduleUpdateMessage;
@@ -10,6 +8,7 @@ import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
@@ -23,34 +22,52 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
             LoggerFactory.getLogger(EquivalentScheduleStoreScheduleUpdateWorker.class);
 
     private final EquivalentScheduleWriter scheduleWriter;
-    private final Timer messageTimer;
 
-    public EquivalentScheduleStoreScheduleUpdateWorker(EquivalentScheduleWriter scheduleWriter,
-            @Nullable MetricRegistry metrics) {
+    private final Timer executionTimer;
+    private final Meter messageReceivedMeter;
+    private final Meter failureMeter;
+
+    private EquivalentScheduleStoreScheduleUpdateWorker(
+            EquivalentScheduleWriter scheduleWriter,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
         this.scheduleWriter = checkNotNull(scheduleWriter);
-        this.messageTimer = (metrics != null ? checkNotNull(metrics.timer(
-                "EquivalentScheduleStoreScheduleUpdateWorker")) : null);
+
+        this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
+        this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
+        this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+    }
+
+    public static EquivalentScheduleStoreScheduleUpdateWorker create(
+            EquivalentScheduleWriter scheduleWriter,
+            String metricPrefix,
+            MetricRegistry metricRegistry
+    ) {
+        return new EquivalentScheduleStoreScheduleUpdateWorker(
+                scheduleWriter, metricPrefix, metricRegistry
+        );
     }
 
     @Override
     public void process(ScheduleUpdateMessage message) throws RecoverableException {
+        messageReceivedMeter.mark();
+
         LOG.debug("Processing message on id {}, took: PT{}S, message: {}",
                 message.getScheduleUpdate().getSchedule().getChannel(),
                 getTimeToProcessInSeconds(message),
                 message
         );
 
+        Timer.Context time = executionTimer.time();
+
         try {
-            Timer.Context timer = null;
-            if (messageTimer != null) {
-                timer = messageTimer.time();
-            }
             scheduleWriter.updateSchedule(message.getScheduleUpdate());
-            if (timer != null) {
-                timer.stop();
-            }
         } catch (WriteException e) {
+            failureMeter.mark();
             throw new RecoverableException("update failed for " + message.getScheduleUpdate(), e);
+        } finally {
+            time.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
@@ -25,7 +25,6 @@ import com.metabroadcast.common.properties.Configurer;
 import com.metabroadcast.common.queue.kafka.KafkaConsumer;
 import com.metabroadcast.common.queue.kafka.KafkaMessageConsumerFactory;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -49,6 +48,8 @@ import org.springframework.context.annotation.Lazy;
         ProcessingHealthModule.class
 })
 public class BootstrapWorkersModule {
+
+    private static final String WORKER_METRIC_PREFIX = "messaging.worker.";
 
     private final String consumerSystem = Configurer.get("messaging.system").get();
     private final String zookeeper = Configurer.get("messaging.zookeeper").get();
@@ -120,26 +121,27 @@ public class BootstrapWorkersModule {
 
     @Bean
     @Lazy
-    KafkaConsumer contentBootstrapWorker() {
-        MetricRegistry metricRegistry = metricsModule.metrics();
+    public KafkaConsumer contentBootstrapWorker() {
+        String workerName = "ContentBootstrap";
+
         ContentBootstrapWorker worker = ContentBootstrapWorker.create(
                 persistence.legacyContentResolver(),
                 persistence.contentStore(),
-                metricRegistry.timer("ContentBootstrapWorker"),
-                metricRegistry.meter("ContentBootstrapWorker.notWritten"),
-                metricRegistry.meter("ContentBootstrapWorker.errorRate"),
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics(),
                 ColumbusTelescopeReporter.create(
-                        getTelescopeClient(),
+                        TelescopeClientImpl.create(columbusTelescopeHost),
                         reportingEnvironment,
                         getObjectMapper()
                 )
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         new EntityUpdatedLegacyMessageSerializer(),
                         contentChanges,
-                        "ContentBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(contentChangesNumOfConsumers)
@@ -151,26 +153,27 @@ public class BootstrapWorkersModule {
 
     @Bean
     @Lazy
-    KafkaConsumer cqlContentBootstrapWorker() {
-        MetricRegistry metricRegistry = metricsModule.metrics();
+    public KafkaConsumer cqlContentBootstrapWorker() {
+        String workerName = "CqlContentBootstrap";
+
         ContentBootstrapWorker worker = ContentBootstrapWorker.create(
                 persistence.legacyContentResolver(),
                 persistence.cqlContentStore(),
-                metricRegistry.timer("CqlContentBootstrapWorker"),
-                metricRegistry.meter("CqlContentBootstrapWorker.notWritten"),
-                metricRegistry.meter("CqlContentBootstrapWorker.errorRate"),
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics(),
                 ColumbusTelescopeReporter.create(
-                        getTelescopeClient(),
+                        TelescopeClientImpl.create(columbusTelescopeHost),
                         reportingEnvironment,
                         getObjectMapper()
                 )
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         new EntityUpdatedLegacyMessageSerializer(),
                         contentChanges,
-                        "CqlContentBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(cqlContentChangesNumOfConsumers)
@@ -183,17 +186,21 @@ public class BootstrapWorkersModule {
     @Bean
     @Lazy
     KafkaConsumer organisationBootstrapWorker() {
-        OrganisationBootstrapWorker worker = new OrganisationBootstrapWorker(
+        String workerName = "OrganisationBootstrap";
+
+        OrganisationBootstrapWorker worker = OrganisationBootstrapWorker.create(
                 persistence.legacyOrganisationResolver(),
                 persistence.idSettingOrganisationStore(),
-                metricsModule.metrics().timer("OrganisationBootstrapWorker")
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics()
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         new EntityUpdatedLegacyMessageSerializer(),
                         organisationChanges,
-                        "OrganisationBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(organisationChangesNumOfConsumers)
@@ -206,18 +213,22 @@ public class BootstrapWorkersModule {
     @Bean
     @Lazy
     KafkaConsumer scheduleReadWriter() {
-        ScheduleReadWriteWorker worker = new ScheduleReadWriteWorker(
+        String workerName = "ScheduleBootstrap";
+
+        ScheduleReadWriteWorker worker = ScheduleReadWriteWorker.create(
                 scheduleBootstrapTaskFactory(),
                 persistence.channelResolver(),
                 ignoredScheduleSources,
-                metricsModule.metrics().timer("ScheduleBootstrapWorker")
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics()
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         JacksonMessageSerializer.forType(ScheduleUpdateMessage.class),
                         scheduleChanges,
-                        "ScheduleBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(scheduleChangesNumOfConsumers)
@@ -230,18 +241,32 @@ public class BootstrapWorkersModule {
     @Bean
     @Lazy
     KafkaConsumer scheduleV2ReadWriter() {
-        ScheduleReadWriteWorker worker = new ScheduleReadWriteWorker(
-                scheduleV2BootstrapTaskFactory(),
+        String workerName = "ScheduleBootstrapV2";
+
+        ChannelIntervalScheduleBootstrapTaskFactory scheduleV2BootstrapTaskFactory =
+                new ChannelIntervalScheduleBootstrapTaskFactory(
+                        persistence.legacyScheduleStore(),
+                        persistence.v2ScheduleStore(),
+                        new DelegatingContentStore(
+                                persistence.legacyContentResolver(),
+                                persistence.contentStore()
+                        )
+                );
+
+        ScheduleReadWriteWorker worker = ScheduleReadWriteWorker.create(
+                scheduleV2BootstrapTaskFactory,
                 persistence.channelResolver(),
                 ignoredScheduleSources,
-                metricsModule.metrics().timer("ScheduleV2BootstrapWorker")
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics()
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         JacksonMessageSerializer.forType(ScheduleUpdateMessage.class),
                         scheduleChanges,
-                        "ScheduleBootstrapV2"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(scheduleChangesNumOfConsumers)
@@ -254,17 +279,21 @@ public class BootstrapWorkersModule {
     @Bean
     @Lazy
     KafkaConsumer topicReadWriter() {
-        TopicReadWriteWorker worker = new TopicReadWriteWorker(
+        String workerName = "TopicBootstrap";
+
+        TopicReadWriteWorker worker = TopicReadWriteWorker.create(
                 persistence.legacyTopicResolver(),
                 persistence.topicStore(),
-                metricsModule.metrics().timer("TopicBootstrapWorker")
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics()
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         new EntityUpdatedLegacyMessageSerializer(),
                         topicChanges,
-                        "TopicBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(topicChangesNumOfConsumers)
@@ -277,17 +306,21 @@ public class BootstrapWorkersModule {
     @Bean
     @Lazy
     KafkaConsumer eventReadWriter() {
-        SeparatingEventReadWriteWorker worker = new SeparatingEventReadWriteWorker(
+        String workerName = "SeparatingEventBootstrap";
+
+        SeparatingEventReadWriteWorker worker = SeparatingEventReadWriteWorker.create(
                 persistence.legacyEventResolver(),
                 persistence.eventWriter(),
-                metricsModule.metrics().timer("SeparatingEventBootstrapWorker")
+                WORKER_METRIC_PREFIX + workerName + ".",
+                metricsModule.metrics()
         );
+
         return bootstrapQueueFactory()
                 .createConsumer(
                         worker,
                         new EntityUpdatedLegacyMessageSerializer(),
                         eventChanges,
-                        "SeparatingEventBootstrap"
+                        workerName
                 )
                 .withConsumerSystem(consumerSystem)
                 .withDefaultConsumers(eventChangesNumOfConsumers)
@@ -295,15 +328,6 @@ public class BootstrapWorkersModule {
                 .withPersistentRetryPolicy(persistence.databasedWriteMongo())
                 .withMetricRegistry(metricsModule.metrics())
                 .build();
-    }
-
-    @Bean
-    public DirectAndExplicitEquivalenceMigrator explicitEquivalenceMigrator() {
-        return new DirectAndExplicitEquivalenceMigrator(
-                persistence.legacyContentResolver(),
-                persistence.legacyEquivalenceStore(),
-                persistence.nullMessageSendingGraphStore()
-        );
     }
 
     @PostConstruct
@@ -364,7 +388,11 @@ public class BootstrapWorkersModule {
                         persistence.contentStore()
                 ),
                 search.equivContentIndex(),
-                explicitEquivalenceMigrator(),
+                new DirectAndExplicitEquivalenceMigrator(
+                        persistence.legacyContentResolver(),
+                        persistence.legacyEquivalenceStore(),
+                        persistence.nullMessageSendingGraphStore()
+                ),
                 persistence,
                 persistence.legacySegmentMigrator(),
                 persistence.legacyContentResolver()
@@ -384,22 +412,6 @@ public class BootstrapWorkersModule {
                 persistence.getEquivalentScheduleStore(),
                 persistence.getContentEquivalenceGraphStore()
         );
-    }
-
-    @Bean
-    public ChannelIntervalScheduleBootstrapTaskFactory scheduleV2BootstrapTaskFactory() {
-        return new ChannelIntervalScheduleBootstrapTaskFactory(
-                persistence.legacyScheduleStore(),
-                persistence.v2ScheduleStore(),
-                new DelegatingContentStore(
-                        persistence.legacyContentResolver(),
-                        persistence.contentStore()
-                )
-        );
-    }
-
-    private TelescopeClientImpl getTelescopeClient() {
-        return TelescopeClientImpl.create(columbusTelescopeHost);
     }
 
     private ObjectMapper getObjectMapper() {

--- a/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorkerTest.java
@@ -13,7 +13,6 @@ import org.atlasapi.media.entity.Publisher;
 import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import org.joda.time.DateTime;
@@ -25,7 +24,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
@@ -36,20 +34,15 @@ public class EquivalentContentIndexingContentWorkerTest {
 
     private @Mock ContentResolver contentResolver;
     private @Mock ContentIndex contentIndex;
-    private @Mock MetricRegistry metricRegistry;
-    private @Mock Timer timer;
-    private @Mock Timer.Context timerContext;
     private @Mock Content content;
 
     @Before
     public void setUp() throws Exception {
-        when(metricRegistry.timer(anyString())).thenReturn(timer);
-        when(timer.time()).thenReturn(timerContext);
-
-        worker = new EquivalentContentIndexingContentWorker(
+        worker = EquivalentContentIndexingContentWorker.create(
                 contentResolver,
                 contentIndex,
-                metricRegistry
+                "prefix",
+                new MetricRegistry()
         );
     }
 
@@ -73,10 +66,8 @@ public class EquivalentContentIndexingContentWorkerTest {
 
         worker.process(message);
 
-        InOrder order = inOrder(contentResolver, contentIndex, timer, timerContext);
-        order.verify(timer).time();
+        InOrder order = inOrder(contentResolver, contentIndex);
         order.verify(contentResolver).resolveIds(ids);
         order.verify(contentIndex).index(content);
-        order.verify(timerContext).stop();
     }
 }

--- a/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorkerTest.java
@@ -12,7 +12,6 @@ import org.atlasapi.schedule.EquivalentScheduleWriter;
 import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import org.joda.time.DateTime;
@@ -22,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,24 +33,16 @@ public class EquivalentScheduleStoreContentUpdateWorkerTest {
     @Mock
     private EquivalentScheduleWriter scheduleWriter;
 
-    @Mock
-    private MetricRegistry metrics;
-
-    @Mock
-    private Timer timer;
-
     private EquivalentScheduleStoreContentUpdateWorker objectUnderTest;
 
     @Before
     public void setUp() {
-        when(metrics.timer("EquivalentScheduleStoreContentUpdateWorker")).thenReturn(timer);
-        objectUnderTest = new EquivalentScheduleStoreContentUpdateWorker(
+        objectUnderTest = EquivalentScheduleStoreContentUpdateWorker.create(
                 contentStore,
                 scheduleWriter,
-                metrics
+                "prefix",
+                new MetricRegistry()
         );
-        Timer.Context context = mock(Timer.Context.class);
-        when(timer.time()).thenReturn(context);
     }
 
     @Test

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/ContentBootstrapWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/ContentBootstrapWorkerTest.java
@@ -21,8 +21,7 @@ import com.metabroadcast.common.media.MimeType;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.time.Timestamp;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -47,40 +46,35 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ContentBootstrapWorkerTest {
 
+    private static final String TEST_RAW_STRING = "{ \"test\":\"test\"}";
+
+    @Captor private ArgumentCaptor<Event> columbusTelescopeEventCaptor;
+
     @Mock private ContentResolver contentResolver;
     @Mock private ContentWriter writer;
-    @Mock private Timer metricsTimer;
-    @Mock private Meter contentNotWrittenMeter;
-    @Mock private Meter failureMeter;
     @Mock private TelescopeClientImpl telescopeClient;
     @Mock private ResourceRef resourceRef;
-    @Mock private Timer.Context timerContext;
     @Mock private ResourceUpdatedMessage resourceUpdatedMessage;
     @Mock private ListenableFuture<Resolved<Content>> listenableFuture;
     @Mock private ObjectMapper objectMapper;
-    @Captor private ArgumentCaptor<Event> columbusTelescopeEventCaptor;
 
-    private ColumbusTelescopeReporter columbusTelescopeReporter;
     private ContentBootstrapWorker bootstrapWorker;
     private WriteResult<Content, Content> successfulWriteResult;
     private Content content;
-    private String environment = "PRODUCTION";
-    private static final String TEST_RAW_STRING = "{ \"test\":\"test\"}";
 
     @Before
     public void setUp() throws Exception {
-        this.columbusTelescopeReporter = ColumbusTelescopeReporter.create(
+        ColumbusTelescopeReporter columbusTelescopeReporter = ColumbusTelescopeReporter.create(
                 telescopeClient,
-                environment,
+                "PRODUCTION",
                 objectMapper
         );
 
         this.bootstrapWorker = ContentBootstrapWorker.create(
                 contentResolver,
                 writer,
-                metricsTimer,
-                contentNotWrittenMeter,
-                failureMeter,
+                "prefix",
+                new MetricRegistry(),
                 columbusTelescopeReporter
         );
         this.content = new org.atlasapi.content.Item("panda.com", "panda", Publisher.PA);
@@ -93,9 +87,9 @@ public class ContentBootstrapWorkerTest {
         ResourceUpdatedMessage updatedMessage = createUpdatedMessage();
 
         when(resourceRef.getId()).thenReturn(Id.valueOf(1));
-        when(contentResolver.resolveIds(any(Collection.class))).thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
+        when(contentResolver.resolveIds(any(Collection.class)))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
         when(writer.writeContent(content)).thenReturn(successfulWriteResult);
-        when(metricsTimer.time()).thenReturn(timerContext);
 
         bootstrapWorker.process(updatedMessage);
 
@@ -115,9 +109,9 @@ public class ContentBootstrapWorkerTest {
         ResourceUpdatedMessage updatedMessage = createUpdatedMessage();
 
         when(resourceRef.getId()).thenReturn(Id.valueOf(1));
-        when(contentResolver.resolveIds(any(Collection.class))).thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
+        when(contentResolver.resolveIds(any(Collection.class)))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(content))));
         when(writer.writeContent(content)).thenReturn(successfulWriteResult);
-        when(metricsTimer.time()).thenReturn(timerContext);
         when(objectMapper.writeValueAsString(any(Content.class))).thenReturn(TEST_RAW_STRING);
 
         bootstrapWorker.process(updatedMessage);

--- a/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/EventReadWriteWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/system/bootstrap/workers/EventReadWriteWorkerTest.java
@@ -10,7 +10,7 @@ import org.atlasapi.messaging.ResourceUpdatedMessage;
 
 import com.metabroadcast.common.time.Timestamp;
 
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import org.joda.time.DateTime;
@@ -28,24 +28,23 @@ public class EventReadWriteWorkerTest {
 
     private @Mock EventResolver resolver;
     private @Mock EventWriter writer;
-    private @Mock Timer timer;
-    private @Mock Timer.Context timerContext;
-    private ResourceUpdatedMessage message;
     private @Mock ResourceRef updatedResource;
     private @Mock Event event;
 
+    private ResourceUpdatedMessage message;
     private SeparatingEventReadWriteWorker worker;
 
     @Before
     public void setUp() throws Exception {
         message = new ResourceUpdatedMessage("message", Timestamp.of(DateTime.now()), updatedResource);
-        worker = new SeparatingEventReadWriteWorker(resolver, writer, timer);
+        worker = SeparatingEventReadWriteWorker.create(
+                resolver, writer, "prefix", new MetricRegistry()
+        );
 
         Id id = Id.valueOf(0L);
         when(updatedResource.getId()).thenReturn(id);
         when(resolver.resolveIds(ImmutableList.of(id)))
                 .thenReturn(Futures.immediateFuture(Resolved.valueOf(ImmutableList.of(event))));
-        when(timer.time()).thenReturn(timerContext);
     }
 
     @Test


### PR DESCRIPTION
- Standardise metric naming across Kafka workers and in
  ContentHashGenerator for consistency and to make it easier to
  create standardised views for them in Grafana