### PR TITLE
Bt annotation fix

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -82,7 +82,8 @@ public class ChannelQueryExecutor implements QueryExecutor<ResolvedChannel> {
             Id.valueOf(codec.decode("hk99")), // DTT + BT channel group
             Id.valueOf(codec.decode("hmb9")),
             Id.valueOf(codec.decode("hmck")),
-            Id.valueOf(codec.decode("hmcv"))
+            Id.valueOf(codec.decode("hmcv")),
+            Id.valueOf(codec.decode("ccjc9"))
     );
 
     private final List<String> whitelistedNamespaces = Lists.newArrayList(

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -15,7 +15,6 @@ import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
-import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.media.channel.ChannelQuery;
@@ -29,7 +28,6 @@ import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.query.common.UncheckedQueryExecutionException;
 
 import com.metabroadcast.common.base.MoreOrderings;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.promise.Promise;
 
@@ -41,7 +39,6 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -78,7 +78,8 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
             Id.valueOf(codec.decode("hk99")), // DTT + BT channel group
             Id.valueOf(codec.decode("hmb9")),
             Id.valueOf(codec.decode("hmck")),
-            Id.valueOf(codec.decode("hmcv"))
+            Id.valueOf(codec.decode("hmcv")),
+            Id.valueOf(codec.decode("ccjc9"))
     );
 
     private final List<String> whitelistedNamespaces = Lists.newArrayList(

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -21,6 +21,7 @@ import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
+import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.NotFoundException;
@@ -31,6 +32,7 @@ import org.atlasapi.query.common.QueryExecutor;
 import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.query.common.UncheckedQueryExecutionException;
 
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.promise.Promise;
 
@@ -40,6 +42,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.Futures;
 import org.joda.time.LocalDate;
@@ -50,6 +53,38 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
 
     private final ChannelGroupResolver channelGroupResolver;
     private final ChannelResolver channelResolver;
+
+    private final SubstitutionTableNumberCodec codec = SubstitutionTableNumberCodec.lowerCaseOnly();
+    private final List<Id> whitelistedIds = Lists.newArrayList(
+            Id.valueOf(codec.decode("hk62")), // BT TV Platform channel group
+            Id.valueOf(codec.decode("hk97")), // Watchable Live channel group
+            Id.valueOf(codec.decode("hmb6")),
+            Id.valueOf(codec.decode("hmcg")),
+            Id.valueOf(codec.decode("hmcr")),
+            Id.valueOf(codec.decode("hmbb")), // Output Protection channel group
+            Id.valueOf(codec.decode("jkzv")),
+            Id.valueOf(codec.decode("hmch")),
+            Id.valueOf(codec.decode("hmcs")),
+            Id.valueOf(codec.decode("hmb7")),
+            Id.valueOf(codec.decode("cbbd")), // On-demand location service
+            Id.valueOf(codec.decode("cbbb")),
+            Id.valueOf(codec.decode("cbbf")), // On-demand location player
+            Id.valueOf(codec.decode("cbbd")),
+            Id.valueOf(codec.decode("cbbb")),
+            Id.valueOf(codec.decode("hk98")), // BT channel group
+            Id.valueOf(codec.decode("hmb8")),
+            Id.valueOf(codec.decode("hmcj")),
+            Id.valueOf(codec.decode("hmct")),
+            Id.valueOf(codec.decode("hk99")), // DTT + BT channel group
+            Id.valueOf(codec.decode("hmb9")),
+            Id.valueOf(codec.decode("hmck")),
+            Id.valueOf(codec.decode("hmcv"))
+    );
+
+    private final List<String> whitelistedNamespaces = Lists.newArrayList(
+            "bt:subscription-code",
+            "bt:tug"
+    );
 
     public ChannelGroupQueryExecutor(ChannelGroupResolver channelGroupResolver, ChannelResolver channelResolver) {
         this.channelGroupResolver = checkNotNull(channelGroupResolver);
@@ -260,19 +295,23 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         );
     }
 
-    private Optional<List<ChannelGroupSummary>> resolveChannelGroupSummaries(Channel channel) {
-
-        ImmutableList<Id> channelGroupIds = channel.getChannelGroups()
-                .stream()
-                .map(cg -> cg.getChannelGroup().getId())
-                .collect(MoreCollectors.toImmutableList());
+    public Optional<List<ChannelGroupSummary>> resolveChannelGroupSummaries(Channel channel) {
 
         Iterable<ChannelGroup<?>> channelGroups =
-                Promise.wrap(channelGroupResolver.resolveIds(channelGroupIds))
+                Promise.wrap(channelGroupResolver.resolveIds(
+                        channel.getChannelGroups()
+                                .stream()
+                                .map(cg -> cg.getChannelGroup().getId())
+                                .collect(Collectors.toList())))
                         .then(Resolved::getResources)
                         .get(1, TimeUnit.MINUTES);
 
-        return Optional.of(StreamSupport.stream(channelGroups.spliterator(), false)
+        Iterable<ChannelGroup<?>> whitelistedChannelGroups =
+                StreamSupport.stream(channelGroups.spliterator(), false)
+                        .filter(this::channelGroupIsWhitelisted)
+                        .collect(MoreCollectors.toImmutableList());
+
+        return Optional.of(StreamSupport.stream(whitelistedChannelGroups.spliterator(), false)
                 .map(ChannelGroup::toSummary)
                 .collect(MoreCollectors.toImmutableList()));
     }
@@ -285,5 +324,13 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                         .splitToList(
                                 ctxt.getRequest().getParameter("annotations")
                         ).contains(annotation.toKey()));
+    }
+
+    private boolean channelGroupIsWhitelisted(ChannelGroup channelGroup) {
+        return whitelistedIds.contains(channelGroup.getId()) ||
+                channelGroup.getAliases()
+                        .stream()
+                        .map(Alias::getNamespace)
+                        .anyMatch(whitelistedNamespaces::contains);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -295,7 +295,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         );
     }
 
-    public Optional<List<ChannelGroupSummary>> resolveChannelGroupSummaries(Channel channel) {
+    private Optional<List<ChannelGroupSummary>> resolveChannelGroupSummaries(Channel channel) {
 
         Iterable<ChannelGroup<?>> channelGroups =
                 Promise.wrap(channelGroupResolver.resolveIds(


### PR DESCRIPTION
This stop all ChannelGroups from being returned that do not have a whitelisted ID or Alias namespace. The whitelist was created from the docs page displaying the special BT channel group ID's and namespaces.