### PR TITLE
Change how stale broadcast deletions are handled

### DIFF
--- a/atlas-testlib/src/main/java/org/atlasapi/schedule/EquivalentScheduleStoreTester.java
+++ b/atlas-testlib/src/main/java/org/atlasapi/schedule/EquivalentScheduleStoreTester.java
@@ -1468,55 +1468,58 @@ public final class EquivalentScheduleStoreTester
         item4 -> (2015-10-26T06:00:00.000Z -> 2015-10-26T10:00:00.000Z)
         item2 -> (2015-10-26T10:00:00.000Z -> 2015-10-26T12:00:00.000Z)
 
-        After update2 the broadcast for item1 will be modified in the row for 2015-10-25 with updated
-        end time, but will be orphaned in the row for 2015-10-26 with incorrect times.
-        During update 3 for row for 2015-10-26, this broadcast is considered stale(it's not in the update for the interval)
-        and it's get deleted. The problem is that it is deleted from the interval of the broadcast(which includes 2015-10-25)
-        rather than interval of the update, which causes a correct broadcast from 2015-10-25 to be deleted
-        The solution for this is to only delete stale broadcasts from update intervals, not the broadcast intervals
-         */
-        DateTime item1Broadcast1Start = new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC);
-        DateTime item1Broadcast1End = new DateTime(2015, 10, 26, 10, 0, 0, 0, DateTimeZones.UTC);
-        DateTime item1Broadcast2Start = item1Broadcast1Start;
-        DateTime item1Broadcast2End = new DateTime(2015, 10, 26, 0, 0, 0, 0, DateTimeZones.UTC);
+        After update2 the broadcast for item1 will be modified in the row for 2015-10-25 with
+        updated end time, but will be orphaned in the row for 2015-10-26 with incorrect times.
 
-        DateTime item2BroadcastStart = item1Broadcast1End;
-        DateTime item2BroadcastEnd = new DateTime(2015, 10, 26, 12, 0, 0, 0, DateTimeZones.UTC);
+        During update 3 for row for 2015-10-26, this broadcast is considered stale(it's not in the
+        update for the interval) and it's get deleted. The problem is that it is deleted from the
+        interval of the broadcast(which includes 2015-10-25) rather than interval of the update,
+        which causes a correct broadcast from 2015-10-25 to be deleted
 
-        DateTime item3BroadcastStart = item1Broadcast2End;
-        DateTime item3BroadcastEnd = new DateTime(2015, 10, 26, 6, 0, 0, 0, DateTimeZones.UTC);
-
-        DateTime item4BroadcastStart = item3BroadcastEnd;
-        DateTime item4BroadcastEnd = item2BroadcastStart;
+        The solution for this is to only delete stale broadcasts from update intervals, not the
+        broadcast intervals
+        */
 
         Item item1 = new Item(Id.valueOf(1), Publisher.METABROADCAST);
         Item item2 = new Item(Id.valueOf(2), Publisher.METABROADCAST);
         Item item3 = new Item(Id.valueOf(3), Publisher.METABROADCAST);
         Item item4 = new Item(Id.valueOf(4), Publisher.METABROADCAST);
 
-        Broadcast item1Broadcast1 = new Broadcast(channel, item1Broadcast1Start, item1Broadcast1End)
+        Broadcast item1Broadcast1 = new Broadcast(
+                channel,
+                new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC),
+                new DateTime(2015, 10, 26, 10, 0, 0, 0, DateTimeZones.UTC)
+        )
                 .withId("bid1");
+
         //it's the same broadcast that got shortened
