### PR TITLE
Change schedule equiv updates to not update the schedule

### DIFF
--- a/atlas-cassandra/src/test/java/org/atlasapi/util/TestCassandraPersistenceModule.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/util/TestCassandraPersistenceModule.java
@@ -18,7 +18,6 @@ import org.atlasapi.segment.SegmentStore;
 import org.atlasapi.system.legacy.LegacyContentResolver;
 import org.atlasapi.topic.TopicStore;
 
-import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.ids.IdGeneratorBuilder;
 import com.metabroadcast.common.ids.SequenceGenerator;
 import com.metabroadcast.common.persistence.cassandra.DatastaxCassandraService;
@@ -138,19 +137,17 @@ public class TestCassandraPersistenceModule extends AbstractIdleService
         clearTables(session, context);
     }
 
+    public Session getSession() {
+        return cassandraService.getCluster().connect(keyspace);
+    }
+
     private void clearTables(Session session, AstyanaxContext<Keyspace> context)
             throws ConnectionException {
         CassandraInit.truncate(session, context);
     }
 
     private IdGeneratorBuilder idGeneratorBuilder() {
-        return new IdGeneratorBuilder() {
-
-            @Override
-            public IdGenerator generator(String sequenceIdentifier) {
-                return new SequenceGenerator();
-            }
-        };
+        return sequenceIdentifier -> new SequenceGenerator();
     }
 
     @Override


### PR DESCRIPTION
- Equivalence updates should only change the content in a given
  broadcast row, but never the schedule itself. This is done by
  -- not writing the broadcast when updating equivalences
  -- not resolving equiv schedule rows with null broadcasts
  -- resolving equiv schedule rows with null broadcasts as
  potentially stale when updating the schedule