### PR TITLE
Fix bug causing channel groups summary to not be resolved

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupChannelWriter.java
@@ -4,10 +4,8 @@ import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ChannelNumbering;
-import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.output.ResolvedChannelWithChannelGroupMembership;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.FieldWriter;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -167,6 +167,10 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                     resolveAdvertisedChannelsWithChannelGroups(channelGroup) :
                     resolveAdvertisedChannels(channelGroup)
             );
+        } else if (contextHasAnnotation(ctxt, Annotation.CHANNEL_GROUPS_SUMMARY)) {
+            resolvedChannelGroupBuilder.withAdvertisedChannels(
+                    resolveAdvertisedChannelsWithChannelGroups(channelGroup)
+            );
         } else {
             resolvedChannelGroupBuilder.withAdvertisedChannels(Optional.absent());
         }


### PR DESCRIPTION
The logic skipped over channel groups summary resolution if the
channels annotation wasnt present. This has now been fixed to
work as intended.