-        Broadcast item1Broadcast2 = new Broadcast(channel, item1Broadcast2Start, item1Broadcast2End)
+        Broadcast item1Broadcast2 = new Broadcast(
+                channel,
+                new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC),
+                new DateTime(2015, 10, 26, 0, 0, 0, 0, DateTimeZones.UTC)
+        )
                 .withId("bid1");
 
         Broadcast item2Broadcast = new Broadcast(
                 channel,
-                item2BroadcastStart,
-                item2BroadcastEnd
-        ).withId("bid2");
+                new DateTime(2015, 10, 26, 10, 0, 0, 0, DateTimeZones.UTC),
+                new DateTime(2015, 10, 26, 12, 0, 0, 0, DateTimeZones.UTC)
+        )
+                .withId("bid2");
 
         Broadcast item3Broadcast = new Broadcast(
                 channel,
-                item3BroadcastStart,
-                item3BroadcastEnd
-        ).withId("bid3");
+                new DateTime(2015, 10, 26, 0, 0, 0, 0, DateTimeZones.UTC),
+                new DateTime(2015, 10, 26, 6, 0, 0, 0, DateTimeZones.UTC)
+        )
+                .withId("bid3");
 
         Broadcast item4Broadcast = new Broadcast(
                 channel,
-                item4BroadcastStart,
-                item4BroadcastEnd
-        ).withId("bid4");
+                new DateTime(2015, 10, 26, 6, 0, 0, 0, DateTimeZones.UTC),
+                new DateTime(2015, 10, 26, 10, 0, 0, 0, DateTimeZones.UTC)
+        )
+                .withId("bid4");
 
         item1.addBroadcast(item1Broadcast1);
         getSubjectGenerator().getContentStore().writeContent(item1);
@@ -1526,7 +1529,9 @@ public final class EquivalentScheduleStoreTester
 
         ScheduleRef update1 = ScheduleRef.forChannel(
                 channel.getId(),
-                new Interval(item1Broadcast1Start, item2BroadcastEnd)
+                new Interval(new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC),
+                        new DateTime(2015, 10, 26, 12, 0, 0, 0, DateTimeZones.UTC)
+                )
         )
                 .addEntry(item1.getId(), item1Broadcast1.toRef())
                 .addEntry(item2.getId(), item2Broadcast.toRef())
@@ -1546,14 +1551,18 @@ public final class EquivalentScheduleStoreTester
 
         ScheduleRef update2 = ScheduleRef.forChannel(
                 channel.getId(),
-                new Interval(item1Broadcast2Start, item3BroadcastEnd)
+                new Interval(
+                        new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC),
+                        new DateTime(2015, 10, 26, 6, 0, 0, 0, DateTimeZones.UTC)
+                )
         )
                 .addEntry(item1.getId(), item1Broadcast2.toRef())
                 .addEntry(item3.getId(), item3Broadcast.toRef())
                 .build();
 
         getSubjectGenerator().getEquivalentScheduleStore()
-                .updateSchedule(new ScheduleUpdate(Publisher.METABROADCAST,
+                .updateSchedule(new ScheduleUpdate(
+                        Publisher.METABROADCAST,
                         update2,
                         ImmutableSet.of()
                 ));
@@ -1563,7 +1572,10 @@ public final class EquivalentScheduleStoreTester
 
         ScheduleRef update3 = ScheduleRef.forChannel(
                 channel.getId(),
-                new Interval(item4BroadcastStart, item2BroadcastEnd)
+                new Interval(
+                        new DateTime(2015, 10, 26, 6, 0, 0, 0, DateTimeZones.UTC),
+                        new DateTime(2015, 10, 26, 12, 0, 0, 0, DateTimeZones.UTC)
+                )
         )
                 .addEntry(item4.getId(), item4Broadcast.toRef())
                 .addEntry(item2.getId(), item2Broadcast.toRef())
@@ -1578,7 +1590,9 @@ public final class EquivalentScheduleStoreTester
         EquivalentSchedule resolved = get(
                 getSubjectGenerator().getEquivalentScheduleStore().resolveSchedules(
                         ImmutableList.of(channel),
-                        new Interval(item1Broadcast1Start, item2BroadcastEnd),
+                        new Interval(new DateTime(2015, 10, 25, 19, 30, 0, 0, DateTimeZones.UTC),
+                                new DateTime(2015, 10, 26, 12, 0, 0, 0, DateTimeZones.UTC)
+                        ),
                         Publisher.METABROADCAST,
                         ImmutableSet.of(Publisher.METABROADCAST)
                 )
@@ -1619,5 +1633,4 @@ public final class EquivalentScheduleStoreTester
     private <T> T get(ListenableFuture<T> future) throws Exception {
         return Futures.get(future, 10, TimeUnit.SECONDS, Exception.class);
     }
-
 }


### PR DESCRIPTION
- Only delete stale broadcasts from the intersection of the days in
  the broadcast interval and the schedule update interval. This way
  we will only delete a stale broadcast from a particular day if that
  stale broadcast's interval overlaps with that day and and schedule
  update we are currently processing also overlaps with that day.
  This protects from over-eagerly deleting a broadcast from a day
  that the update is not asserting on