### PR TITLE
Fix Group Lock class loader

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/AbstractEquivalentContentStore.java
@@ -11,7 +11,7 @@ import org.atlasapi.equivalence.EquivalenceGraphStore;
 import org.atlasapi.equivalence.EquivalenceGraphUpdate;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
 import org.atlasapi.messaging.EquivalentContentUpdatedMessage;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.queue.MessageSender;

--- a/atlas-cassandra/src/main/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStore.java
@@ -10,7 +10,7 @@ import java.util.stream.StreamSupport;
 
 import org.atlasapi.entity.Id;
 import org.atlasapi.equivalence.EquivalenceGraph.Adjacents;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;

--- a/atlas-cassandra/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/schedule/AbstractEquivalentScheduleStore.java
@@ -24,7 +24,7 @@ import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphStore;
 import org.atlasapi.equivalence.Equivalent;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.stream.MoreCollectors;

--- a/atlas-cassandra/src/main/java/org/atlasapi/schedule/CassandraEquivalentScheduleStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/schedule/CassandraEquivalentScheduleStore.java
@@ -36,12 +36,11 @@ import org.atlasapi.equivalence.Equivalent;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.serialization.protobuf.ContentProtos;
 import org.atlasapi.util.Column;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.time.Clock;
 
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.ConsistencyLevel;

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStore.java
@@ -15,7 +15,7 @@ import org.atlasapi.entity.util.StoreException;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph.Adjacents;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.collect.MoreSets;
 import com.metabroadcast.common.collect.OptionalMap;
@@ -25,7 +25,6 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.Timestamp;
 
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;

--- a/atlas-core/src/main/java/org/atlasapi/locks/GroupLock.java
+++ b/atlas-core/src/main/java/org/atlasapi/locks/GroupLock.java
@@ -1,4 +1,4 @@
-package org.atlasapi.util;
+package org.atlasapi.locks;
 
 import java.util.List;
 import java.util.Set;
@@ -34,7 +34,7 @@ public final class GroupLock<T> {
      *
      * @return a new GroupLock
      */
-    public static final <C extends Comparable<? super C>> GroupLock<C> natural(
+    public static <C extends Comparable<? super C>> GroupLock<C> natural(
             MetricRegistry metricRegistry,
             String metricPrefix
     ) {

--- a/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
@@ -19,7 +19,7 @@ import org.atlasapi.entity.Sourceds;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph.Adjacents;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.util.GroupLock;
+import org.atlasapi.locks.GroupLock;
 
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;

--- a/atlas-core/src/test/java/org/atlasapi/util/GroupLockTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/util/GroupLockTest.java
@@ -19,7 +19,7 @@ public class GroupLockTest {
     @Test
     public void testCanLockDifferentThings() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "CanLockDifferentThings"
         );
@@ -48,7 +48,7 @@ public class GroupLockTest {
     @Test
     public void testCantAcquireLockForKeyTwice() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "CantAcquireLockForKeyTwice"
         );
@@ -79,7 +79,7 @@ public class GroupLockTest {
     @Test
     public void testTryLock() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "TryLock"
         );
@@ -94,7 +94,7 @@ public class GroupLockTest {
     @Test
     public void testCantLockGroupWhereOneElementIsLocked() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "CantLockGroupWhereOneElementIsLocked"
         );
@@ -125,7 +125,7 @@ public class GroupLockTest {
     @Test
     public void testLocksGroupElementsInOrder() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "LocksGroupElementsInOrder"
         );
@@ -171,7 +171,7 @@ public class GroupLockTest {
     @Test
     public void testUnlocksAllGroupElementsIfTryLockFailsAGroup() throws InterruptedException {
 
-        final GroupLock<String> lock = GroupLock.<String>natural(
+        final org.atlasapi.locks.GroupLock<String> lock = org.atlasapi.locks.GroupLock.<String>natural(
                 new MetricRegistry(),
                 "UnlocksAllGroupElementsIfTryLockFailsAGroup"
         );


### PR DESCRIPTION
Duplicate GroupLock from atlas model with same package name
was causing the class loader to not know which one to pick
meaning it selected the wrong one.

Package names have now been distinctly named.