### PR TITLE
Mbst 16562/refactor violations in deer architecture

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/BroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/BroadcastsAnnotation.java
@@ -21,13 +21,11 @@ public class BroadcastsAnnotation extends OutputAnnotation<Content> {
     private final BroadcastWriter broadcastWriter;
     private final ChannelsBroadcastFilter channelsBroadcastFilter = new ChannelsBroadcastFilter();
 
-    public BroadcastsAnnotation(NumberToShortStringCodec codec, ChannelResolver channelResolver,
-            ChannelGroupResolver channelGroupResolver) {
+    public BroadcastsAnnotation(NumberToShortStringCodec codec, ChannelResolver channelResolver) {
         broadcastWriter = new BroadcastWriter(
                 "broadcasts",
                 codec,
-                channelResolver,
-                channelGroupResolver
+                channelResolver
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelAnnotation.java
@@ -3,13 +3,14 @@ package org.atlasapi.output.annotation;
 import java.io.IOException;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.query.v4.channel.ChannelWriter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelAnnotation extends OutputAnnotation<Channel> {
+public class ChannelAnnotation extends OutputAnnotation<ResolvedChannel> {
 
     private final ChannelWriter channelWriter;
 
@@ -18,7 +19,7 @@ public class ChannelAnnotation extends OutputAnnotation<Channel> {
     }
 
     @Override
-    public void write(Channel entity, FieldWriter format, OutputContext ctxt) throws IOException {
+    public void write(ResolvedChannel entity, FieldWriter format, OutputContext ctxt) throws IOException {
         channelWriter.write(entity, format, ctxt);
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -6,6 +6,7 @@ import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
@@ -38,12 +39,13 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<R
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
 
-        Optional<Iterable<Channel>> resolvedChannels = entity.getChannels();
+        Optional<Iterable<ResolvedChannel>> resolvedChannels = entity.getChannels();
         if (!resolvedChannels.isPresent()) {
             throw new MissingResolvedDataException(channelWriter.listName());
         }
 
         Iterable<Channel> filteredChannels = StreamSupport.stream(resolvedChannels.get().spliterator(), false)
+                .map(ResolvedChannel::getChannel)
                 .filter(channel -> channel.getAdvertiseFrom()
                         .isBeforeNow() || channel.getAdvertiseFrom()
                         .isEqualNow())

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -46,9 +46,8 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<R
 
         Iterable<Channel> filteredChannels = StreamSupport.stream(resolvedChannels.get().spliterator(), false)
                 .map(ResolvedChannel::getChannel)
-                .filter(channel -> channel.getAdvertiseFrom()
-                        .isBeforeNow() || channel.getAdvertiseFrom()
-                        .isEqualNow())
+                .filter(channel -> channel.getAdvertiseFrom().isBeforeNow()
+                        || channel.getAdvertiseFrom().isEqualNow())
                 .collect(Collectors.toList());
 
         String genre = ctxt.getRequest()

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -1,18 +1,14 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ResolvedChannelGroup;
-import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.ChannelWithChannelGroupMembership;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
@@ -20,15 +16,12 @@ import org.atlasapi.query.common.MissingResolvedDataException;
 import org.atlasapi.query.v4.channelgroup.ChannelGroupChannelWriter;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import org.joda.time.LocalDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -45,13 +38,50 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<R
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
 
-        Optional<ImmutableSet<ChannelWithChannelGroupMembership>> channels =
-                entity.getAdvertisedChannels();
-        if (channels.isPresent()) {
-            writer.writeList(channelWriter, channels.get(), ctxt);
-        } else {
+        Optional<Iterable<Channel>> resolvedChannels = entity.getChannels();
+        if (!resolvedChannels.isPresent()) {
             throw new MissingResolvedDataException(channelWriter.listName());
         }
+
+        Iterable<Channel> filteredChannels = StreamSupport.stream(resolvedChannels.get().spliterator(), false)
+                .filter(channel -> channel.getAdvertiseFrom()
+                        .isBeforeNow() || channel.getAdvertiseFrom()
+                        .isEqualNow())
+                .collect(Collectors.toList());
+
+        String genre = ctxt.getRequest()
+                .getParameter(Attributes.CHANNEL_GROUP_CHANNEL_GENRES.externalName());
+
+        if (!Strings.isNullOrEmpty(genre)) {
+            final ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',').split(genre));
+            filteredChannels = Iterables.filter(filteredChannels,
+                    input -> !Sets.intersection(input.getGenres(), genres).isEmpty()
+            );
+        }
+        ImmutableSet.Builder<ChannelWithChannelGroupMembership> resultBuilder = ImmutableSet.builder();
+
+        ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
+        for (ChannelGroupMembership channelGroupMembership :
+                entity.getChannelGroup().getChannelsAvailable(LocalDate.now())) {
+            builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
+        }
+        ImmutableMultimap<Id, ChannelGroupMembership> channelGroupMemberships = builder.build();
+
+        for (Channel channel : filteredChannels) {
+            for (ChannelGroupMembership channelGroupMembership : channelGroupMemberships.get(channel
+                    .getId())) {
+                resultBuilder.add(
+                        new ChannelWithChannelGroupMembership(
+                                channel,
+                                channelGroupMembership
+                        )
+                );
+            }
+        }
+
+        ImmutableSet<ChannelWithChannelGroupMembership> result = resultBuilder.build();
+
+        writer.writeList(channelWriter,result,ctxt);
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -7,8 +7,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
-import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
@@ -31,7 +31,7 @@ import org.joda.time.LocalDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<ChannelGroup<?>> {
+public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private final ChannelGroupChannelWriter channelWriter;
     private final ChannelResolver channelResolver;
@@ -43,10 +43,10 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<C
     }
 
     @Override
-    public void write(ChannelGroup<?> entity, FieldWriter writer, OutputContext ctxt) throws
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt) throws
             IOException {
         final ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
-        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelsAvailable(
+        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelGroup().getChannelsAvailable(
                 LocalDate.now());
         List<Id> orderedIds = StreamSupport.stream(availableChannels.spliterator(), false)
                 //TODO fix channel appearing twice in ordering blowing this thing up

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAnnotation.java
@@ -2,12 +2,12 @@ package org.atlasapi.output.annotation;
 
 import java.io.IOException;
 
-import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
 
-public class ChannelGroupAnnotation extends OutputAnnotation<ChannelGroup<?>> {
+public class ChannelGroupAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private static final ChannelGroupWriter CHANNEL_GROUP_WRITER = new ChannelGroupWriter(
             "channel_groups",
@@ -15,8 +15,8 @@ public class ChannelGroupAnnotation extends OutputAnnotation<ChannelGroup<?>> {
     );
 
     @Override
-    public void write(ChannelGroup entity, FieldWriter format, OutputContext ctxt)
+    public void write(ResolvedChannelGroup entity, FieldWriter format, OutputContext ctxt)
             throws IOException {
-        CHANNEL_GROUP_WRITER.write(entity, format, ctxt);
+        CHANNEL_GROUP_WRITER.write(entity.getChannelGroup(), format, ctxt);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -53,7 +53,7 @@ public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedCha
                 .getParameter(Attributes.CHANNEL_GROUP_CHANNEL_GENRES.externalName());
 
         if (!Strings.isNullOrEmpty(genre)) {
-            final ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',')
+            ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',')
                     .split(genre));
             channels = Iterables.filter(channels,
                     input -> !Sets.intersection(input.getGenres(), genres).isEmpty()

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -1,32 +1,25 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ResolvedChannelGroup;
-import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.ChannelWithChannelGroupMembership;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
+import org.atlasapi.query.common.MissingResolvedDataException;
 import org.atlasapi.query.v4.channelgroup.ChannelGroupChannelWriter;
 
-import com.google.common.base.Predicate;
+import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import org.joda.time.LocalDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -34,61 +27,46 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private final ChannelGroupChannelWriter channelWriter;
-    private final ChannelResolver channelResolver;
 
-    public ChannelGroupChannelsAnnotation(ChannelGroupChannelWriter channelWriter,
-            ChannelResolver channelResolver) {
+    public ChannelGroupChannelsAnnotation(ChannelGroupChannelWriter channelWriter) {
         this.channelWriter = checkNotNull(channelWriter);
-        this.channelResolver = checkNotNull(channelResolver);
     }
 
     @Override
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        final ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
-        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelGroup().getChannelsAvailable(
-                LocalDate.now());
-        List<Id> orderedIds = StreamSupport.stream(availableChannels.spliterator(), false)
-                //TODO fix channel appearing twice in ordering blowing this thing up
-                .map(cm -> cm.getChannel().getId())
-                .distinct()
-                .collect(Collectors.toList());
-        Ordering<Id> idOrdering = Ordering.explicit(orderedIds);
-        for (ChannelGroupMembership channelGroupMembership : availableChannels) {
-            builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
+
+        Optional<Iterable<Channel>> resolvedChannels = entity.getChannels();
+
+        if(!resolvedChannels.isPresent()) {
+            throw new MissingResolvedDataException(channelWriter.listName());
         }
 
-        ImmutableMultimap<Id, ChannelGroupMembership> channelGroupMemberships = builder.build();
+        Iterable<Channel> channels = resolvedChannels.get();
+
         String genre = ctxt.getRequest()
                 .getParameter(Attributes.CHANNEL_GROUP_CHANNEL_GENRES.externalName());
 
-        Iterable<Channel> channels = Futures.get(
-                Futures.transform(
-                        this.channelResolver.resolveIds(channelGroupMemberships.keySet()),
-                        (Resolved<Channel> channelResolved) -> {
-                            return StreamSupport.stream(channelResolved.getResources()
-                                    .spliterator(), false)
-                                    .sorted((o1, o2) -> idOrdering.compare(o1.getId(), o2.getId()))
-                                    .collect(Collectors.toList());
-                        }
-
-                ), 1, TimeUnit.MINUTES, IOException.class
-        );
         if (!Strings.isNullOrEmpty(genre)) {
-            final ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',').split(genre));
-            channels = Iterables.filter(channels, new Predicate<Channel>() {
-
-                @Override
-                public boolean apply(Channel input) {
-                    return !Sets.intersection(input.getGenres(), genres).isEmpty();
-                }
-            });
+            final ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',')
+                    .split(genre));
+            channels = Iterables.filter(channels,
+                    input -> !Sets.intersection(input.getGenres(), genres).isEmpty()
+            );
         }
+
         ImmutableSet.Builder<ChannelWithChannelGroupMembership> resultBuilder = ImmutableSet.builder();
 
+        ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
+        for (ChannelGroupMembership channelGroupMembership :
+                entity.getChannelGroup().getChannelsAvailable(LocalDate.now())) {
+            builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
+        }
+        ImmutableMultimap<Id, ChannelGroupMembership> channelGroupMemberships = builder.build();
+
         for (Channel channel : channels) {
-            for (ChannelGroupMembership channelGroupMembership : channelGroupMemberships.get(channel
-                    .getId())) {
+            for (ChannelGroupMembership channelGroupMembership : channelGroupMemberships.get(
+                    channel.getId())) {
                 resultBuilder.add(
                         new ChannelWithChannelGroupMembership(
                                 channel,

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -1,9 +1,12 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
@@ -36,13 +39,15 @@ public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedCha
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
 
-        Optional<Iterable<Channel>> resolvedChannels = entity.getChannels();
+        Optional<Iterable<ResolvedChannel>> resolvedChannels = entity.getChannels();
 
         if(!resolvedChannels.isPresent()) {
             throw new MissingResolvedDataException(channelWriter.listName());
         }
 
-        Iterable<Channel> channels = resolvedChannels.get();
+        Iterable<Channel> channels = StreamSupport.stream(resolvedChannels.get().spliterator(), false)
+                .map(ResolvedChannel::getChannel)
+                .collect(Collectors.toList());
 
         String genre = ctxt.getRequest()
                 .getParameter(Attributes.CHANNEL_GROUP_CHANNEL_GENRES.externalName());

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -7,8 +7,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.atlasapi.channel.Channel;
-import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
@@ -31,7 +31,7 @@ import org.joda.time.LocalDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ChannelGroup<?>> {
+public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private final ChannelGroupChannelWriter channelWriter;
     private final ChannelResolver channelResolver;
@@ -43,10 +43,10 @@ public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ChannelGrou
     }
 
     @Override
-    public void write(ChannelGroup<?> entity, FieldWriter writer, OutputContext ctxt)
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
         final ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
-        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelsAvailable(
+        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelGroup().getChannelsAvailable(
                 LocalDate.now());
         List<Id> orderedIds = StreamSupport.stream(availableChannels.spliterator(), false)
                 //TODO fix channel appearing twice in ordering blowing this thing up

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupIdSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupIdSummaryAnnotation.java
@@ -1,0 +1,28 @@
+package org.atlasapi.output.annotation;
+
+import java.io.IOException;
+
+import org.atlasapi.channel.ResolvedChannelGroup;
+import org.atlasapi.output.FieldWriter;
+import org.atlasapi.output.OutputContext;
+import org.atlasapi.output.writers.IdSummaryWriter;
+
+import com.google.common.base.Throwables;
+
+public class ChannelGroupIdSummaryAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
+
+    IdSummaryWriter idSummaryWriter;
+    public ChannelGroupIdSummaryAnnotation(IdSummaryWriter idSummaryWriter) {
+        this.idSummaryWriter = idSummaryWriter;
+    }
+
+    @Override
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt) {
+        try {
+            idSummaryWriter.write(entity.getChannelGroup(), writer, ctxt);
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
+    }
+
+}

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupIdSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupIdSummaryAnnotation.java
@@ -9,20 +9,24 @@ import org.atlasapi.output.writers.IdSummaryWriter;
 
 import com.google.common.base.Throwables;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class ChannelGroupIdSummaryAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
-    IdSummaryWriter idSummaryWriter;
-    public ChannelGroupIdSummaryAnnotation(IdSummaryWriter idSummaryWriter) {
-        this.idSummaryWriter = idSummaryWriter;
+    private final IdSummaryWriter idSummaryWriter;
+
+    private ChannelGroupIdSummaryAnnotation(IdSummaryWriter idSummaryWriter) {
+        this.idSummaryWriter = checkNotNull(idSummaryWriter);
+    }
+
+    public static ChannelGroupIdSummaryAnnotation create(IdSummaryWriter idSummaryWriter) {
+        return new ChannelGroupIdSummaryAnnotation(idSummaryWriter);
     }
 
     @Override
-    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt) {
-        try {
-            idSummaryWriter.write(entity.getChannelGroup(), writer, ctxt);
-        } catch (IOException e) {
-            Throwables.propagate(e);
-        }
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
+            throws IOException {
+        idSummaryWriter.write(entity.getChannelGroup(), writer, ctxt);
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupMembershipAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupMembershipAnnotation.java
@@ -3,12 +3,13 @@ package org.atlasapi.output.annotation;
 import java.io.IOException;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupMembershipAnnotation extends OutputAnnotation<Channel> {
+public class ChannelGroupMembershipAnnotation extends OutputAnnotation<ResolvedChannel> {
 
     private final ChannelGroupMembershipListWriter channelGroupMembershipWriter;
 
@@ -18,8 +19,8 @@ public class ChannelGroupMembershipAnnotation extends OutputAnnotation<Channel> 
     }
 
     @Override
-    public void write(Channel entity, FieldWriter format, OutputContext ctxt) throws IOException {
-        format.writeList(channelGroupMembershipWriter, entity.getChannelGroups(), ctxt);
+    public void write(ResolvedChannel entity, FieldWriter format, OutputContext ctxt) throws IOException {
+        format.writeList(channelGroupMembershipWriter, entity.getChannel().getChannelGroups(), ctxt);
 
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelIdSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelIdSummaryAnnotation.java
@@ -1,0 +1,30 @@
+package org.atlasapi.output.annotation;
+
+import java.io.IOException;
+
+import org.atlasapi.channel.ResolvedChannel;
+import org.atlasapi.output.FieldWriter;
+import org.atlasapi.output.OutputContext;
+import org.atlasapi.output.writers.IdSummaryWriter;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ChannelIdSummaryAnnotation extends OutputAnnotation<ResolvedChannel> {
+
+    private final IdSummaryWriter idSummaryWriter;
+
+    private ChannelIdSummaryAnnotation(IdSummaryWriter idSummaryWriter) {
+        this.idSummaryWriter = checkNotNull(idSummaryWriter);
+    }
+
+    public static ChannelIdSummaryAnnotation create(IdSummaryWriter idSummaryWriter) {
+        return new ChannelIdSummaryAnnotation(idSummaryWriter);
+    }
+
+    @Override
+    public void write(ResolvedChannel entity, FieldWriter writer, OutputContext ctxt)
+            throws IOException {
+        idSummaryWriter.write(entity.getChannel(), writer, ctxt);
+    }
+
+}

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelVariationAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelVariationAnnotation.java
@@ -2,60 +2,58 @@ package org.atlasapi.output.annotation;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelRef;
 import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
+import org.atlasapi.query.common.MissingResolvedDataException;
 import org.atlasapi.query.v4.channel.ChannelWriter;
 
+import com.metabroadcast.common.stream.MoreCollectors;
+
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
+import scala.concurrent.pilib;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelVariationAnnotation extends OutputAnnotation<Channel> {
+public class ChannelVariationAnnotation extends OutputAnnotation<ResolvedChannel> {
 
-    private final ChannelResolver channelResolver;
     private final ChannelWriter channelWriter;
 
     public ChannelVariationAnnotation(
-            ChannelResolver channelResolver,
             ChannelWriter channelWriter
     ) {
-        this.channelResolver = checkNotNull(channelResolver);
-        this.channelWriter = channelWriter;
+        this.channelWriter = checkNotNull(channelWriter);
     }
 
     @Override
-    public void write(Channel entity, FieldWriter format, OutputContext ctxt) throws IOException {
-        Iterable<Id> ids = Iterables.transform(
-                entity.getVariations(),
-                new Function<ChannelRef, Id>() {
+    public void write(ResolvedChannel entity, FieldWriter format, OutputContext ctxt) throws IOException {
 
-                    @Override
-                    public Id apply(ChannelRef input) {
-                        return input.getId();
-                    }
-                }
-        );
+        Optional<Iterable<Channel>> channelVariations = entity.getChannelVariations();
+        if (channelVariations.isPresent()) {
+            Iterable<ResolvedChannel> resolvedChannels =
+                    StreamSupport.stream(channelVariations.get().spliterator(), false)
+                    .map(input -> ResolvedChannel.builder(input).build())
+                    .collect(Collectors.toList());
+            // ^^ This is because the writer needs a ResolvedChannel as it does an annotation check
+            // for some reason so channels need to be converted to resolved channels before theyre
+            // written
 
-        Iterable<Channel> channels = Futures.get(Futures.transform(
-                channelResolver.resolveIds(ids),
-                new Function<Resolved<Channel>, Iterable<Channel>>() {
-
-                    @Override
-                    public Iterable<Channel> apply(@Nullable Resolved<Channel> input) {
-                        return input.getResources();
-                    }
-                }
-        ), 1, TimeUnit.MINUTES, IOException.class);
-        format.writeList(channelWriter, channels, ctxt);
+            format.writeList(channelWriter, resolvedChannels, ctxt);
+        } else {
+            throw new MissingResolvedDataException("channel variations");
+        }
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/CurrentAndFutureBroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/CurrentAndFutureBroadcastsAnnotation.java
@@ -24,13 +24,14 @@ public class CurrentAndFutureBroadcastsAnnotation extends OutputAnnotation<Conte
     private final BroadcastWriter broadcastWriter;
     private final ChannelsBroadcastFilter channelsBroadcastFilter = new ChannelsBroadcastFilter();
 
-    public CurrentAndFutureBroadcastsAnnotation(NumberToShortStringCodec codec,
-            ChannelResolver channelResolver, ChannelGroupResolver channelGroupResolver) {
+    public CurrentAndFutureBroadcastsAnnotation(
+            NumberToShortStringCodec codec,
+            ChannelResolver channelResolver
+    ) {
         this.broadcastWriter = new BroadcastWriter(
                 "broadcasts",
                 codec,
-                channelResolver,
-                channelGroupResolver
+                channelResolver
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/FirstBroadcastAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/FirstBroadcastAnnotation.java
@@ -22,13 +22,14 @@ public class FirstBroadcastAnnotation extends OutputAnnotation<Content> {
 
     private final BroadcastWriter broadcastWriter;
 
-    public FirstBroadcastAnnotation(NumberToShortStringCodec codec, ChannelResolver channelResolver,
-            ChannelGroupResolver channelGroupResolver) {
+    public FirstBroadcastAnnotation(
+            NumberToShortStringCodec codec,
+            ChannelResolver channelResolver
+    ) {
         broadcastWriter = new BroadcastWriter(
                 "first_broadcasts",
                 codec,
-                channelResolver,
-                channelGroupResolver
+                channelResolver
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/IdentificationSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/IdentificationSummaryAnnotation.java
@@ -9,11 +9,15 @@ import org.atlasapi.output.writers.IdSummaryWriter;
 
 public class IdentificationSummaryAnnotation extends OutputAnnotation<Identified> {
 
-    private IdSummaryWriter idSummaryWriter;
+    private final IdSummaryWriter idSummaryWriter;
 
-    public IdentificationSummaryAnnotation() {
+    private IdentificationSummaryAnnotation(IdSummaryWriter idSummaryWriter) {
         super();
-        this.idSummaryWriter = IdSummaryWriter.create();
+        this.idSummaryWriter = idSummaryWriter;
+    }
+
+    public static IdentificationSummaryAnnotation create(IdSummaryWriter idSummaryWriter) {
+        return new IdentificationSummaryAnnotation(idSummaryWriter);
     }
 
     @Override

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/IdentificationSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/IdentificationSummaryAnnotation.java
@@ -5,26 +5,20 @@ import java.io.IOException;
 import org.atlasapi.entity.Identified;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
-
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import org.atlasapi.output.writers.IdSummaryWriter;
 
 public class IdentificationSummaryAnnotation extends OutputAnnotation<Identified> {
 
-    private final NumberToShortStringCodec codec;
+    private IdSummaryWriter idSummaryWriter;
 
-    public IdentificationSummaryAnnotation(NumberToShortStringCodec codec) {
+    public IdentificationSummaryAnnotation() {
         super();
-        this.codec = codec;
+        this.idSummaryWriter = IdSummaryWriter.create();
     }
 
     @Override
-    public void write(Identified entity, FieldWriter formatter, OutputContext ctxt)
+    public void write(Identified entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        formatter.writeField("id", encodedIdOrNull(entity));
-    }
-
-    private String encodedIdOrNull(Identified entity) {
-        return entity.getId() != null ? codec.encode(entity.getId().toBigInteger())
-                                      : null;
+        idSummaryWriter.write(entity, writer, ctxt);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/NextBroadcastAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/NextBroadcastAnnotation.java
@@ -2,7 +2,6 @@ package org.atlasapi.output.annotation;
 
 import java.io.IOException;
 
-import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.Content;
@@ -27,7 +26,8 @@ public class NextBroadcastAnnotation extends OutputAnnotation<Content> {
     public NextBroadcastAnnotation(
             Clock clock,
             NumberToShortStringCodec codec,
-            ChannelResolver channelResolver) {
+            ChannelResolver channelResolver
+    ) {
         super();
         this.clock = clock;
         this.broadcastWriter = new BroadcastWriter(

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/NextBroadcastAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/NextBroadcastAnnotation.java
@@ -24,15 +24,16 @@ public class NextBroadcastAnnotation extends OutputAnnotation<Content> {
     private final BroadcastWriter broadcastWriter;
     private final Clock clock;
 
-    public NextBroadcastAnnotation(Clock clock, NumberToShortStringCodec codec,
-            ChannelResolver channelResolver, ChannelGroupResolver channelGroupResolver) {
+    public NextBroadcastAnnotation(
+            Clock clock,
+            NumberToShortStringCodec codec,
+            ChannelResolver channelResolver) {
         super();
         this.clock = clock;
         this.broadcastWriter = new BroadcastWriter(
                 "next_broadcasts",
                 codec,
-                channelResolver,
-                channelGroupResolver
+                channelResolver
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ParentChannelAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ParentChannelAnnotation.java
@@ -5,48 +5,34 @@ import java.util.concurrent.TimeUnit;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.query.v4.channel.ChannelWriter;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ParentChannelAnnotation extends OutputAnnotation<Channel> {
+public class ParentChannelAnnotation extends OutputAnnotation<ResolvedChannel> {
 
     private final ChannelWriter channelWriter;
 
-    private final ChannelResolver channelResolver;
-
-    public ParentChannelAnnotation(
-            ChannelWriter channelWriter,
-            ChannelResolver channelResolver
-    ) {
+    public ParentChannelAnnotation(ChannelWriter channelWriter) {
         this.channelWriter = checkNotNull(channelWriter);
-        this.channelResolver = checkNotNull(channelResolver);
     }
 
     @Override
-    public void write(Channel entity, FieldWriter format, OutputContext ctxt) throws IOException {
-        if (entity.getParent() != null) {
-            Channel parentChannel = Futures.get(
-                    Futures.transform(
-                            channelResolver.resolveIds(ImmutableList.of(entity.getParent()
-                                    .getId())),
-                            new Function<Resolved<Channel>, Channel>() {
+    public void write(ResolvedChannel entity, FieldWriter format, OutputContext ctxt) throws IOException {
 
-                                @Override
-                                public Channel apply(Resolved<Channel> input) {
-                                    return input.getResources().first().get();
-                                }
-                            }
-                    ), 1, TimeUnit.MINUTES, IOException.class
-            );
-            format.writeObject(channelWriter, "parent", parentChannel, ctxt);
+       Optional<Channel> parentChannel = entity.getParentChannel();
+        if (entity.getParentChannel().isPresent()) {
+            ResolvedChannel resolvedParentChannel = ResolvedChannel.builder(parentChannel.get()).build();
+            format.writeObject(channelWriter, "parent", resolvedParentChannel, ctxt);
         } else {
             format.writeField("parent", null);
         }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
@@ -1,63 +1,37 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import org.atlasapi.channel.ChannelGroup;
-import org.atlasapi.channel.ChannelGroupRef;
-import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.channel.Platform;
-import org.atlasapi.entity.Id;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Futures;
+import com.google.common.base.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-public class PlatformAnnotation extends OutputAnnotation<ChannelGroup<?>> {
+public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private static final ChannelGroupWriter CHANNEL_GROUP_WRITER = new ChannelGroupWriter(
             "regions",
             "region"
     );
-    private final ChannelGroupResolver channelGroupResolver;
-
-    public PlatformAnnotation(ChannelGroupResolver channelGroupResolver) {
-        this.channelGroupResolver = checkNotNull(channelGroupResolver);
-    }
 
     @Override
-    public void write(ChannelGroup entity, FieldWriter writer, OutputContext ctxt)
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        if (!(entity instanceof Platform)) {
+        if (!(entity.getChannelGroup() instanceof Platform)) {
             return;
         }
-        Platform platform = (Platform) entity;
-        Iterable<Id> regionIds = Iterables.transform(
-                platform.getRegions(),
-                new Function<ChannelGroupRef, Id>() {
 
-                    @Override
-                    public Id apply(ChannelGroupRef input) {
-                        return input.getId();
-                    }
-                }
-        );
+        Optional<Iterable<ChannelGroup<?>>> channelGroups = entity.getRegionChannelGroups();
+        if (channelGroups.isPresent()) {
+            writer.writeList(CHANNEL_GROUP_WRITER, channelGroups.get(), ctxt);
+        } else {
+            throw new NullPointerException();
+        }
 
-        Iterable<ChannelGroup<?>> channelGroups = Futures.get(
-                Futures.transform(
-                        channelGroupResolver.resolveIds(regionIds),
-                        (Resolved<ChannelGroup<?>> input) -> {
-                            return input.getResources();
-                        }
-                ), 1, TimeUnit.MINUTES, IOException.class
-        );
 
-        writer.writeList(CHANNEL_GROUP_WRITER, channelGroups, ctxt);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
@@ -1,7 +1,6 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ResolvedChannelGroup;
@@ -10,6 +9,8 @@ import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
 import org.atlasapi.query.common.MissingResolvedDataException;
+
+import com.google.common.base.Optional;
 
 public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
@@ -1,6 +1,7 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ResolvedChannelGroup;
@@ -8,8 +9,7 @@ import org.atlasapi.channel.Platform;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
-
-import com.google.common.base.Optional;
+import org.atlasapi.query.common.MissingResolvedDataException;
 
 public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
@@ -29,9 +29,7 @@ public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
         if (channelGroups.isPresent()) {
             writer.writeList(CHANNEL_GROUP_WRITER, channelGroups.get(), ctxt);
         } else {
-            throw new NullPointerException();
+            throw new MissingResolvedDataException(CHANNEL_GROUP_WRITER.listName());
         }
-
-
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
@@ -30,7 +30,7 @@ public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
         if (channelGroup.isPresent()) {
             writer.writeObject(CHANNEL_GROUP_WRITER, channelGroup.get(), ctxt);
         } else {
-            throw new MissingResolvedDataException("regions");
+            throw new MissingResolvedDataException("missing regions for channel group");
         }
 
     }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.channel.Region;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
@@ -17,7 +18,7 @@ import com.google.common.util.concurrent.Futures;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class RegionsAnnotation extends OutputAnnotation<ChannelGroup<?>> {
+public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private static final ChannelGroupWriter CHANNEL_GROUP_WRITER = new ChannelGroupWriter(
             "regions",
@@ -32,12 +33,12 @@ public class RegionsAnnotation extends OutputAnnotation<ChannelGroup<?>> {
     }
 
     @Override
-    public void write(ChannelGroup entity, FieldWriter writer, OutputContext ctxt)
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        if (!(entity instanceof Region)) {
+        if (!(entity.getChannelGroup() instanceof Region)) {
             return;
         }
-        Region region = (Region) entity;
+        Region region = (Region) entity.getChannelGroup();
         if (region.getPlatform() == null) {
             writer.writeField("parent", null);
             return;

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
@@ -39,10 +39,7 @@ public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
             return;
         }
         Region region = (Region) entity.getChannelGroup();
-        if (region.getPlatform() == null) {
-            writer.writeField("parent", null);
-            return;
-        }
+
         Id platformId = region.getPlatform().getId();
 
         ChannelGroup channelGroup = Futures.get(

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
@@ -30,7 +30,7 @@ public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
         if (channelGroup.isPresent()) {
             writer.writeObject(CHANNEL_GROUP_WRITER, channelGroup.get(), ctxt);
         } else {
-            throw new MissingResolvedDataException(CHANNEL_GROUP_WRITER.listName());
+            throw new MissingResolvedDataException("regions");
         }
 
     }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingBroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingBroadcastsAnnotation.java
@@ -32,8 +32,7 @@ public class UpcomingBroadcastsAnnotation extends OutputAnnotation<Content> {
         this.broadcastWriter = new BroadcastWriter(
                 "broadcasts",
                 codec,
-                channelResolver,
-                channelGroupResolver
+                channelResolver
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/output/writers/BroadcastWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/BroadcastWriter.java
@@ -97,14 +97,14 @@ public final class BroadcastWriter implements EntityListWriter<Broadcast> {
         if (channel == null) {
             log.error("Unable to resolve channel {}", entity.getChannelId());
 
+        } else {
+            // Little hack until Broadcasts have their own composite objects to deal with resolution of
+            // channels and channel groups outside annotation/writer logic
+
+            ResolvedChannel resolvedChannel = ResolvedChannel.builder(channel).build();
+            writer.writeObject(channelWriter, resolvedChannel, ctxt);
         }
 
-        // Little hack until Broadcasts have their own composite objects to deal with resolution of
-        // channels and channel groups outside annotation/writer logic
-
-        ResolvedChannel resolvedChannel = ResolvedChannel.builder(channel).build();
-
-        writer.writeObject(channelWriter, resolvedChannel, ctxt);
         writer.writeField("schedule_date", entity.getScheduleDate());
         writer.writeField("repeat", entity.getRepeat());
         writer.writeField("subtitled", entity.getSubtitled());

--- a/atlas-api/src/main/java/org/atlasapi/output/writers/IdSummaryWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/IdSummaryWriter.java
@@ -1,0 +1,46 @@
+package org.atlasapi.output.writers;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+import org.atlasapi.entity.Identified;
+import org.atlasapi.output.EntityWriter;
+import org.atlasapi.output.FieldWriter;
+import org.atlasapi.output.OutputContext;
+
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+
+public class IdSummaryWriter implements EntityWriter<Identified> {
+
+    private final NumberToShortStringCodec codec;
+
+    private IdSummaryWriter() {
+        this.codec = SubstitutionTableNumberCodec.lowerCaseOnly();
+    }
+
+    public static IdSummaryWriter create() {
+        return new IdSummaryWriter();
+    }
+
+    @Override
+    public void write(
+            @Nonnull Identified entity,
+            @Nonnull FieldWriter writer,
+            @Nonnull OutputContext ctxt
+    ) throws IOException {
+        //noinspection ConstantConditions
+        String id = entity.getId() != null
+                    ? codec.encode(entity.getId().toBigInteger())
+                    : null;
+
+        writer.writeField("id", id);
+    }
+
+    @Nonnull
+    @Override
+    public String fieldName(Identified entity) {
+        return "id";
+    }
+}

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -97,7 +97,9 @@ public class QueryModule {
 
     @Bean
     public QueryExecutor<ResolvedChannelGroup> channelGroupQueryExecutor() {
-        return new ChannelGroupQueryExecutor(persistenceModule.channelGroupResolver());
+        return new ChannelGroupQueryExecutor(
+                persistenceModule.channelGroupResolver(),
+                persistenceModule.channelResolver());
     }
 
     public MergingEquivalentsResolver<Content> mergingContentResolver() {

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -16,7 +16,7 @@ package org.atlasapi.query;
 
 import org.atlasapi.AtlasPersistenceModule;
 import org.atlasapi.channel.Channel;
-import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.content.ContainerSummaryResolver;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.MergingEquivalentsResolverBackedContainerSummaryResolver;
@@ -96,7 +96,7 @@ public class QueryModule {
     }
 
     @Bean
-    public QueryExecutor<ChannelGroup<?>> channelGroupQueryExecutor() {
+    public QueryExecutor<ResolvedChannelGroup> channelGroupQueryExecutor() {
         return new ChannelGroupQueryExecutor(persistenceModule.channelGroupResolver());
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -15,7 +15,6 @@ permissions and limitations under the License. */
 package org.atlasapi.query;
 
 import org.atlasapi.AtlasPersistenceModule;
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.content.ContainerSummaryResolver;
@@ -144,7 +143,9 @@ public class QueryModule {
 
     @Bean
     public ContainerSummaryResolver containerSummaryResolver() {
-        return new MergingEquivalentsResolverBackedContainerSummaryResolver(mergingContentResolver());
+        return new MergingEquivalentsResolverBackedContainerSummaryResolver(
+                mergingContentResolver()
+        );
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -16,6 +16,7 @@ package org.atlasapi.query;
 
 import org.atlasapi.AtlasPersistenceModule;
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.content.ContainerSummaryResolver;
 import org.atlasapi.content.Content;
@@ -91,8 +92,11 @@ public class QueryModule {
     }
 
     @Bean
-    public QueryExecutor<Channel> channelQueryExecutor() {
-        return ChannelQueryExecutor.create(persistenceModule.channelResolver());
+    public QueryExecutor<ResolvedChannel> channelQueryExecutor() {
+        return ChannelQueryExecutor.create(
+                persistenceModule.channelResolver(),
+                persistenceModule.channelGroupResolver()
+        );
     }
 
     @Bean

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -7,7 +7,6 @@ import org.atlasapi.LicenseModule;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.application.auth.ApplicationSourcesFetcher;
 import org.atlasapi.application.auth.UserFetcher;
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
@@ -113,7 +112,6 @@ import org.atlasapi.query.common.QueryExecutor;
 import org.atlasapi.query.common.QueryParser;
 import org.atlasapi.query.common.Resource;
 import org.atlasapi.query.common.StandardQueryParser;
-import org.atlasapi.query.common.UncheckedQueryExecutionException;
 import org.atlasapi.query.v4.channel.ChannelController;
 import org.atlasapi.query.v4.channel.ChannelListWriter;
 import org.atlasapi.query.v4.channel.ChannelQueryResultWriter;
@@ -166,8 +164,6 @@ import com.metabroadcast.common.query.Selection;
 import com.metabroadcast.common.query.Selection.SelectionBuilder;
 import com.metabroadcast.common.time.SystemClock;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -695,14 +691,7 @@ public class QueryWebModule {
                         QueryAtomParser.valueOf(
                                 Attributes.MEDIA_TYPE,
                                 AttributeCoercers.enumCoercer(
-                                        new Function<String, Optional<MediaType>>() {
-
-                                            @Override
-                                            public Optional<MediaType> apply(
-                                                    String input) {
-                                                return MediaType.fromKey(input);
-                                            }
-                                        }
+                                        MediaType::fromKey
                                 )
                         )
                 )
@@ -715,28 +704,30 @@ public class QueryWebModule {
         );
 
         return new StandardQueryParser<Topic>(Resource.TOPIC,
-                new QueryAttributeParser(ImmutableList.<QueryAtomParser<String, ? extends Comparable<?>>>of(
-                        QueryAtomParser.valueOf(
-                                Attributes.ID,
-                                AttributeCoercers.idCoercer(idCodec())
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.TOPIC_TYPE,
-                                AttributeCoercers.enumCoercer(Topic.Type.fromKey())
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.SOURCE,
-                                AttributeCoercers.enumCoercer(Sources.fromKey())
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.ALIASES_NAMESPACE,
-                                AttributeCoercers.stringCoercer()
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.ALIASES_VALUE,
-                                AttributeCoercers.stringCoercer()
+                new QueryAttributeParser(
+                        ImmutableList.<QueryAtomParser<String, ? extends Comparable<?>>>of(
+                            QueryAtomParser.valueOf(
+                                    Attributes.ID,
+                                    AttributeCoercers.idCoercer(idCodec())
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.TOPIC_TYPE,
+                                    AttributeCoercers.enumCoercer(Topic.Type.fromKey())
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.SOURCE,
+                                    AttributeCoercers.enumCoercer(Sources.fromKey())
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.ALIASES_NAMESPACE,
+                                    AttributeCoercers.stringCoercer()
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.ALIASES_VALUE,
+                                    AttributeCoercers.stringCoercer()
+                            )
                         )
-                )),
+                ),
                 idCodec(), contextParser
         );
     }
@@ -747,24 +738,26 @@ public class QueryWebModule {
         );
 
         return new StandardQueryParser<Event>(Resource.EVENT,
-                new QueryAttributeParser(ImmutableList.<QueryAtomParser<String, ? extends Comparable<?>>>of(
-                        QueryAtomParser.valueOf(
-                                Attributes.ID,
-                                AttributeCoercers.idCoercer(idCodec())
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.SOURCE,
-                                AttributeCoercers.enumCoercer(Sources.fromKey())
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.ALIASES_NAMESPACE,
-                                AttributeCoercers.stringCoercer()
-                        ),
-                        QueryAtomParser.valueOf(
-                                Attributes.ALIASES_VALUE,
-                                AttributeCoercers.stringCoercer()
+                new QueryAttributeParser(
+                        ImmutableList.<QueryAtomParser<String, ? extends Comparable<?>>>of(
+                            QueryAtomParser.valueOf(
+                                    Attributes.ID,
+                                    AttributeCoercers.idCoercer(idCodec())
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.SOURCE,
+                                    AttributeCoercers.enumCoercer(Sources.fromKey())
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.ALIASES_NAMESPACE,
+                                    AttributeCoercers.stringCoercer()
+                            ),
+                            QueryAtomParser.valueOf(
+                                    Attributes.ALIASES_VALUE,
+                                    AttributeCoercers.stringCoercer()
+                            )
                         )
-                )),
+                ),
                 idCodec(), contextParser
         );
     }
@@ -1051,8 +1044,12 @@ public class QueryWebModule {
                         NullWriter.create(Content.class)
                 )
                 .register(NON_MERGED, NullWriter.create(Content.class))
-                .register(REVIEWS, new ReviewsAnnotation(new ReviewsWriter(SourceWriter.sourceWriter("source"))))
-                .register(RATINGS, new RatingsAnnotation(new RatingsWriter(SourceWriter.sourceWriter("source"))))
+                .register(REVIEWS, new ReviewsAnnotation(
+                        new ReviewsWriter(SourceWriter.sourceWriter("source")))
+                )
+                .register(RATINGS, new RatingsAnnotation(
+                        new RatingsWriter(SourceWriter.sourceWriter("source")))
+                )
                 .build();
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -233,25 +233,36 @@ public class QueryWebModule {
     private @Value("${local.host.name}") String localHostName;
     private @Value("${atlas.uri}") String baseAtlasUri;
 
-    @Autowired
-    private KafkaMessagingModule messaging;
+    private IdSummaryWriter idSummaryWriter = IdSummaryWriter.create();
 
-    private @Autowired DatabasedMongo mongo;
+    private
+    @Autowired
+    KafkaMessagingModule messaging;
+
+    private
+    @Autowired
+    DatabasedMongo mongo;
+
     private
     @Autowired
     QueryModule queryModule;
+
     private
     @Autowired
     org.atlasapi.media.channel.ChannelResolver legacyChannelResolver;
+
     private
     @Autowired
     SearchResolver v4SearchResolver;
+
     private
     @Autowired
     TopicResolver topicResolver;
+
     private
     @Autowired
     PopularTopicIndex popularTopicIndex;
+
     private
     @Autowired
     UserFetcher userFetcher;
@@ -585,11 +596,9 @@ public class QueryWebModule {
                         ),
                         CHANNEL_GROUP
                 )
-                .register(ID_SUMMARY, new ChannelGroupIdSummaryAnnotation(
-                        IdSummaryWriter.create()
-                ))
+                .register(ID_SUMMARY, ChannelGroupIdSummaryAnnotation.create(idSummaryWriter))
                 .register(REGIONS, new PlatformAnnotation(), CHANNEL_GROUP)
-                .register(PLATFORM, new RegionsAnnotation(channelGroupResolver), CHANNEL_GROUP)
+                .register(PLATFORM, new RegionsAnnotation(), CHANNEL_GROUP)
                 .register(
                         CHANNEL_GROUPS_SUMMARY,
                         NullWriter.create(ResolvedChannelGroup.class),
@@ -597,8 +606,10 @@ public class QueryWebModule {
                 )
                 .register(
                         ADVERTISED_CHANNELS,
-                        new ChannelGroupAdvertisedChannelsAnnotation(new ChannelGroupChannelWriter(
-                                channelWriter()), channelResolver)
+                        new ChannelGroupAdvertisedChannelsAnnotation(
+                                new ChannelGroupChannelWriter(channelWriter()
+                                )
+                        )
                 )
                 .build());
     }
@@ -848,7 +859,7 @@ public class QueryWebModule {
     private AnnotationRegistry<Content> contentAnnotations() {
         ImmutableSet<Annotation> commonImplied = ImmutableSet.of(ID_SUMMARY);
         return AnnotationRegistry.<Content>builder()
-                .registerDefault(ID_SUMMARY, new IdentificationSummaryAnnotation())
+                .registerDefault(ID_SUMMARY, IdentificationSummaryAnnotation.create(idSummaryWriter))
                 .register(ID, new IdentificationAnnotation(), commonImplied)
                 .register(
                         EXTENDED_ID,
@@ -1003,8 +1014,11 @@ public class QueryWebModule {
                                                 channelResolver,
                                                 channelGroupResolver
                                         ),
-                                        new ItemDetailWriter(new IdentificationSummaryAnnotation(
-                                        ))
+                                        new ItemDetailWriter(
+                                                IdentificationSummaryAnnotation.create(
+                                                        idSummaryWriter
+                                                )
+                                        )
                                 )
                         ), commonImplied
                 )
@@ -1013,7 +1027,7 @@ public class QueryWebModule {
                         new AvailableContentDetailAnnotation(
                                 queryModule.mergingContentResolver(),
                                 new ItemDetailWriter(
-                                        new IdentificationSummaryAnnotation(),
+                                        IdentificationSummaryAnnotation.create(idSummaryWriter),
                                         AvailableContentDetailAnnotation.AVAILABLE_CONTENT_DETAIL,
                                         new LocationsAnnotation(
                                                 persistenceModule.playerResolver(),
@@ -1051,7 +1065,7 @@ public class QueryWebModule {
     @Bean
     protected EntityListWriter<Topic> topicListWriter() {
         return new TopicListWriter(AnnotationRegistry.<Topic>builder()
-                .registerDefault(ID_SUMMARY, new IdentificationSummaryAnnotation())
+                .registerDefault(ID_SUMMARY, IdentificationSummaryAnnotation.create(idSummaryWriter))
                 .register(ID, new IdentificationAnnotation(), ID_SUMMARY)
                 .register(
                         EXTENDED_ID,
@@ -1065,7 +1079,7 @@ public class QueryWebModule {
     @Bean
     protected EntityListWriter<Event> eventListWriter() {
         return new EventListWriter(AnnotationRegistry.<Event>builder()
-                .registerDefault(ID_SUMMARY, new IdentificationSummaryAnnotation())
+                .registerDefault(ID_SUMMARY, IdentificationSummaryAnnotation.create(idSummaryWriter))
                 .register(ID, new IdentificationAnnotation(), ID_SUMMARY)
                 .register(
                         EXTENDED_ID,
@@ -1084,7 +1098,7 @@ public class QueryWebModule {
 
     private AnnotationRegistry<Topic> topicAnnotationRegistry() {
         return AnnotationRegistry.<Topic>builder()
-                .registerDefault(ID_SUMMARY, new IdentificationSummaryAnnotation())
+                .registerDefault(ID_SUMMARY, IdentificationSummaryAnnotation.create(idSummaryWriter))
                 .register(ID, new IdentificationAnnotation(), ID_SUMMARY)
                 .register(
                         EXTENDED_ID,
@@ -1117,7 +1131,7 @@ public class QueryWebModule {
         return new ChannelListWriter(
                 AnnotationRegistry.<Channel>builder()
                         .registerDefault(CHANNEL, new ChannelAnnotation(channelWriter()))
-                        .register(ID_SUMMARY, new IdentificationSummaryAnnotation())
+                        .register(ID_SUMMARY, IdentificationSummaryAnnotation.create(idSummaryWriter))
                         .register(
                                 CHANNEL_GROUPS,
                                 new ChannelGroupMembershipAnnotation(

--- a/atlas-api/src/main/java/org/atlasapi/query/common/MissingResolvedDataException.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/common/MissingResolvedDataException.java
@@ -1,0 +1,20 @@
+package org.atlasapi.query.common;
+
+import org.atlasapi.entity.util.RuntimeWriteException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MissingResolvedDataException extends RuntimeException {
+
+    private final String message;
+
+    public MissingResolvedDataException(String message) {
+        this.message = checkNotNull(message);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/atlas-api/src/main/java/org/atlasapi/query/common/QueryResult.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/common/QueryResult.java
@@ -91,7 +91,7 @@ public abstract class QueryResult<T> {
 
         public T getOnlyResource() {
             throw new IllegalStateException(
-                    "QueryResult.getOnlyResource() cannot be called on single result");
+                    "QueryResult.getOnlyResource() cannot be called on list result");
         }
 
         @Override

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelController.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.meta.annotations.ProducesType;
 import org.atlasapi.output.ErrorResultWriter;
 import org.atlasapi.output.ErrorSummary;
@@ -29,17 +30,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @ProducesType(type = Channel.class)
 public class ChannelController {
 
-    private final QueryParser<Channel> requestParser;
-    private final QueryExecutor<Channel> queryExecutor;
-    private final QueryResultWriter<Channel> resultWriter;
+    private final QueryParser<ResolvedChannel> requestParser;
+    private final QueryExecutor<ResolvedChannel> queryExecutor;
+    private final QueryResultWriter<ResolvedChannel> resultWriter;
     private final ResponseWriterFactory writerResolver = new ResponseWriterFactory();
 
     private static Logger log = LoggerFactory.getLogger(ChannelController.class);
 
     public ChannelController(
-            QueryParser<Channel> requestParser,
-            QueryExecutor<Channel> queryExecutor,
-            QueryResultWriter<Channel> resultWriter
+            QueryParser<ResolvedChannel> requestParser,
+            QueryExecutor<ResolvedChannel> queryExecutor,
+            QueryResultWriter<ResolvedChannel> resultWriter
     ) {
         this.requestParser = checkNotNull(requestParser);
         this.queryExecutor = checkNotNull(queryExecutor);
@@ -52,8 +53,8 @@ public class ChannelController {
         ResponseWriter writer = null;
         try {
             writer = writerResolver.writerFor(request, response);
-            Query<Channel> channelQuery = requestParser.parse(request);
-            QueryResult<Channel> queryResult = queryExecutor.execute(channelQuery);
+            Query<ResolvedChannel> channelQuery = requestParser.parse(request);
+            QueryResult<ResolvedChannel> queryResult = queryExecutor.execute(channelQuery);
             resultWriter.write(queryResult, writer);
         } catch (Exception e) {
             log.error("Request exception " + request.getRequestURI(), e);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelListWriter.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.AnnotationRegistry;
 import org.atlasapi.output.EntityListWriter;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelListWriter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.AnnotationRegistry;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.FieldWriter;
@@ -15,11 +16,11 @@ import org.atlasapi.query.common.Resource;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelListWriter implements EntityListWriter<Channel> {
+public class ChannelListWriter implements EntityListWriter<ResolvedChannel> {
 
-    private AnnotationRegistry<Channel> annotationRegistry;
+    private AnnotationRegistry<ResolvedChannel> annotationRegistry;
 
-    public ChannelListWriter(AnnotationRegistry<Channel> annotationRegistry) {
+    public ChannelListWriter(AnnotationRegistry<ResolvedChannel> annotationRegistry) {
         this.annotationRegistry = checkNotNull(annotationRegistry);
     }
 
@@ -29,12 +30,12 @@ public class ChannelListWriter implements EntityListWriter<Channel> {
     }
 
     @Override
-    public void write(@Nonnull Channel entity, @Nonnull FieldWriter writer,
+    public void write(@Nonnull ResolvedChannel entity, @Nonnull FieldWriter writer,
             @Nonnull OutputContext ctxt) throws IOException {
         ctxt.startResource(Resource.CHANNEL);
-        List<OutputAnnotation<? super Channel>> annotations = ctxt
+        List<OutputAnnotation<? super ResolvedChannel>> annotations = ctxt
                 .getAnnotations(annotationRegistry);
-        for (OutputAnnotation<? super Channel> annotation : annotations) {
+        for (OutputAnnotation<? super ResolvedChannel> annotation : annotations) {
             annotation.write(entity, writer, ctxt);
         }
         ctxt.endResource();
@@ -43,8 +44,8 @@ public class ChannelListWriter implements EntityListWriter<Channel> {
 
     @Nonnull
     @Override
-    public String fieldName(Channel entity) {
-        return entity.getClass().getSimpleName().toLowerCase();
+    public String fieldName(ResolvedChannel entity) {
+        return entity.getChannel().getClass().getSimpleName().toLowerCase();
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -16,7 +16,6 @@ import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
-import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.media.channel.ChannelQuery;
 import org.atlasapi.media.entity.Publisher;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -1,16 +1,30 @@
 package org.atlasapi.query.v4.channel;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import javax.annotation.Nullable;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelGroupSummary;
 import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.media.channel.ChannelQuery;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.NotFoundException;
 import org.atlasapi.query.common.Query;
+import org.atlasapi.query.common.QueryContext;
 import org.atlasapi.query.common.QueryExecutionException;
 import org.atlasapi.query.common.QueryExecutor;
 import org.atlasapi.query.common.QueryResult;
@@ -18,55 +32,74 @@ import org.atlasapi.query.common.UncheckedQueryExecutionException;
 
 import com.metabroadcast.common.base.MoreOrderings;
 import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.promise.Promise;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelQueryExecutor implements QueryExecutor<Channel> {
+public class ChannelQueryExecutor implements QueryExecutor<ResolvedChannel> {
 
     private static final String TITLE = "title";
     private static final String TITLE_REVERSE = "title.reverse";
 
-    private final ChannelResolver resolver;
+    private final ChannelResolver channelResolver;
+    private final ChannelGroupResolver channelGroupResolver;
 
-    private ChannelQueryExecutor(ChannelResolver resolver) {
-        this.resolver = checkNotNull(resolver);
+    private ChannelQueryExecutor(
+            ChannelResolver channelResolver,
+            ChannelGroupResolver channelGroupResolver
+    ) {
+        this.channelResolver = checkNotNull(channelResolver);
+        this.channelGroupResolver = checkNotNull(channelGroupResolver);
     }
 
-    public static ChannelQueryExecutor create(ChannelResolver channelResolver) {
-        return new ChannelQueryExecutor(channelResolver);
+    public static ChannelQueryExecutor create(
+            ChannelResolver channelResolver,
+            ChannelGroupResolver channelGroupResolver
+    ) {
+        return new ChannelQueryExecutor(channelResolver, channelGroupResolver);
     }
 
     @Override
-    public QueryResult<Channel> execute(Query<Channel> query) throws QueryExecutionException {
+    public QueryResult<ResolvedChannel> execute(Query<ResolvedChannel> query) throws QueryExecutionException {
         return query.isListQuery()
                ? executeListQuery(query)
                : executeSingleQuery(query);
     }
 
-    private QueryResult<Channel> executeSingleQuery(Query<Channel> query)
+    private QueryResult<ResolvedChannel> executeSingleQuery(Query<ResolvedChannel> query)
             throws QueryExecutionException {
         return Futures.get(
                 Futures.transform(
-                        resolver.resolveIds(ImmutableSet.of(query.getOnlyId())),
-                        (Function<Resolved<Channel>, QueryResult<Channel>>) input -> {
+                        channelResolver.resolveIds(ImmutableSet.of(query.getOnlyId())),
+                        (Function<Resolved<Channel>, QueryResult<ResolvedChannel>>) input -> {
                             if (input.getResources().isEmpty()) {
                                 throw new UncheckedQueryExecutionException(
                                         new NotFoundException(query.getOnlyId())
                                 );
                             }
+
+                            ResolvedChannel resolvedChannel =
+                                    resolveAnnotationData(
+                                            query.getContext(),
+                                            input.getResources().first().get()
+                                    );
+
                             return QueryResult.singleResult(
-                                    input.getResources().first().get(),
+                                    resolvedChannel,
                                     query.getContext()
                             );
                         }
@@ -77,7 +110,7 @@ public class ChannelQueryExecutor implements QueryExecutor<Channel> {
         );
     }
 
-    private QueryResult<Channel> executeListQuery(Query<Channel> query)
+    private QueryResult<ResolvedChannel> executeListQuery(Query<ResolvedChannel> query)
             throws QueryExecutionException {
 
         ChannelQuery.Builder channelQueryBuilder = ChannelQuery.builder();
@@ -133,8 +166,13 @@ public class ChannelQueryExecutor implements QueryExecutor<Channel> {
                 .get()
                 .applyTo(filteredChannels);
 
+        ImmutableList<ResolvedChannel> resolvedChannels =
+                selectedChannels.stream()
+                        .map(channel -> resolveAnnotationData(query.getContext(), channel))
+                .collect(MoreCollectors.toImmutableList());
+
         return QueryResult.listResult(
-                selectedChannels,
+                resolvedChannels,
                 query.getContext(),
                 filteredChannels.size()
         );
@@ -142,7 +180,7 @@ public class ChannelQueryExecutor implements QueryExecutor<Channel> {
 
     private FluentIterable<Channel> getChannels(ChannelQuery channelQuery)
             throws QueryExecutionException {
-        ListenableFuture<Resolved<Channel>> resolvingChannels = resolver.resolveChannels(
+        ListenableFuture<Resolved<Channel>> resolvingChannels = channelResolver.resolveChannels(
                 channelQuery
         );
 
@@ -161,6 +199,63 @@ public class ChannelQueryExecutor implements QueryExecutor<Channel> {
         } catch (Exception e) {
             throw new QueryExecutionException(e);
         }
+    }
+
+    private ResolvedChannel resolveAnnotationData(QueryContext ctxt, Channel channel) {
+        ResolvedChannel.Builder resolvedChannelBuilder =
+                ResolvedChannel.builder(channel);
+
+        if (contextHasAnnotation(ctxt, Annotation.CHANNEL_GROUPS_SUMMARY)) {
+            resolvedChannelBuilder.withChannelGroupSummaries(
+                    resolveChannelGroupSummaries(channel)
+            );
+        }
+
+        if (contextHasAnnotation(ctxt, Annotation.PARENT)) {
+            resolvedChannelBuilder.withParentChannel(
+                    resolveParentChannel(channel)
+            );
+        }
+
+        return resolvedChannelBuilder.build();
+    }
+
+    private Optional<List<ChannelGroupSummary>> resolveChannelGroupSummaries(Channel channel) {
+
+        ImmutableList<Id> channelGroupIds = channel.getChannelGroups()
+                .stream()
+                .map(cg -> cg.getChannelGroup().getId())
+                .collect(MoreCollectors.toImmutableList());
+
+        Iterable<ChannelGroup<?>> channelGroups =
+                Promise.wrap(channelGroupResolver.resolveIds(channelGroupIds))
+                        .then(Resolved::getResources)
+                        .get(1, TimeUnit.MINUTES);
+
+        return Optional.of(StreamSupport.stream(channelGroups.spliterator(), false)
+                .map(ChannelGroup::toSummary)
+                .collect(MoreCollectors.toImmutableList()));
+
+    }
+
+    private Optional<Channel> resolveParentChannel(Channel channel) {
+
+        return Optional.of(Promise.wrap(channelResolver.resolveIds(
+                ImmutableList.of(channel.getParent().getId())))
+                .then(Resolved::getResources)
+                .then(FluentIterable::first)
+                .then(Optional::get)
+                .get(1, TimeUnit.MINUTES));
+    }
+
+    private Optional<Iterable<Channel>> resolveChannelVariations(Channel channel) {
+
+        Iterable<Id> ids = Iterables.transform(channel.getVariations(), ResourceRef::getId);
+
+        return Optional.of(Promise.wrap(channelResolver.resolveIds(ids))
+        .then(Resolved::getResources)
+        .get(1, TimeUnit.MINUTES));
+
     }
 
     private Ordering<? super Channel> ordering(String orderBy) {
@@ -187,5 +282,12 @@ public class ChannelQueryExecutor implements QueryExecutor<Channel> {
         }
 
         return ordering;
+    }
+
+    private boolean contextHasAnnotation(QueryContext ctxt, Annotation annotation) {
+
+        return (ctxt.getAnnotations().all().size() > 0)
+                &&
+                ctxt.getAnnotations().all().contains(annotation);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryResultWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryResultWriter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.EntityWriter;
 import org.atlasapi.output.OutputContext;
@@ -16,12 +17,12 @@ import com.google.common.collect.FluentIterable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelQueryResultWriter extends QueryResultWriter<Channel> {
+public class ChannelQueryResultWriter extends QueryResultWriter<ResolvedChannel> {
 
-    private final EntityListWriter<Channel> channelListWriter;
+    private final EntityListWriter<ResolvedChannel> channelListWriter;
 
     public ChannelQueryResultWriter(
-            EntityListWriter<Channel> channelListWriter,
+            EntityListWriter<ResolvedChannel> channelListWriter,
             EntityWriter<Object> licenseWriter,
             EntityWriter<HttpServletRequest> requestWriter
     ) {
@@ -30,13 +31,13 @@ public class ChannelQueryResultWriter extends QueryResultWriter<Channel> {
     }
 
     @Override
-    protected void writeResult(QueryResult<Channel> result, ResponseWriter writer)
+    protected void writeResult(QueryResult<ResolvedChannel> result, ResponseWriter writer)
             throws IOException {
 
         OutputContext ctxt = OutputContext.valueOf(result.getContext());
 
         if (result.isListResult()) {
-            FluentIterable<Channel> resources = result.getResources();
+            FluentIterable<ResolvedChannel> resources = result.getResources();
             writer.writeList(channelListWriter, resources, ctxt);
         } else {
             writer.writeObject(channelListWriter, result.getOnlyResource(), ctxt);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryResultWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryResultWriter.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.EntityWriter;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.atlasapi.annotation.Annotation;
+import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupSummary;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.media.entity.Publisher;
@@ -63,21 +64,24 @@ public class ChannelWriter implements EntityListWriter<ResolvedChannel> {
     @Override
     public void write(@Nonnull ResolvedChannel entity, @Nonnull FieldWriter format,
             @Nonnull OutputContext ctxt) throws IOException {
-        format.writeField("title", entity.getChannel().getTitle());
-        format.writeField("id", idCode.encode(entity.getChannel().getId().toBigInteger()));
-        format.writeField("uri", entity.getChannel().getCanonicalUri());
-        format.writeList(IMAGE_WRITER, entity.getChannel().getImages(), ctxt);
-        format.writeList(AVAILABLE_FROM_WRITER, entity.getChannel().getAvailableFrom(), ctxt);
-        format.writeObject(AVAILABLE_FROM_WRITER, entity.getChannel().getSource(), ctxt);
-        format.writeField("media_type", entity.getChannel().getMediaType());
-        format.writeObject(BROADCASTER_WRITER, entity.getChannel().getBroadcaster(), ctxt);
-        format.writeList(ALIAS_WRITER, entity.getChannel().getAliases(), ctxt);
-        format.writeList("genres", "genres", entity.getChannel().getGenres(), ctxt);
-        format.writeField("high_definition", entity.getChannel().getHighDefinition());
-        format.writeField("regional", entity.getChannel().getRegional());
-        format.writeList(RELATED_LINKS_WRITER, entity.getChannel().getRelatedLinks(), ctxt);
-        format.writeField("start_date", entity.getChannel().getStartDate());
-        format.writeField("advertised_from", entity.getChannel().getAdvertiseFrom());
+
+        Channel channel = entity.getChannel();
+
+        format.writeField("title", channel.getTitle());
+        format.writeField("id", idCode.encode(channel.getId().toBigInteger()));
+        format.writeField("uri", channel.getCanonicalUri());
+        format.writeList(IMAGE_WRITER, channel.getImages(), ctxt);
+        format.writeList(AVAILABLE_FROM_WRITER, channel.getAvailableFrom(), ctxt);
+        format.writeObject(AVAILABLE_FROM_WRITER, channel.getSource(), ctxt);
+        format.writeField("media_type", channel.getMediaType());
+        format.writeObject(BROADCASTER_WRITER, channel.getBroadcaster(), ctxt);
+        format.writeList(ALIAS_WRITER, channel.getAliases(), ctxt);
+        format.writeList("genres", "genres", channel.getGenres(), ctxt);
+        format.writeField("high_definition", channel.getHighDefinition());
+        format.writeField("regional", channel.getRegional());
+        format.writeList(RELATED_LINKS_WRITER, channel.getRelatedLinks(), ctxt);
+        format.writeField("start_date", channel.getStartDate());
+        format.writeField("advertised_from", channel.getAdvertiseFrom());
 
         if (hasChannelGroupSummaryAnnotation(ctxt)) {
 
@@ -89,9 +93,7 @@ public class ChannelWriter implements EntityListWriter<ResolvedChannel> {
             } else {
                 throw new MissingResolvedDataException(channelGroupSummaryWriter.listName());
             }
-
         }
-
     }
 
     @Nonnull

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
@@ -2,18 +2,12 @@ package org.atlasapi.query.v4.channel;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.StreamSupport;
 
 import javax.annotation.Nonnull;
 
 import org.atlasapi.annotation.Annotation;
-import org.atlasapi.channel.Channel;
-import org.atlasapi.channel.ChannelGroup;
-import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ChannelGroupSummary;
 import org.atlasapi.channel.ResolvedChannel;
-import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.ChannelGroupSummaryWriter;
 import org.atlasapi.output.EntityListWriter;
@@ -27,13 +21,10 @@ import org.atlasapi.query.common.MissingResolvedDataException;
 
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 
 import static org.atlasapi.output.writers.SourceWriter.sourceListWriter;
 import static org.atlasapi.output.writers.SourceWriter.sourceWriter;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelWriter.java
@@ -12,6 +12,7 @@ import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ChannelGroupSummary;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.ChannelGroupSummaryWriter;
@@ -22,12 +23,14 @@ import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.AliasWriter;
 import org.atlasapi.output.writers.ImageListWriter;
 import org.atlasapi.output.writers.RelatedLinkWriter;
+import org.atlasapi.query.common.MissingResolvedDataException;
 
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
@@ -36,7 +39,7 @@ import static org.atlasapi.output.writers.SourceWriter.sourceListWriter;
 import static org.atlasapi.output.writers.SourceWriter.sourceWriter;
 import static org.elasticsearch.common.base.Preconditions.checkNotNull;
 
-public class ChannelWriter implements EntityListWriter<Channel> {
+public class ChannelWriter implements EntityListWriter<ResolvedChannel> {
 
     private static final EntityListWriter<Publisher> AVAILABLE_FROM_WRITER = sourceListWriter(
             "available_from");
@@ -44,7 +47,6 @@ public class ChannelWriter implements EntityListWriter<Channel> {
     private static final AliasWriter ALIAS_WRITER = new AliasWriter();
     private static final ImageListWriter IMAGE_WRITER = new ImageListWriter();
     private static final RelatedLinkWriter RELATED_LINKS_WRITER = new RelatedLinkWriter();
-    private final ChannelGroupResolver channelGroupResolver;
 
     private final String listName;
     private final String fieldName;
@@ -52,12 +54,10 @@ public class ChannelWriter implements EntityListWriter<Channel> {
     private final ChannelGroupSummaryWriter channelGroupSummaryWriter;
 
     public ChannelWriter(
-            ChannelGroupResolver channelGroupResolver,
             String listName,
             String fieldName,
             ChannelGroupSummaryWriter channelGroupSummaryWriter
     ) {
-        this.channelGroupResolver = checkNotNull(channelGroupResolver);
         this.listName = checkNotNull(listName);
         this.fieldName = checkNotNull(fieldName);
         this.channelGroupSummaryWriter = checkNotNull(channelGroupSummaryWriter);
@@ -70,42 +70,34 @@ public class ChannelWriter implements EntityListWriter<Channel> {
     }
 
     @Override
-    public void write(@Nonnull Channel entity, @Nonnull FieldWriter format,
+    public void write(@Nonnull ResolvedChannel entity, @Nonnull FieldWriter format,
             @Nonnull OutputContext ctxt) throws IOException {
-        format.writeField("title", entity.getTitle());
-        format.writeField("id", idCode.encode(entity.getId().toBigInteger()));
-        format.writeField("uri", entity.getCanonicalUri());
-        format.writeList(IMAGE_WRITER, entity.getImages(), ctxt);
-        format.writeList(AVAILABLE_FROM_WRITER, entity.getAvailableFrom(), ctxt);
-        format.writeObject(AVAILABLE_FROM_WRITER, entity.getSource(), ctxt);
-        format.writeField("media_type", entity.getMediaType());
-        format.writeObject(BROADCASTER_WRITER, entity.getBroadcaster(), ctxt);
-        format.writeList(ALIAS_WRITER, entity.getAliases(), ctxt);
-        format.writeList("genres", "genres", entity.getGenres(), ctxt);
-        format.writeField("high_definition", entity.getHighDefinition());
-        format.writeField("regional", entity.getRegional());
-        format.writeList(RELATED_LINKS_WRITER, entity.getRelatedLinks(), ctxt);
-        format.writeField("start_date", entity.getStartDate());
-        format.writeField("advertised_from", entity.getAdvertiseFrom());
+        format.writeField("title", entity.getChannel().getTitle());
+        format.writeField("id", idCode.encode(entity.getChannel().getId().toBigInteger()));
+        format.writeField("uri", entity.getChannel().getCanonicalUri());
+        format.writeList(IMAGE_WRITER, entity.getChannel().getImages(), ctxt);
+        format.writeList(AVAILABLE_FROM_WRITER, entity.getChannel().getAvailableFrom(), ctxt);
+        format.writeObject(AVAILABLE_FROM_WRITER, entity.getChannel().getSource(), ctxt);
+        format.writeField("media_type", entity.getChannel().getMediaType());
+        format.writeObject(BROADCASTER_WRITER, entity.getChannel().getBroadcaster(), ctxt);
+        format.writeList(ALIAS_WRITER, entity.getChannel().getAliases(), ctxt);
+        format.writeList("genres", "genres", entity.getChannel().getGenres(), ctxt);
+        format.writeField("high_definition", entity.getChannel().getHighDefinition());
+        format.writeField("regional", entity.getChannel().getRegional());
+        format.writeList(RELATED_LINKS_WRITER, entity.getChannel().getRelatedLinks(), ctxt);
+        format.writeField("start_date", entity.getChannel().getStartDate());
+        format.writeField("advertised_from", entity.getChannel().getAdvertiseFrom());
 
         if (hasChannelGroupSummaryAnnotation(ctxt)) {
 
-            ImmutableList<Id> channelGroupIds = entity.getChannelGroups()
-                    .stream()
-                    .map(cg -> cg.getChannelGroup().getId())
-                    .collect(MoreCollectors.toImmutableList());
+            Optional<List<ChannelGroupSummary>> channelGroupSummaries =
+                    entity.getChannelGroupSummaries();
 
-            List<ChannelGroupSummary> channelGroupSummaries = StreamSupport.stream(
-                    Futures.get(
-                            channelGroupResolver.resolveIds(channelGroupIds),
-                            1, TimeUnit.MINUTES,
-                            IOException.class
-                    ).getResources().spliterator(), false
-            )
-                    .map(ChannelGroup::toSummary)
-                    .collect(MoreCollectors.toImmutableList());
-
-            format.writeList(channelGroupSummaryWriter, channelGroupSummaries, ctxt);
+            if(channelGroupSummaries.isPresent()) {
+                format.writeList(channelGroupSummaryWriter, channelGroupSummaries.get(), ctxt);
+            } else {
+                throw new MissingResolvedDataException(channelGroupSummaryWriter.listName());
+            }
 
         }
 
@@ -113,7 +105,7 @@ public class ChannelWriter implements EntityListWriter<Channel> {
 
     @Nonnull
     @Override
-    public String fieldName(Channel entity) {
+    public String fieldName(ResolvedChannel entity) {
         return fieldName;
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ChannelNumbering;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.ChannelWithChannelGroupMembership;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.FieldWriter;
@@ -35,7 +36,11 @@ public class ChannelGroupChannelWriter
         Channel channel = entity.getChannel();
         ChannelGroupMembership channelGroupMembership = entity.getChannelGroupMembership();
 
-        format.writeObject(channelWriter, "channel", channel, ctxt);
+        ResolvedChannel resolvedChannel = ResolvedChannel.builder(channel).build();
+        // Forced casting to resolvedChannel because of how writer works atm
+
+        format.writeObject(channelWriter, "channel", resolvedChannel, ctxt);
+
         if (channelGroupMembership instanceof ChannelNumbering) {
             ChannelNumbering channelNumbering = ((ChannelNumbering) channelGroupMembership);
             format.writeField("channel_number", channelNumbering.getChannelNumber().orElse(null));

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
@@ -36,8 +36,8 @@ public class ChannelGroupChannelWriter
         Channel channel = entity.getChannel();
         ChannelGroupMembership channelGroupMembership = entity.getChannelGroupMembership();
 
+        // Forced wrapping in a ResolvedChannel because of how the writer currently works.
         ResolvedChannel resolvedChannel = ResolvedChannel.builder(channel).build();
-        // Forced casting to resolvedChannel because of how writer works atm
 
         format.writeObject(channelWriter, "channel", resolvedChannel, ctxt);
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupController.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupController.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.meta.annotations.ProducesType;
 import org.atlasapi.output.ErrorResultWriter;
 import org.atlasapi.output.ErrorSummary;
@@ -29,17 +30,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @ProducesType(type = ChannelGroup.class)
 public class ChannelGroupController {
 
-    private final QueryParser<ChannelGroup<?>> requestParser;
-    private final QueryExecutor<ChannelGroup<?>> queryExecutor;
-    private final QueryResultWriter<ChannelGroup<?>> resultWriter;
+    private final QueryParser<ResolvedChannelGroup> requestParser;
+    private final QueryExecutor<ResolvedChannelGroup> queryExecutor;
+    private final QueryResultWriter<ResolvedChannelGroup> resultWriter;
     private final ResponseWriterFactory writerResolver = new ResponseWriterFactory();
 
     private static Logger log = LoggerFactory.getLogger(ChannelGroupController.class);
 
     public ChannelGroupController(
-            QueryParser<ChannelGroup<?>> requestParser,
-            QueryExecutor<ChannelGroup<?>> queryExecutor,
-            QueryResultWriter<ChannelGroup<?>> resultWriter
+            QueryParser<ResolvedChannelGroup> requestParser,
+            QueryExecutor<ResolvedChannelGroup> queryExecutor,
+            QueryResultWriter<ResolvedChannelGroup> resultWriter
     ) {
         this.requestParser = checkNotNull(requestParser);
         this.queryExecutor = checkNotNull(queryExecutor);
@@ -52,8 +53,8 @@ public class ChannelGroupController {
         ResponseWriter writer = null;
         try {
             writer = writerResolver.writerFor(request, response);
-            Query<ChannelGroup<?>> channelGroupQuery = requestParser.parse(request);
-            QueryResult<ChannelGroup<?>> queryResult = queryExecutor.execute(channelGroupQuery);
+            Query<ResolvedChannelGroup> channelGroupQuery = requestParser.parse(request);
+            QueryResult<ResolvedChannelGroup> queryResult = queryExecutor.execute(channelGroupQuery);
             resultWriter.write(queryResult, writer);
         } catch (Exception e) {
             log.error("Request exception " + request.getRequestURI(), e);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupListWriter.java
@@ -15,7 +15,7 @@ import org.atlasapi.query.common.Resource;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupListWriter implements EntityListWriter<ResolvedChannelGroup> { //new writer implement EntityWriter
+public class ChannelGroupListWriter implements EntityListWriter<ResolvedChannelGroup> {
 
     private final AnnotationRegistry<ResolvedChannelGroup> annotationRegistry;
 
@@ -30,8 +30,8 @@ public class ChannelGroupListWriter implements EntityListWriter<ResolvedChannelG
     }
 
     @Override
-    public void write(@Nonnull ResolvedChannelGroup entity, @Nonnull FieldWriter writer,
-            @Nonnull OutputContext ctxt) throws IOException {
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
+            throws IOException {
         ctxt.startResource(Resource.CHANNEL_GROUP);
         List<OutputAnnotation<? super ResolvedChannelGroup>> annotations = ctxt
                 .getAnnotations(annotationRegistry);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupListWriter.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.AnnotationRegistry;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.FieldWriter;
@@ -15,11 +15,11 @@ import org.atlasapi.query.common.Resource;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupListWriter implements EntityListWriter<ChannelGroup<?>> {
+public class ChannelGroupListWriter implements EntityListWriter<ResolvedChannelGroup> { //new writer implement EntityWriter
 
-    private final AnnotationRegistry<ChannelGroup<?>> annotationRegistry;
+    private final AnnotationRegistry<ResolvedChannelGroup> annotationRegistry;
 
-    public ChannelGroupListWriter(AnnotationRegistry<ChannelGroup<?>> annotationRegistry) {
+    public ChannelGroupListWriter(AnnotationRegistry<ResolvedChannelGroup> annotationRegistry) {
         this.annotationRegistry = checkNotNull(annotationRegistry);
     }
 
@@ -30,12 +30,12 @@ public class ChannelGroupListWriter implements EntityListWriter<ChannelGroup<?>>
     }
 
     @Override
-    public void write(@Nonnull ChannelGroup<?> entity, @Nonnull FieldWriter writer,
+    public void write(@Nonnull ResolvedChannelGroup entity, @Nonnull FieldWriter writer,
             @Nonnull OutputContext ctxt) throws IOException {
         ctxt.startResource(Resource.CHANNEL_GROUP);
-        List<OutputAnnotation<? super ChannelGroup<?>>> annotations = ctxt
+        List<OutputAnnotation<? super ResolvedChannelGroup>> annotations = ctxt
                 .getAnnotations(annotationRegistry);
-        for (OutputAnnotation<? super ChannelGroup<?>> annotation : annotations) {
+        for (OutputAnnotation<? super ResolvedChannelGroup> annotation : annotations) {
             annotation.write(entity, writer, ctxt);
         }
         ctxt.endResource();
@@ -43,7 +43,7 @@ public class ChannelGroupListWriter implements EntityListWriter<ChannelGroup<?>>
 
     @Nonnull
     @Override
-    public String fieldName(ChannelGroup entity) {
+    public String fieldName(ResolvedChannelGroup entity) {
         return "channel_group";
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -1,6 +1,7 @@
 package org.atlasapi.query.v4.channelgroup;
 
-import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -8,15 +9,20 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 
 import org.atlasapi.annotation.Annotation;
+import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.Region;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.channel.Platform;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.output.ChannelWithChannelGroupMembership;
 import org.atlasapi.output.NotFoundException;
 import org.atlasapi.query.common.Query;
 import org.atlasapi.query.common.QueryContext;
@@ -28,18 +34,28 @@ import org.atlasapi.query.common.UncheckedQueryExecutionException;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.promise.Promise;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
+import org.joda.time.LocalDate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelGroup> {
 
-    private final ChannelGroupResolver resolver;
+    private final ChannelGroupResolver channelGroupResolver;
+    private final ChannelResolver channelResolver;
 
-    public ChannelGroupQueryExecutor(ChannelGroupResolver resolver) {
-        this.resolver = checkNotNull(resolver);
+    public ChannelGroupQueryExecutor(ChannelGroupResolver channelGroupResolver, ChannelResolver channelResolver) {
+        this.channelGroupResolver = checkNotNull(channelGroupResolver);
+        this.channelResolver = channelResolver;
     }
 
     @Nonnull
@@ -53,7 +69,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
             throws QueryExecutionException {
         return Futures.get(
                 Futures.transform(
-                        resolver.resolveIds(ImmutableSet.of(query.getOnlyId())),
+                        channelGroupResolver.resolveIds(ImmutableSet.of(query.getOnlyId())),
                         (Resolved<ChannelGroup<?>> input) -> {
                             if (input.getResources().isEmpty()) {
                                 throw new UncheckedQueryExecutionException(new NotFoundException(
@@ -79,7 +95,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
             throws QueryExecutionException {
         Iterable<ChannelGroup<?>> channelGroups = Futures.get(
                 Futures.transform(
-                        resolver.allChannels(),
+                        channelGroupResolver.allChannels(),
                         (Resolved<ChannelGroup<?>> input) -> {
                             return input.getResources();
                         }
@@ -137,18 +153,30 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                 ResolvedChannelGroup.builder(channelGroup);
 
         if (contextHasAnnotation(ctxt, Annotation.REGIONS)) {
-            resolvedChannelGroupBuilder.withRegionChannelGroup(
+            resolvedChannelGroupBuilder.withRegionChannelGroups(
                     resolveRegionChannelGroups(channelGroup)
+            );
+        }
+
+        if(contextHasAnnotation(ctxt, Annotation.PLATFORM)) {
+            resolvedChannelGroupBuilder.withPlatformChannelGroup(
+                    resolvePlatformChannelGroup(channelGroup)
+            );
+        }
+
+        if(contextHasAnnotation(ctxt, Annotation.ADVERTISED_CHANNELS)) {
+            resolvedChannelGroupBuilder.withAdvertisedChannels(
+                    resolveAdvertisedChannels(ctxt, channelGroup)
             );
         }
 
         return resolvedChannelGroupBuilder.build();
     }
 
-    private Optional<Iterable<ChannelGroup<?>>> resolveRegionChannelGroups(ChannelGroup entity) {
+    private Optional<Iterable<ChannelGroup<?>>> resolveRegionChannelGroups(ChannelGroup<?> entity) {
 
         if(!(entity instanceof  Platform)) {
-            return Optional.empty();
+            return Optional.absent();
         }
 
         Platform platform = (Platform) entity;
@@ -157,9 +185,81 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                 .map(ChannelGroupRef::getId)
                 .collect(MoreCollectors.toImmutableSet());
 
-        return Optional.of(Promise.wrap(resolver.resolveIds(regionIds))
+        return Optional.of(Promise.wrap(channelGroupResolver.resolveIds(regionIds))
                 .then(Resolved::getResources)
                 .get(1, TimeUnit.MINUTES));
+    }
+
+    private Optional<ChannelGroup<?>> resolvePlatformChannelGroup(ChannelGroup<?> entity) {
+        if(!(entity instanceof Region)) {
+            return Optional.absent();
+        }
+
+        Id platformId = ((Region) entity).getPlatform().getId();
+
+        return Promise.wrap(channelGroupResolver.resolveIds(ImmutableSet.of(platformId)))
+                .then(Resolved::getResources)
+                .get(1, TimeUnit.MINUTES)
+                .first();
+    }
+
+    private Optional<ImmutableSet<ChannelWithChannelGroupMembership>> resolveAdvertisedChannels(
+            QueryContext ctxt, ChannelGroup<?> entity
+    ) {
+
+        final ImmutableMultimap.Builder<Id, ChannelGroupMembership> builder = ImmutableMultimap.builder();
+
+        Iterable<? extends ChannelGroupMembership> availableChannels = entity.getChannelsAvailable(
+                LocalDate.now());
+
+        List<Id> orderedIds = StreamSupport.stream(availableChannels.spliterator(), false)
+                //TODO fix channel appearing twice in ordering blowing this thing up
+                .map(cm -> cm.getChannel().getId())
+                .distinct()
+                .collect(Collectors.toList());
+        Ordering<Id> idOrdering = Ordering.explicit(orderedIds);
+
+        for (ChannelGroupMembership channelGroupMembership : availableChannels) {
+            builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
+        }
+
+        ImmutableMultimap<Id, ChannelGroupMembership> channelGroupMemberships = builder.build();
+
+        Iterable<Channel> resolvedChannels = Promise.wrap(
+                channelResolver.resolveIds(channelGroupMemberships.keySet()))
+                .then(Resolved::getResources)
+                .get(1, TimeUnit.MINUTES);
+
+        Iterable<Channel> filteredChannels = StreamSupport.stream(resolvedChannels.spliterator(), false)
+                .filter(channel -> channel.getAdvertiseFrom()
+                        .isBeforeNow() || channel.getAdvertiseFrom()
+                        .isEqualNow())
+                .sorted((o1, o2) -> idOrdering.compare(o1.getId(), o2.getId()))
+                .collect(Collectors.toList());
+
+        String genre = ctxt.getRequest()
+                .getParameter(Attributes.CHANNEL_GROUP_CHANNEL_GENRES.externalName());
+
+        if (!Strings.isNullOrEmpty(genre)) {
+            final ImmutableSet<String> genres = ImmutableSet.copyOf(Splitter.on(',').split(genre));
+            filteredChannels = Iterables.filter(filteredChannels,
+                    input -> !Sets.intersection(input.getGenres(), genres).isEmpty()
+            );
+        }
+        ImmutableSet.Builder<ChannelWithChannelGroupMembership> resultBuilder = ImmutableSet.builder();
+
+        for (Channel channel : filteredChannels) {
+            for (ChannelGroupMembership channelGroupMembership : channelGroupMemberships.get(channel
+                    .getId())) {
+                resultBuilder.add(
+                        new ChannelWithChannelGroupMembership(
+                                channel,
+                                channelGroupMembership
+                        )
+                );
+            }
+        }
+        return Optional.of(resultBuilder.build());
     }
 
     private boolean contextHasAnnotation(QueryContext ctxt, Annotation annotation) {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -159,7 +159,8 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         );
 
         resolvedChannelGroupBuilder.withAdvertisedChannels(
-                contextHasAnnotation(ctxt, Annotation.ADVERTISED_CHANNELS) ?
+                contextHasAnnotation(ctxt, Annotation.ADVERTISED_CHANNELS) ||
+                contextHasAnnotation(ctxt, Annotation.CHANNELS) ?
                     resolveAdvertisedChannels(channelGroup) :
                     Optional.absent()
         );

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -1,21 +1,34 @@
 package org.atlasapi.query.v4.channelgroup;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ResolvedChannelGroup;
+import org.atlasapi.channel.Platform;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
+import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.NotFoundException;
 import org.atlasapi.query.common.Query;
+import org.atlasapi.query.common.QueryContext;
 import org.atlasapi.query.common.QueryExecutionException;
 import org.atlasapi.query.common.QueryExecutor;
 import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.query.common.UncheckedQueryExecutionException;
 
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -23,7 +36,7 @@ import com.google.common.util.concurrent.Futures;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupQueryExecutor implements QueryExecutor<ChannelGroup<?>> {
+public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelGroup> {
 
     private final ChannelGroupResolver resolver;
 
@@ -33,12 +46,12 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ChannelGroup<?>>
 
     @Nonnull
     @Override
-    public QueryResult<ChannelGroup<?>> execute(@Nonnull Query<ChannelGroup<?>> query)
+    public QueryResult<ResolvedChannelGroup> execute(@Nonnull Query<ResolvedChannelGroup> query)  //resolvedchannelgroup
             throws QueryExecutionException {
         return query.isListQuery() ? executeListQuery(query) : executeSingleQuery(query);
     }
 
-    private QueryResult<ChannelGroup<?>> executeSingleQuery(final Query<ChannelGroup<?>> query)
+    private QueryResult<ResolvedChannelGroup> executeSingleQuery(final Query<ResolvedChannelGroup> query)
             throws QueryExecutionException {
         return Futures.get(
                 Futures.transform(
@@ -48,16 +61,23 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ChannelGroup<?>>
                                 throw new UncheckedQueryExecutionException(new NotFoundException(
                                         query.getOnlyId()));
                             }
+
+                            ResolvedChannelGroup resolvedChannelGroup =
+                                    resolveAnnotationData(
+                                            query.getContext(),
+                                            input.getResources().first().get()
+                                    );
+
                             return QueryResult.singleResult(
-                                    input.getResources().first().get(),
+                                    resolvedChannelGroup,
                                     query.getContext()
                             );
                         }
                 ), 1, TimeUnit.MINUTES, QueryExecutionException.class
-        );
+        );                                                                              // MESS THIS UP
     }
 
-    private QueryResult<ChannelGroup<?>> executeListQuery(final Query<ChannelGroup<?>> query)
+    private QueryResult<ResolvedChannelGroup> executeListQuery(final Query<ResolvedChannelGroup> query)
             throws QueryExecutionException {
         Iterable<ChannelGroup<?>> channelGroups = Futures.get(
                 Futures.transform(
@@ -91,12 +111,81 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ChannelGroup<?>>
                             .isReadEnabled(input.getSource());
                 }
         ));
+
+        ImmutableList<ChannelGroup<?>> selectedChannelGroups =
+                query.getContext()
+                        .getSelection()
+                        .get()
+                        .applyTo(filteredChannelGroups);
+
+        ImmutableList<ResolvedChannelGroup> resolvedChannelGroups =
+                selectedChannelGroups.stream()
+                        .map(channelGroup ->
+                                resolveAnnotationData(query.getContext(), channelGroup)
+                        )
+                        .collect(MoreCollectors.toImmutableList());
+
+
         return QueryResult.listResult(
-                query.getContext().getSelection().get().applyTo(
-                        filteredChannelGroups
-                ),
+                resolvedChannelGroups,
                 query.getContext(),
-                filteredChannelGroups.size()
+                resolvedChannelGroups.size()
         );
+    }
+
+    private ResolvedChannelGroup resolveAnnotationData(
+            QueryContext ctxt,
+            ChannelGroup<?> channelGroup
+    ) {
+        ResolvedChannelGroup resolvedChannelGroup =
+                ResolvedChannelGroup.create(channelGroup);
+
+        if (contextHasAnnotation(ctxt, Annotation.REGIONS)) {
+            resolvedChannelGroup.setRegions(
+                    resolveRegionChannelGroups(channelGroup)
+            );
+        }
+
+        return resolvedChannelGroup;
+    }
+
+    private Iterable<ChannelGroup<?>> resolveRegionChannelGroups(ChannelGroup entity) {
+
+        try {
+            if (entity instanceof Platform){
+                Platform platform = (Platform) entity;
+                Iterable<Id> regionIds = Iterables.transform(
+                        platform.getRegions(),
+                        new Function<ChannelGroupRef, Id>() {
+
+                            @Override
+                            public Id apply(ChannelGroupRef input) {
+                                return input.getId();
+                            }
+                        }
+                );
+
+                return Futures.get(
+                        Futures.transform(
+                                resolver.resolveIds(regionIds),
+                                (Resolved<ChannelGroup<?>> input) -> {
+                                    return input.getResources();
+                                }
+                        ), 1, TimeUnit.MINUTES, IOException.class
+                );
+            }
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
+        return null;
+    }
+
+    private boolean contextHasAnnotation(QueryContext ctxt, Annotation annotation) {
+        return !Strings.isNullOrEmpty(ctxt.getRequest().getParameter("annotations"))
+            &&
+            Splitter.on(',')
+                    .splitToList(
+                            ctxt.getRequest().getParameter("annotations")
+                    ).contains(annotation.toKey());
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryResultWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryResultWriter.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.EntityWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.QueryResultWriter;
@@ -16,7 +16,7 @@ import com.google.common.collect.FluentIterable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ChannelGroupQueryResultWriter extends QueryResultWriter<ChannelGroup<?>> {
+public class ChannelGroupQueryResultWriter extends QueryResultWriter<ResolvedChannelGroup> {
 
     private final ChannelGroupListWriter channelGroupListWriter;
 
@@ -30,12 +30,12 @@ public class ChannelGroupQueryResultWriter extends QueryResultWriter<ChannelGrou
     }
 
     @Override
-    protected void writeResult(QueryResult<ChannelGroup<?>> result, ResponseWriter writer)
+    protected void writeResult(QueryResult<ResolvedChannelGroup> result, ResponseWriter writer)
             throws IOException {
         OutputContext ctxt = outputContext(result.getContext());
 
         if (result.isListResult()) {
-            FluentIterable<ChannelGroup<?>> resources = result.getResources();
+            FluentIterable<ResolvedChannelGroup> resources = result.getResources();
             writer.writeList(channelGroupListWriter, resources, ctxt);
         } else {
             writer.writeObject(channelGroupListWriter, result.getOnlyResource(), ctxt);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
@@ -3,7 +3,9 @@ package org.atlasapi.query.v4.schedule;
 import java.io.IOException;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.ItemAndBroadcast;
+import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.EntityWriter;
 import org.atlasapi.output.FieldWriter;
@@ -12,10 +14,10 @@ import org.atlasapi.schedule.ChannelSchedule;
 
 public class ScheduleListWriter implements EntityListWriter<ChannelSchedule> {
 
-    private final EntityWriter<Channel> channelWriter;
+    private final EntityWriter<ResolvedChannel> channelWriter;
     private final EntityListWriter<ItemAndBroadcast> entryWriter;
 
-    public ScheduleListWriter(EntityWriter<Channel> channelWriter,
+    public ScheduleListWriter(EntityWriter<ResolvedChannel> channelWriter,
             EntityListWriter<ItemAndBroadcast> contentWriter) {
         this.channelWriter = channelWriter;
         this.entryWriter = contentWriter;
@@ -24,7 +26,8 @@ public class ScheduleListWriter implements EntityListWriter<ChannelSchedule> {
     @Override
     public void write(ChannelSchedule entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        writer.writeObject(channelWriter, entity.getChannel(), ctxt);
+        ResolvedChannel resolvedChannel = ResolvedChannel.builder(entity.getChannel()).build();
+        writer.writeObject(channelWriter, resolvedChannel, ctxt);
         writer.writeList(entryWriter, entity.getEntries(), ctxt);
     }
 

--- a/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
@@ -38,7 +38,7 @@ public class AnnotationRegistryTest {
 
     private final NumberToShortStringCodec idCodec = SubstitutionTableNumberCodec.lowerCaseOnly();
     private final IdentificationSummaryAnnotation idSum = new IdentificationSummaryAnnotation(
-            idCodec);
+    );
     private final IdentificationAnnotation ident = new IdentificationAnnotation();
     private final ExtendedIdentificationAnnotation extIdent = new ExtendedIdentificationAnnotation(
             idCodec);

--- a/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
@@ -13,6 +13,7 @@ import org.atlasapi.output.annotation.IdentificationSummaryAnnotation;
 import org.atlasapi.output.annotation.OutputAnnotation;
 import org.atlasapi.output.annotation.SeriesReferenceAnnotation;
 import org.atlasapi.output.writers.ContainerSummaryWriter;
+import org.atlasapi.output.writers.IdSummaryWriter;
 
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
@@ -37,7 +38,8 @@ import static org.mockito.Mockito.mock;
 public class AnnotationRegistryTest {
 
     private final NumberToShortStringCodec idCodec = SubstitutionTableNumberCodec.lowerCaseOnly();
-    private final IdentificationSummaryAnnotation idSum = new IdentificationSummaryAnnotation(
+    private final IdentificationSummaryAnnotation idSum = IdentificationSummaryAnnotation.create(
+            IdSummaryWriter.create()
     );
     private final IdentificationAnnotation ident = new IdentificationAnnotation();
     private final ExtendedIdentificationAnnotation extIdent = new ExtendedIdentificationAnnotation(

--- a/atlas-api/src/test/java/org/atlasapi/output/writers/BroadcastWriterTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/writers/BroadcastWriterTest.java
@@ -39,7 +39,7 @@ public class BroadcastWriterTest {
     @Before
     public void setUp() throws Exception {
         broadcastWriter = BroadcastWriter.create(
-                "list", codec, channelResolver, channelGroupResolver
+                "list", codec, channelResolver
         );
 
         when(channelResolver.resolveIds(anyCollectionOf(Id.class)))

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
@@ -4,7 +4,12 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.application.ApplicationSources;
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelGroupSummary;
+import org.atlasapi.channel.ChannelRef;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
@@ -25,6 +30,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
+import org.bouncycastle.util.Iterable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -112,6 +118,140 @@ public class ChannelQueryExecutorTest {
                 .collect(MoreCollectors.toImmutableList());
 
         assertThat(channels, containsInAnyOrder(result, result2));
+    }
+
+    @Test
+    public void testSingleChannelIsFullyResolvedByAnnotations() throws Exception {
+        Channel result = mock(Channel.class);
+        Channel parent = mock(Channel.class);
+        ChannelRef parentRef = mock(ChannelRef.class);
+
+        QueryContext context = mock(QueryContext.class);
+        Query<ResolvedChannel> channelQuery = mock(Query.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        Id channelId = Id.valueOf(1L);
+        Id parentId = Id.valueOf(2L);
+
+        when(request.getParameter("annotations")).thenReturn("parent");
+        when(context.getRequest()).thenReturn(request);
+
+        when(parentRef.getId()).thenReturn(parentId);
+        when(result.getParent()).thenReturn(parentRef);
+
+        when(channelQuery.isListQuery()).thenReturn(false);
+        when(channelQuery.getOnlyId()).thenReturn(channelId);
+        when(channelQuery.getContext()).thenReturn(context);
+
+        when(channelResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(channelId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(result))
+                        )
+                );
+
+        when(channelResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(parentId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(parent))
+                        )
+                );
+
+        QueryResult<ResolvedChannel> queryResult = objectUnderTest.execute(channelQuery);
+
+        assertThat(queryResult.getOnlyResource().getChannel(), is(result));
+        assert(queryResult.getOnlyResource().getParentChannel().isPresent());
+        assertThat(queryResult.getOnlyResource().getChannelGroupSummaries(), is(Optional.absent()));
+        assertThat(queryResult.getOnlyResource().getChannelVariations(), is(Optional.absent()));
+        assertThat(queryResult.getOnlyResource().getParentChannel().get(), is(parent));
+    }
+
+    @Test
+    public void testMultipleChannelsAreFullyResolvedByAnnotations() throws Exception {
+        Channel result = mock(Channel.class);
+        Channel result2 = mock(Channel.class);
+        ChannelGroupMembership channelGroupMembership = mock(ChannelGroupMembership.class);
+        ChannelGroup<?> channelGroup = mock(ChannelGroup.class);
+        ChannelGroupRef channelGroupRef = mock(ChannelGroupRef.class);
+        ChannelGroupSummary channelGroupSummary = mock(ChannelGroupSummary.class);
+        ChannelRef channelRef = mock(ChannelRef.class);
+
+        Id channelGroupId = Id.valueOf(5L);
+        Id variationId = Id.valueOf(10L);
+
+        QueryContext context = mock(QueryContext.class);
+        Query<ResolvedChannel> channelQuery = mock(Query.class);
+
+        ApplicationSources applicationSources = mock(ApplicationSources.class);
+        Selection selection = Selection.ALL;
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getParameter("annotations")).thenReturn("variations,channel_groups_summary");
+        when(context.getRequest()).thenReturn(request);
+
+        when(applicationSources.isReadEnabled(any(Publisher.class))).thenReturn(true);
+        when(context.getApplicationSources()).thenReturn(applicationSources);
+
+        when(context.getSelection()).thenReturn(Optional.of(selection));
+
+        when(channelGroupRef.getId()).thenReturn(channelGroupId);
+        when(channelGroupMembership.getChannelGroup()).thenReturn(channelGroupRef);
+
+        when(channelRef.getId()).thenReturn(variationId);
+        when(result.getVariations()).thenReturn(ImmutableSet.of(channelRef));
+        when(result2.getVariations()).thenReturn(ImmutableSet.of(channelRef));
+
+        when(channelGroup.toSummary()).thenReturn(channelGroupSummary);
+
+        when(result.getChannelGroups())
+                .thenReturn(ImmutableSet.of(channelGroupMembership));
+        when(result2.getChannelGroups())
+                .thenReturn(ImmutableSet.of(channelGroupMembership));
+
+        when(channelQuery.isListQuery()).thenReturn(true);
+        when(channelQuery.getContext()).thenReturn(context);
+        when(channelQuery.getOperands()).thenReturn(
+                new AttributeQuerySet(Sets.<AttributeQuery<Object>>newHashSet())
+        );
+
+        when(channelResolver.resolveChannels(any(ChannelQuery.class)))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(result, result2))
+                        )
+                );
+
+        when(channelGroupResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(channelGroupId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableList.of(channelGroup))
+                        )
+                );
+
+        when(channelResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(variationId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableList.of(result))
+                        )
+                );
+
+        QueryResult<ResolvedChannel> queryResult = objectUnderTest.execute(channelQuery);
+
+        ImmutableList<Channel> channels = queryResult.getResources().toList().stream()
+                .map(ResolvedChannel::getChannel)
+                .collect(MoreCollectors.toImmutableList());
+
+        assertThat(channels, containsInAnyOrder(result, result2));
+
+        ImmutableList<ResolvedChannel> resolvedChannels = queryResult.getResources().toList();
+
+        for(ResolvedChannel resolvedChannel : resolvedChannels) {
+            assertThat(resolvedChannel.getParentChannel(), is(Optional.absent()));
+            assert(resolvedChannel.getChannelGroupSummaries().isPresent());
+            assert(resolvedChannel.getChannelVariations().isPresent());
+
+            assert(resolvedChannel.getChannelGroupSummaries().get().contains(channelGroupSummary));
+        }
     }
 
 }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
@@ -1,10 +1,10 @@
 package org.atlasapi.query.v4.channel;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.application.ApplicationSources;
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
@@ -22,7 +22,6 @@ import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.api.client.util.Sets;
 import com.google.common.base.Optional;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
@@ -46,6 +45,9 @@ public class ChannelQueryExecutorTest {
     @Mock
     private ChannelResolver channelResolver;
 
+    @Mock
+    private ChannelGroupResolver channelGroupResolver;
+
     @InjectMocks
     private ChannelQueryExecutor objectUnderTest;
 
@@ -55,6 +57,9 @@ public class ChannelQueryExecutorTest {
         Channel result = mock(Channel.class);
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannel> channelQuery = mock(Query.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("annotations")).thenReturn("banana");
+        when(context.getRequest()).thenReturn(request);
         when(channelQuery.isListQuery()).thenReturn(false);
         when(channelQuery.getOnlyId()).thenReturn(channelId);
         when(channelQuery.getContext()).thenReturn(context);
@@ -79,6 +84,9 @@ public class ChannelQueryExecutorTest {
         Query<ResolvedChannel> channelQuery = mock(Query.class);
         ApplicationSources applicationSources = mock(ApplicationSources.class);
         Selection selection = Selection.ALL;
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("annotations")).thenReturn("banana");
+        when(context.getRequest()).thenReturn(request);
 
         when(applicationSources.isReadEnabled(any(Publisher.class))).thenReturn(true);
         when(context.getApplicationSources()).thenReturn(applicationSources);

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
@@ -1,8 +1,12 @@
 package org.atlasapi.query.v4.channel;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.atlasapi.application.ApplicationSources;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.AttributeQuerySet;
 import org.atlasapi.entity.Id;
@@ -14,9 +18,12 @@ import org.atlasapi.query.common.QueryContext;
 import org.atlasapi.query.common.QueryResult;
 
 import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.api.client.util.Sets;
 import com.google.common.base.Optional;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import org.junit.Test;
@@ -47,7 +54,7 @@ public class ChannelQueryExecutorTest {
         Id channelId = Id.valueOf(1L);
         Channel result = mock(Channel.class);
         QueryContext context = mock(QueryContext.class);
-        Query<Channel> channelQuery = mock(Query.class);
+        Query<ResolvedChannel> channelQuery = mock(Query.class);
         when(channelQuery.isListQuery()).thenReturn(false);
         when(channelQuery.getOnlyId()).thenReturn(channelId);
         when(channelQuery.getContext()).thenReturn(context);
@@ -58,9 +65,9 @@ public class ChannelQueryExecutorTest {
                         )
                 );
 
-        QueryResult<Channel> queryResult = objectUnderTest.execute(channelQuery);
+        QueryResult<ResolvedChannel> queryResult = objectUnderTest.execute(channelQuery);
 
-        assertThat(queryResult.getOnlyResource(), is(result));
+        assertThat(queryResult.getOnlyResource().getChannel(), is(result));
 
     }
 
@@ -69,7 +76,7 @@ public class ChannelQueryExecutorTest {
         Channel result = mock(Channel.class);
         Channel result2 = mock(Channel.class);
         QueryContext context = mock(QueryContext.class);
-        Query<Channel> channelQuery = mock(Query.class);
+        Query<ResolvedChannel> channelQuery = mock(Query.class);
         ApplicationSources applicationSources = mock(ApplicationSources.class);
         Selection selection = Selection.ALL;
 
@@ -90,9 +97,13 @@ public class ChannelQueryExecutorTest {
                         )
                 );
 
-        QueryResult<Channel> queryResult = objectUnderTest.execute(channelQuery);
+        QueryResult<ResolvedChannel> queryResult = objectUnderTest.execute(channelQuery);
 
-        assertThat(queryResult.getResources(), containsInAnyOrder(result, result2));
+        ImmutableList<Channel> channels = queryResult.getResources().toList().stream()
+                .map(ResolvedChannel::getChannel)
+                .collect(MoreCollectors.toImmutableList());
+
+        assertThat(channels, containsInAnyOrder(result, result2));
     }
 
 }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -1,8 +1,18 @@
 package org.atlasapi.query.v4.channelgroup;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.atlasapi.application.ApplicationSources;
+import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.Platform;
+import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.AttributeQuerySet;
 import org.atlasapi.criteria.attribute.Attribute;
@@ -16,6 +26,7 @@ import org.atlasapi.query.common.QueryResult;
 import com.metabroadcast.common.query.Selection;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -48,7 +59,7 @@ public class ChannelGroupQueryExecutorTest {
         Id channelGroupId = Id.valueOf(1L);
         ChannelGroup result = mock(ChannelGroup.class);
         QueryContext context = mock(QueryContext.class);
-        Query<ChannelGroup<?>> channelQuery = mock(Query.class);
+        Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
         when(channelQuery.isListQuery()).thenReturn(false);
         when(channelQuery.getOnlyId()).thenReturn(channelGroupId);
         when(channelQuery.getContext()).thenReturn(context);
@@ -60,9 +71,9 @@ public class ChannelGroupQueryExecutorTest {
                         )
                 );
 
-        QueryResult<ChannelGroup<?>> queryResult = objectUnderTest.execute(channelQuery);
+        QueryResult<ResolvedChannelGroup> queryResult = objectUnderTest.execute(channelQuery);
 
-        assertThat(queryResult.getOnlyResource(), is(result));
+        assertThat(queryResult.getOnlyResource().getChannelGroup(), is(result));
 
     }
 
@@ -77,20 +88,26 @@ public class ChannelGroupQueryExecutorTest {
         when(result3.getType()).thenReturn("platform");
 
         QueryContext context = mock(QueryContext.class);
-        Query<ChannelGroup<?>> channelQuery = mock(Query.class);
+        Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
         ApplicationSources applicationSources = mock(ApplicationSources.class);
         Selection selection = Selection.ALL;
+        HttpServletRequest request = mock(HttpServletRequest.class);
 
         when(applicationSources.isReadEnabled(any(Publisher.class))).thenReturn(true);
-        when(context.getApplicationSources()).thenReturn(applicationSources);
 
+        when(context.getApplicationSources()).thenReturn(applicationSources);
         when(context.getSelection()).thenReturn(Optional.of(selection));
+        when(context.getRequest()).thenReturn(request);
+
+        when(request.getParameter("annotations")).thenReturn("regions");
 
         when(channelQuery.isListQuery()).thenReturn(true);
         when(channelQuery.getContext()).thenReturn(context);
+
         AttributeQuery attributeQuery = mock(AttributeQuery.class);
         when(attributeQuery.getAttributeName()).thenReturn("type");
         when(attributeQuery.getValue()).thenReturn(ImmutableList.of("platform"));
+
         Attribute attribute = mock(Attribute.class);
         when(attributeQuery.getAttribute()).thenReturn(attribute);
         when(attribute.getPath()).thenReturn(ImmutableList.of("path"));
@@ -107,9 +124,66 @@ public class ChannelGroupQueryExecutorTest {
                         )
                 );
 
-        QueryResult<ChannelGroup<?>> queryResult = objectUnderTest.execute(channelQuery);
+        QueryResult<ResolvedChannelGroup> queryResult = objectUnderTest.execute(channelQuery);
 
-        assertThat(queryResult.getResources(), containsInAnyOrder(result, result3));
+
+        assertThat(queryResult.getResources()
+                .toList()
+                .stream()
+                .map(ResolvedChannelGroup::getChannelGroup)
+                .collect(Collectors.toList()),
+                containsInAnyOrder(result, result3));
+    }
+
+    @Test
+    public void testSingleContentIsFullyResolvedByAnnotation() throws Exception{
+
+        Platform testChannelGroup = mock(Platform.class);
+        ChannelGroup<?> testRegionChannelGroup = mock(ChannelGroup.class);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        QueryContext context = mock(QueryContext.class);
+        Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
+        ChannelGroupRef regionChannelGroupRef = mock(ChannelGroupRef.class);
+        Set<ChannelGroupRef> regionChannelGroupRefSet = new HashSet<>();
+        Id channelGroupId = Id.valueOf(1L);
+        Id regionChannelGroupId = Id.valueOf(2L);
+
+        when(request.getParameter("annotations")).thenReturn("regions");
+        when(context.getRequest()).thenReturn(request);
+        when(channelQuery.getContext()).thenReturn(context);
+        when(channelQuery.getOnlyId()).thenReturn(channelGroupId);
+        when(channelQuery.isListQuery()).thenReturn(false);
+
+        when(testChannelGroup.getType()).thenReturn("platform");
+        when(regionChannelGroupRef.getId()).thenReturn(regionChannelGroupId);
+        regionChannelGroupRefSet.add(regionChannelGroupRef);
+        when(testChannelGroup.getRegions()).thenReturn(regionChannelGroupRefSet);
+
+        when(channelGroupResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(
+                channelGroupId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(testChannelGroup))
+                        )
+                );
+        when(channelGroupResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(
+                regionChannelGroupId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(testRegionChannelGroup))
+                        )
+                );
+
+        QueryResult<ResolvedChannelGroup> queryResult = objectUnderTest.execute(channelQuery);
+
+        assert(queryResult.getOnlyResource().getRegionChannelGroups().isPresent());
+        assertThat(queryResult.getOnlyResource().getRegionChannelGroups().get().iterator().next(),
+                is(testRegionChannelGroup));
     }
 
 }
+
+//if annotaiton is present make sure those resolved things come back
+// if theyre not present make sure they dont come back
+// IM POR TANT

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -1,15 +1,20 @@
 package org.atlasapi.query.v4.channelgroup;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.application.ApplicationSources;
+import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelNumbering;
+import org.atlasapi.channel.ChannelRef;
+import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.channel.Platform;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.AttributeQuery;
@@ -27,8 +32,10 @@ import com.metabroadcast.common.query.Selection;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -48,6 +55,9 @@ public class ChannelGroupQueryExecutorTest {
 
     @Mock
     private ChannelGroupResolver channelGroupResolver;
+
+    @Mock
+    private ChannelResolver channelResolver;
 
     @InjectMocks
     private ChannelGroupQueryExecutor objectUnderTest;
@@ -100,7 +110,7 @@ public class ChannelGroupQueryExecutorTest {
         when(context.getSelection()).thenReturn(Optional.of(selection));
         when(context.getRequest()).thenReturn(request);
 
-        when(request.getParameter("annotations")).thenReturn("regions");
+        when(request.getParameter("annotations")).thenReturn("banana");
 
         when(channelQuery.isListQuery()).thenReturn(true);
         when(channelQuery.getContext()).thenReturn(context);
@@ -137,7 +147,7 @@ public class ChannelGroupQueryExecutorTest {
     }
 
     @Test
-    public void testSingleContentIsFullyResolvedByAnnotation() throws Exception{
+    public void testSingleChannelGroupIsFullyResolvedByAnnotation() throws Exception {
 
         Platform testChannelGroup = mock(Platform.class);
         ChannelGroup<?> testRegionChannelGroup = mock(ChannelGroup.class);
@@ -184,5 +194,125 @@ public class ChannelGroupQueryExecutorTest {
                 is(testRegionChannelGroup));
 
         assertThat(queryResult.getOnlyResource().getPlatformChannelGroup(), is(Optional.absent()));
+        assertThat(queryResult.getOnlyResource().getChannels(), is(Optional.absent()));
+    }
+
+    @Test
+    public void testMultipleChannelGroupsAreFullyResolvedByAnnotations() throws Exception {
+        Platform testChannelGroup = mock(Platform.class);
+        ChannelGroup testChannelGroup2 = mock(ChannelGroup.class);
+        Platform testChannelGroup3 = mock(Platform.class);
+        Channel channel = mock(Channel.class);
+        Channel channel2 = mock(Channel.class);
+        ChannelGroup regionChannelGroup = mock(ChannelGroup.class);
+        ChannelNumbering channelNumbering = mock(ChannelNumbering.class);
+        ChannelNumbering channelNumbering2 = mock(ChannelNumbering.class);
+
+        Id channelGroupId = Id.valueOf(1L);
+        Id channelId = Id.valueOf(10L);
+        Id channelId2 = Id.valueOf(11L);
+
+        ChannelGroupRef testChannelGroupRef = mock(ChannelGroupRef.class);
+
+        Set<ChannelGroupRef> testChannelGroupRefSet = new HashSet<>();
+        when(testChannelGroupRef.getId()).thenReturn(channelGroupId);
+        testChannelGroupRefSet.add(testChannelGroupRef);
+        when(testChannelGroup.getRegions()).thenReturn(testChannelGroupRefSet);
+        when(testChannelGroup3.getRegions()).thenReturn(testChannelGroupRefSet);
+
+
+        when(channel.getId()).thenReturn(channelId);
+        when(channel2.getId()).thenReturn(channelId2);
+
+        ChannelRef channelRef = mock(ChannelRef.class);
+        ChannelRef channelRef2 = mock(ChannelRef.class);
+
+        when(channelRef.getId()).thenReturn(channelId);
+        when(channelRef2.getId()).thenReturn(channelId2);
+
+        when(channelNumbering.getChannel()).thenReturn(channelRef);
+        when(channelNumbering2.getChannel()).thenReturn(channelRef2);
+        Iterable<ChannelNumbering> channels = Lists.newArrayList(channelNumbering, channelNumbering2);
+
+        when(testChannelGroup.getChannelsAvailable(any(LocalDate.class)))
+            .thenReturn(channels);
+        when(testChannelGroup3.getChannelsAvailable(any(LocalDate.class)))
+            .thenReturn(channels);
+
+        when(testChannelGroup.getType()).thenReturn("platform");
+        when(testChannelGroup2.getType()).thenReturn("region");
+        when(testChannelGroup3.getType()).thenReturn("platform");
+
+        QueryContext context = mock(QueryContext.class);
+        Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
+        ApplicationSources applicationSources = mock(ApplicationSources.class);
+        Selection selection = Selection.ALL;
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(applicationSources.isReadEnabled(any(Publisher.class))).thenReturn(true);
+
+        when(request.getParameter("annotations")).thenReturn("regions,channels");
+
+        when(context.getApplicationSources()).thenReturn(applicationSources);
+        when(context.getSelection()).thenReturn(Optional.of(selection));
+        when(context.getRequest()).thenReturn(request);
+
+        when(channelQuery.isListQuery()).thenReturn(true);
+        when(channelQuery.getContext()).thenReturn(context);
+
+        AttributeQuery attributeQuery = mock(AttributeQuery.class);
+        when(attributeQuery.getAttributeName()).thenReturn("type");
+        when(attributeQuery.getValue()).thenReturn(ImmutableList.of("platform"));
+
+        Attribute attribute = mock(Attribute.class);
+        when(attributeQuery.getAttribute()).thenReturn(attribute);
+        when(attribute.getPath()).thenReturn(ImmutableList.of("path"));
+
+        AttributeQuerySet attributeQueries = new AttributeQuerySet(Sets.<AttributeQuery<Object>>newHashSet(
+                attributeQuery));
+
+        when(channelQuery.getOperands()).thenReturn(attributeQueries);
+
+        when(channelGroupResolver.allChannels())
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(testChannelGroup, testChannelGroup2, testChannelGroup3))
+                        )
+                );
+
+        when(channelGroupResolver.resolveIds((Iterable<Id>) argThat(containsInAnyOrder(
+                channelGroupId))))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(regionChannelGroup))
+                        )
+                );
+
+        when(channelResolver.resolveIds(any()))
+                .thenReturn(
+                        Futures.immediateFuture(
+                                Resolved.valueOf(ImmutableSet.of(channel, channel2))
+                        )
+                );
+
+        QueryResult<ResolvedChannelGroup> queryResult = objectUnderTest.execute(channelQuery);
+
+        List<ResolvedChannelGroup> resolvedChannelGroups = queryResult.getResources().toList();
+        for(ResolvedChannelGroup resolvedChannelGroup : resolvedChannelGroups) {
+            assert(resolvedChannelGroup.getChannels().isPresent());
+
+            if(resolvedChannelGroup.getChannelGroup().getType().equals("platform")) {
+                assert (resolvedChannelGroup.getRegionChannelGroups().isPresent());
+            } else {
+                assertThat(resolvedChannelGroup.getRegionChannelGroups(), is(Optional.absent()));
+            }
+
+            List<Channel> channelGroupsChannels = Lists.newArrayList(
+                    resolvedChannelGroup.getChannels().get()
+            );
+            assert(channelGroupsChannels.containsAll(ImmutableList.of(channel, channel2)));
+            assertThat(resolvedChannelGroup.getPlatformChannelGroup(), is(Optional.absent()));
+        }
+
     }
 }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -16,6 +17,7 @@ import org.atlasapi.channel.ChannelNumbering;
 import org.atlasapi.channel.ChannelRef;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.channel.Platform;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.AttributeQuerySet;
@@ -307,12 +309,19 @@ public class ChannelGroupQueryExecutorTest {
                 assertThat(resolvedChannelGroup.getRegionChannelGroups(), is(Optional.absent()));
             }
 
-            List<Channel> channelGroupsChannels = Lists.newArrayList(
-                    resolvedChannelGroup.getChannels().get()
-            );
+            List<Channel> channelGroupsChannels = StreamSupport.stream(
+                    resolvedChannelGroup.getChannels().get().spliterator(), false)
+                    .map(ResolvedChannel::getChannel)
+                    .collect(Collectors.toList());
+
             assert(channelGroupsChannels.containsAll(ImmutableList.of(channel, channel2)));
             assertThat(resolvedChannelGroup.getPlatformChannelGroup(), is(Optional.absent()));
         }
 
+    }
+
+    @Test
+    public void testChannelGroupChannelHasFilteredChannelGroups() throws Exception {
+        assert(true); // TODO: write me (MBST-17114)
     }
 }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.application.ApplicationSources;
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
@@ -26,7 +25,6 @@ import org.atlasapi.query.common.QueryResult;
 import com.metabroadcast.common.query.Selection;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -60,6 +58,9 @@ public class ChannelGroupQueryExecutorTest {
         ChannelGroup result = mock(ChannelGroup.class);
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("annotations")).thenReturn("banana");
+        when(context.getRequest()).thenReturn(request);
         when(channelQuery.isListQuery()).thenReturn(false);
         when(channelQuery.getOnlyId()).thenReturn(channelGroupId);
         when(channelQuery.getContext()).thenReturn(context);
@@ -141,8 +142,8 @@ public class ChannelGroupQueryExecutorTest {
         Platform testChannelGroup = mock(Platform.class);
         ChannelGroup<?> testRegionChannelGroup = mock(ChannelGroup.class);
 
-        HttpServletRequest request = mock(HttpServletRequest.class);
         QueryContext context = mock(QueryContext.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
         ChannelGroupRef regionChannelGroupRef = mock(ChannelGroupRef.class);
         Set<ChannelGroupRef> regionChannelGroupRefSet = new HashSet<>();
@@ -151,6 +152,7 @@ public class ChannelGroupQueryExecutorTest {
 
         when(request.getParameter("annotations")).thenReturn("regions");
         when(context.getRequest()).thenReturn(request);
+
         when(channelQuery.getContext()).thenReturn(context);
         when(channelQuery.getOnlyId()).thenReturn(channelGroupId);
         when(channelQuery.isListQuery()).thenReturn(false);
@@ -180,10 +182,7 @@ public class ChannelGroupQueryExecutorTest {
         assert(queryResult.getOnlyResource().getRegionChannelGroups().isPresent());
         assertThat(queryResult.getOnlyResource().getRegionChannelGroups().get().iterator().next(),
                 is(testRegionChannelGroup));
+
+        assertThat(queryResult.getOnlyResource().getPlatformChannelGroup(), is(Optional.absent()));
     }
-
 }
-
-//if annotaiton is present make sure those resolved things come back
-// if theyre not present make sure they dont come back
-// IM POR TANT

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/ScheduleQueryResultWriterTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/ScheduleQueryResultWriterTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.Episode;
@@ -46,14 +47,13 @@ public class ScheduleQueryResultWriterTest {
     private final ContainerSummaryResolver containerSummaryResolver = mock(ContainerSummaryResolver.class);
     private final AnnotationRegistry<Content> contentAnnotations = AnnotationRegistry.<Content>builder()
             .build();
-    private final AnnotationRegistry<Channel> channelAnnotations = AnnotationRegistry.<Channel>builder()
+    private final AnnotationRegistry<ResolvedChannel> channelAnnotations = AnnotationRegistry.<ResolvedChannel>builder()
             .build();
     private EntityWriter<Content> contentWriter = new ContentListWriter(contentAnnotations);
     private EntityWriter<Broadcast> broadcastWriter = new BroadcastWriter(
             "broadcasts",
             SubstitutionTableNumberCodec.lowerCaseOnly(),
-            new NoOpChannelResolver(),
-            new NoOpChannelGroupResolver()
+            new NoOpChannelResolver()
     );
     private final EntityListWriter<ChannelSchedule> scheduleWriter
             = new ScheduleListWriter(

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
@@ -20,9 +20,9 @@ public class ResolvedChannel {
             Optional<Iterable<Channel>> channelVariations
     ) {
         this.channel = checkNotNull(channel);
-        this.channelGroupSummaries = channelGroupSummaries;
-        this.parentChannel = parentChannel;
-        this.channelVariations = channelVariations;
+        this.channelGroupSummaries = checkNotNull(channelGroupSummaries);
+        this.parentChannel = checkNotNull(parentChannel);
+        this.channelVariations = checkNotNull(channelVariations);
     }
 
     public static Builder builder(Channel channel) {
@@ -47,7 +47,7 @@ public class ResolvedChannel {
 
     public static class Builder {
 
-        private Channel channel;
+        private final Channel channel;
         private Optional<List<ChannelGroupSummary>> channelGroupSummaries;
         private Optional<Channel> parentChannel;
         private Optional<Iterable<Channel>> channelVariations;

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
@@ -48,9 +48,9 @@ public class ResolvedChannel {
     public static class Builder {
 
         private final Channel channel;
-        private Optional<List<ChannelGroupSummary>> channelGroupSummaries;
-        private Optional<Channel> parentChannel;
-        private Optional<Iterable<Channel>> channelVariations;
+        private Optional<List<ChannelGroupSummary>> channelGroupSummaries = Optional.absent();
+        private Optional<Channel> parentChannel = Optional.absent();
+        private Optional<Iterable<Channel>> channelVariations = Optional.absent();
 
         private Builder(Channel channel) {
             this.channel = channel;

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannel.java
@@ -1,0 +1,84 @@
+package org.atlasapi.channel;
+
+import java.util.List;
+
+import com.google.common.base.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ResolvedChannel {
+
+    private final Channel channel;
+    private final Optional<List<ChannelGroupSummary>> channelGroupSummaries;
+    private final Optional<Channel> parentChannel;
+    private final Optional<Iterable<Channel>> channelVariations;
+
+    private ResolvedChannel(
+            Channel channel,
+            Optional<List<ChannelGroupSummary>> channelGroupSummaries,
+            Optional<Channel> parentChannel,
+            Optional<Iterable<Channel>> channelVariations
+    ) {
+        this.channel = checkNotNull(channel);
+        this.channelGroupSummaries = channelGroupSummaries;
+        this.parentChannel = parentChannel;
+        this.channelVariations = channelVariations;
+    }
+
+    public static Builder builder(Channel channel) {
+        return new Builder(channel);
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public Optional<List<ChannelGroupSummary>> getChannelGroupSummaries() {
+        return channelGroupSummaries;
+    }
+
+    public Optional<Channel> getParentChannel() {
+        return parentChannel;
+    }
+
+    public Optional<Iterable<Channel>> getChannelVariations() {
+        return channelVariations;
+    }
+
+    public static class Builder {
+
+        private Channel channel;
+        private Optional<List<ChannelGroupSummary>> channelGroupSummaries;
+        private Optional<Channel> parentChannel;
+        private Optional<Iterable<Channel>> channelVariations;
+
+        private Builder(Channel channel) {
+            this.channel = channel;
+        }
+
+        public Builder withChannelGroupSummaries(Optional<List<ChannelGroupSummary>> channelGroupSummaries) {
+            this.channelGroupSummaries = channelGroupSummaries;
+            return this;
+        }
+
+        public Builder withParentChannel(Optional<Channel> parentChannel) {
+            this.parentChannel = parentChannel;
+            return this;
+        }
+
+        public Builder withChannelVariations(Optional<Iterable<Channel>> channelVariations) {
+            this.channelVariations = channelVariations;
+            return this;
+        }
+
+        public ResolvedChannel build() {
+            return new ResolvedChannel(
+                    channel,
+                    channelGroupSummaries,
+                    parentChannel,
+                    channelVariations
+            );
+        }
+    }
+
+}

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,27 +1,36 @@
 package org.atlasapi.channel;
 
-import java.util.Optional;
+import org.atlasapi.output.ChannelWithChannelGroupMembership;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ResolvedChannelGroup {
 
-    private final ChannelGroup channelGroup;
+    private final ChannelGroup<?> channelGroup;
     private final Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
+    private final Optional<ChannelGroup<?>> platformChannelGroup;
+    private final Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels;
 
     private ResolvedChannelGroup(
             ChannelGroup channelGroup,
-            Optional<Iterable<ChannelGroup<?>>> regionChannelGroups
+            Optional<Iterable<ChannelGroup<?>>> regionChannelGroups,
+            Optional<ChannelGroup<?>> platformChannelGroup,
+            Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels
             ) {
         this.channelGroup = channelGroup;
         this.regionChannelGroups = regionChannelGroups;
+        this.platformChannelGroup = platformChannelGroup;
+        this.advertisedChannels = advertisedChannels;
     }
 
     public static Builder builder(ChannelGroup channelGroup) {
         return new Builder(channelGroup);
     }
 
-    public ChannelGroup getChannelGroup() {
+    public ChannelGroup<?> getChannelGroup() {
         return channelGroup;
     }
 
@@ -29,24 +38,46 @@ public class ResolvedChannelGroup {
         return regionChannelGroups;
     }
 
+    public Optional<ChannelGroup<?>> getPlatformChannelGroup() {
+        return platformChannelGroup;
+    }
+
+    public Optional<ImmutableSet<ChannelWithChannelGroupMembership>> getAdvertisedChannels() {
+        return advertisedChannels;
+    }
+
     public static class Builder {
 
-        ChannelGroup channelGroup;
-        Optional<Iterable<ChannelGroup<?>>> regionChannelGroup;
+        ChannelGroup<?> channelGroup;
+        Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
+        Optional<ChannelGroup<?>> platformChannelGroup;
+        Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels;
 
-        public Builder(ChannelGroup channelGroup) {
+        public Builder(ChannelGroup<?> channelGroup) {
             this.channelGroup = checkNotNull(channelGroup);
         }
 
-        public Builder withRegionChannelGroup(Optional<Iterable<ChannelGroup<?>>> regionChannelGroup) {
-            this.regionChannelGroup = regionChannelGroup;
+        public Builder withRegionChannelGroups(Optional<Iterable<ChannelGroup<?>>> regionChannelGroups) {
+            this.regionChannelGroups = regionChannelGroups;
+            return this;
+        }
+
+        public Builder withPlatformChannelGroup(Optional<ChannelGroup<?>> platformChannelGroup) {
+            this.platformChannelGroup = platformChannelGroup;
+            return this;
+        }
+
+        public Builder withAdvertisedChannels(Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels) {
+            this.advertisedChannels = advertisedChannels;
             return this;
         }
 
         public ResolvedChannelGroup build() {
             return new ResolvedChannelGroup(
                     channelGroup,
-                    regionChannelGroup
+                    regionChannelGroups,
+                    platformChannelGroup,
+                    advertisedChannels
             );
         }
     }

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,26 +1,24 @@
 package org.atlasapi.channel;
 
-import javax.annotation.Nullable;
-
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ResolvedChannelGroup {
 
     private final ChannelGroup channelGroup;
-    private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
+    private final Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
 
-    private ResolvedChannelGroup(ChannelGroup channelGroup) {
-        this.channelGroup = checkNotNull(channelGroup);
+    private ResolvedChannelGroup(
+            ChannelGroup channelGroup,
+            Optional<Iterable<ChannelGroup<?>>> regionChannelGroups
+            ) {
+        this.channelGroup = channelGroup;
+        this.regionChannelGroups = regionChannelGroups;
     }
 
-    public static ResolvedChannelGroup create(ChannelGroup channelGroup) {
-        return new ResolvedChannelGroup(channelGroup);
-    }
-
-    public void setRegions(@Nullable Iterable<ChannelGroup<?>> regionChannelGroups) {
-        this.regionChannelGroups = Optional.fromNullable(regionChannelGroups);
+    public static Builder builder(ChannelGroup channelGroup) {
+        return new Builder(channelGroup);
     }
 
     public ChannelGroup getChannelGroup() {
@@ -29,6 +27,28 @@ public class ResolvedChannelGroup {
 
     public Optional<Iterable<ChannelGroup<?>>> getRegionChannelGroups() {
         return regionChannelGroups;
+    }
+
+    public static class Builder {
+
+        ChannelGroup channelGroup;
+        Optional<Iterable<ChannelGroup<?>>> regionChannelGroup;
+
+        public Builder(ChannelGroup channelGroup) {
+            this.channelGroup = checkNotNull(channelGroup);
+        }
+
+        public Builder withRegionChannelGroup(Optional<Iterable<ChannelGroup<?>>> regionChannelGroup) {
+            this.regionChannelGroup = regionChannelGroup;
+            return this;
+        }
+
+        public ResolvedChannelGroup build() {
+            return new ResolvedChannelGroup(
+                    channelGroup,
+                    regionChannelGroup
+            );
+        }
     }
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,9 +1,6 @@
 package org.atlasapi.channel;
 
-import org.atlasapi.output.ChannelWithChannelGroupMembership;
-
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -12,18 +9,18 @@ public class ResolvedChannelGroup {
     private final ChannelGroup<?> channelGroup;
     private final Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
     private final Optional<ChannelGroup<?>> platformChannelGroup;
-    private final Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels;
+    private final Optional<Iterable<Channel>> channels;
 
     private ResolvedChannelGroup(
             ChannelGroup channelGroup,
             Optional<Iterable<ChannelGroup<?>>> regionChannelGroups,
             Optional<ChannelGroup<?>> platformChannelGroup,
-            Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels
+            Optional<Iterable<Channel>> channels
             ) {
         this.channelGroup = channelGroup;
         this.regionChannelGroups = regionChannelGroups;
         this.platformChannelGroup = platformChannelGroup;
-        this.advertisedChannels = advertisedChannels;
+        this.channels = channels;
     }
 
     public static Builder builder(ChannelGroup channelGroup) {
@@ -42,8 +39,8 @@ public class ResolvedChannelGroup {
         return platformChannelGroup;
     }
 
-    public Optional<ImmutableSet<ChannelWithChannelGroupMembership>> getAdvertisedChannels() {
-        return advertisedChannels;
+    public Optional<Iterable<Channel>> getChannels() {
+        return channels;
     }
 
     public static class Builder {
@@ -51,7 +48,7 @@ public class ResolvedChannelGroup {
         ChannelGroup<?> channelGroup;
         Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
         Optional<ChannelGroup<?>> platformChannelGroup;
-        Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels;
+        Optional<Iterable<Channel>> channels;
 
         public Builder(ChannelGroup<?> channelGroup) {
             this.channelGroup = checkNotNull(channelGroup);
@@ -67,8 +64,8 @@ public class ResolvedChannelGroup {
             return this;
         }
 
-        public Builder withAdvertisedChannels(Optional<ImmutableSet<ChannelWithChannelGroupMembership>> advertisedChannels) {
-            this.advertisedChannels = advertisedChannels;
+        public Builder withAdvertisedChannels(Optional<Iterable<Channel>> channels) {
+            this.channels = channels;
             return this;
         }
 
@@ -77,7 +74,7 @@ public class ResolvedChannelGroup {
                     channelGroup,
                     regionChannelGroups,
                     platformChannelGroup,
-                    advertisedChannels
+                    channels
             );
         }
     }

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,5 +1,7 @@
 package org.atlasapi.channel;
 
+import org.atlasapi.entity.util.Resolved;
+
 import com.google.common.base.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -9,13 +11,13 @@ public class ResolvedChannelGroup {
     private final ChannelGroup<?> channelGroup;
     private final Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
     private final Optional<ChannelGroup<?>> platformChannelGroup;
-    private final Optional<Iterable<Channel>> channels;
+    private final Optional<Iterable<ResolvedChannel>> channels;
 
     private ResolvedChannelGroup(
             ChannelGroup channelGroup,
             Optional<Iterable<ChannelGroup<?>>> regionChannelGroups,
             Optional<ChannelGroup<?>> platformChannelGroup,
-            Optional<Iterable<Channel>> channels
+            Optional<Iterable<ResolvedChannel>> channels
             ) {
         this.channelGroup = channelGroup;
         this.regionChannelGroups = regionChannelGroups;
@@ -39,7 +41,7 @@ public class ResolvedChannelGroup {
         return platformChannelGroup;
     }
 
-    public Optional<Iterable<Channel>> getChannels() {
+    public Optional<Iterable<ResolvedChannel>> getChannels() {
         return channels;
     }
 
@@ -48,7 +50,7 @@ public class ResolvedChannelGroup {
         ChannelGroup<?> channelGroup;
         Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
         Optional<ChannelGroup<?>> platformChannelGroup;
-        Optional<Iterable<Channel>> channels;
+        Optional<Iterable<ResolvedChannel>> channels;
 
         public Builder(ChannelGroup<?> channelGroup) {
             this.channelGroup = checkNotNull(channelGroup);
@@ -64,7 +66,7 @@ public class ResolvedChannelGroup {
             return this;
         }
 
-        public Builder withAdvertisedChannels(Optional<Iterable<Channel>> channels) {
+        public Builder withAdvertisedChannels(Optional<Iterable<ResolvedChannel>> channels) {
             this.channels = channels;
             return this;
         }

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,7 +1,5 @@
 package org.atlasapi.channel;
 
-import org.atlasapi.entity.util.Resolved;
-
 import com.google.common.base.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -19,10 +17,10 @@ public class ResolvedChannelGroup {
             Optional<ChannelGroup<?>> platformChannelGroup,
             Optional<Iterable<ResolvedChannel>> channels
             ) {
-        this.channelGroup = channelGroup;
-        this.regionChannelGroups = regionChannelGroups;
-        this.platformChannelGroup = platformChannelGroup;
-        this.channels = channels;
+        this.channelGroup = checkNotNull(channelGroup);
+        this.regionChannelGroups = checkNotNull(regionChannelGroups);
+        this.platformChannelGroup = checkNotNull(platformChannelGroup);
+        this.channels = checkNotNull(channels);
     }
 
     public static Builder builder(ChannelGroup channelGroup) {
@@ -47,10 +45,10 @@ public class ResolvedChannelGroup {
 
     public static class Builder {
 
-        ChannelGroup<?> channelGroup;
-        Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
-        Optional<ChannelGroup<?>> platformChannelGroup;
-        Optional<Iterable<ResolvedChannel>> channels;
+        private final ChannelGroup<?> channelGroup;
+        private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
+        private Optional<ChannelGroup<?>> platformChannelGroup;
+        private Optional<Iterable<ResolvedChannel>> channels;
 
         public Builder(ChannelGroup<?> channelGroup) {
             this.channelGroup = checkNotNull(channelGroup);

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -1,0 +1,34 @@
+package org.atlasapi.channel;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ResolvedChannelGroup {
+
+    private final ChannelGroup channelGroup;
+    private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
+
+    private ResolvedChannelGroup(ChannelGroup channelGroup) {
+        this.channelGroup = checkNotNull(channelGroup);
+    }
+
+    public static ResolvedChannelGroup create(ChannelGroup channelGroup) {
+        return new ResolvedChannelGroup(channelGroup);
+    }
+
+    public void setRegions(@Nullable Iterable<ChannelGroup<?>> regionChannelGroups) {
+        this.regionChannelGroups = Optional.fromNullable(regionChannelGroups);
+    }
+
+    public ChannelGroup getChannelGroup() {
+        return channelGroup;
+    }
+
+    public Optional<Iterable<ChannelGroup<?>>> getRegionChannelGroups() {
+        return regionChannelGroups;
+    }
+
+}

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -46,9 +46,9 @@ public class ResolvedChannelGroup {
     public static class Builder {
 
         private final ChannelGroup<?> channelGroup;
-        private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
-        private Optional<ChannelGroup<?>> platformChannelGroup;
-        private Optional<Iterable<ResolvedChannel>> channels;
+        private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups = Optional.absent();
+        private Optional<ChannelGroup<?>> platformChannelGroup = Optional.absent();
+        private Optional<Iterable<ResolvedChannel>> channels = Optional.absent();
 
         public Builder(ChannelGroup<?> channelGroup) {
             this.channelGroup = checkNotNull(channelGroup);


### PR DESCRIPTION
ChannelGroup and Channel annotations were using resolvers inside annotations to retrieve the data they need. This should have been done in the executor as it violates the Deer architecture. The annotations that previously used resolvers have had their logic refactored to the executor where the annotation is read and appropriate content resolved. 

Tests have been written to check single & multi query execute queries.