### PR TITLE
Add metrics to record the latency of Deer workers

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingContentWorker.java
@@ -10,9 +10,9 @@ import org.atlasapi.content.IndexException;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 
-import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
+import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -38,6 +38,7 @@ public class EquivalentContentIndexingContentWorker
     private final Timer executionTimer;
     private final Meter messageReceivedMeter;
     private final Meter failureMeter;
+    private final Timer latencyTimer;
 
     private EquivalentContentIndexingContentWorker(
             ContentResolver contentResolver,
@@ -51,6 +52,7 @@ public class EquivalentContentIndexingContentWorker
         this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
         this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
         this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+        this.latencyTimer = metricRegistry.timer(metricPrefix + "timer.latency");
     }
 
     public static EquivalentContentIndexingContentWorker create(
@@ -71,12 +73,12 @@ public class EquivalentContentIndexingContentWorker
         Id contentId = getContentId(message);
 
         LOG.debug("Processing message on id {}, took: PT{}S, message: {}",
-                contentId, getTimeToProcessInSeconds(message), message);
+                contentId, getTimeToProcessInMillis(message.getTimestamp()) / 1000L, message);
 
         Timer.Context time = executionTimer.time();
 
         try {
-            indexContent(contentId);
+            indexContent(contentId, message.getTimestamp());
         } catch (TimeoutException | IndexException e) {
             failureMeter.mark();
             throw new RecoverableException("Failed to index content " + contentId, e);
@@ -89,7 +91,8 @@ public class EquivalentContentIndexingContentWorker
         return message.getContentRef().getId();
     }
 
-    private void indexContent(Id contentId) throws TimeoutException, IndexException {
+    private void indexContent(Id contentId, Timestamp timestamp)
+            throws TimeoutException, IndexException {
         Resolved<Content> results = Futures.get(
                 resolveContent(contentId), 30, TimeUnit.SECONDS, TimeoutException.class
         );
@@ -100,6 +103,11 @@ public class EquivalentContentIndexingContentWorker
             Content content = contentOptional.get();
             LOG.debug("Indexing message {}", content);
             contentIndex.index(content);
+
+            latencyTimer.update(
+                    getTimeToProcessInMillis(timestamp),
+                    TimeUnit.MILLISECONDS
+            );
         }
     }
 
@@ -107,7 +115,7 @@ public class EquivalentContentIndexingContentWorker
         return contentResolver.resolveIds(ImmutableList.of(contentId));
     }
 
-    private long getTimeToProcessInSeconds(AbstractMessage message) {
-        return (System.currentTimeMillis() - message.getTimestamp().millis()) / 1000L;
+    private long getTimeToProcessInMillis(Timestamp messageTimestamp) {
+        return System.currentTimeMillis() - messageTimestamp.millis();
     }
 }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentIndexingGraphWorker.java
@@ -1,13 +1,15 @@
 package org.atlasapi.messaging;
 
+import java.util.concurrent.TimeUnit;
+
 import org.atlasapi.content.ContentIndex;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
 
-import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -29,7 +31,7 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
     private final Timer executionTimer;
     private final Meter messageReceivedMeter;
     private final Meter failureMeter;
-
+    private final Timer latencyTimer;
 
     private EquivalentContentIndexingGraphWorker(
             ContentIndex contentIndex,
@@ -43,6 +45,7 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
         this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
         this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
         this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+        this.latencyTimer = metricRegistry.timer(metricPrefix + "timer.latency");
     }
 
     public static EquivalentContentIndexingGraphWorker create(
@@ -65,7 +68,7 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
                 message.getGraphUpdate().getAllGraphs().stream()
                         .map(EquivalenceGraph::getId)
                         .collect(MoreCollectors.toImmutableList()),
-                getTimeToProcessInSeconds(message),
+                getTimeToProcessInMillis(message.getTimestamp()) / 1000L,
                 message
         );
 
@@ -78,6 +81,11 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
             for (EquivalenceGraph graph : graphs) {
                 contentIndex.updateCanonicalIds(graph.getId(), graph.getEquivalenceSet());
             }
+
+            latencyTimer.update(
+                    getTimeToProcessInMillis(message.getTimestamp()),
+                    TimeUnit.MILLISECONDS
+            );
         } catch (Exception e) {
             failureMeter.mark();
             throw new RecoverableException("Failed to update canonical IDs for set"
@@ -87,7 +95,7 @@ public class EquivalentContentIndexingGraphWorker implements Worker<EquivalenceG
         }
     }
 
-    private long getTimeToProcessInSeconds(AbstractMessage message) {
-        return (System.currentTimeMillis() - message.getTimestamp().millis()) / 1000L;
+    private long getTimeToProcessInMillis(Timestamp messageTimestamp) {
+        return System.currentTimeMillis() - messageTimestamp.millis();
     }
 }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentContentStoreGraphUpdateWorker.java
@@ -1,14 +1,16 @@
 package org.atlasapi.messaging;
 
+import java.util.concurrent.TimeUnit;
+
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph;
 import org.atlasapi.equivalence.EquivalenceGraphUpdateMessage;
 
-import com.metabroadcast.common.queue.AbstractMessage;
 import com.metabroadcast.common.queue.RecoverableException;
 import com.metabroadcast.common.queue.Worker;
 import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.time.Timestamp;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -29,6 +31,7 @@ public class EquivalentContentStoreGraphUpdateWorker
     private final Timer executionTimer;
     private final Meter messageReceivedMeter;
     private final Meter failureMeter;
+    private final Timer latencyTimer;
 
     private EquivalentContentStoreGraphUpdateWorker(
             EquivalentContentStore equivalentContentStore,
@@ -40,6 +43,7 @@ public class EquivalentContentStoreGraphUpdateWorker
         this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
         this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
         this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
+        this.latencyTimer = metricRegistry.timer(metricPrefix + "timer.latency");
     }
 
     public static EquivalentContentStoreGraphUpdateWorker create(
@@ -67,7 +71,7 @@ public class EquivalentContentStoreGraphUpdateWorker
                             .map(EquivalenceGraph::getId)
                             .collect(MoreCollectors.toImmutableList()),
                     message.getGraphUpdate().getDeleted(),
-                    getTimeToProcessInSeconds(message),
+                    getTimeToProcessInMillis(message.getTimestamp()) / 1000L,
                     message
             );
         }
@@ -76,6 +80,11 @@ public class EquivalentContentStoreGraphUpdateWorker
 
         try {
             equivalentContentStore.updateEquivalences(message.getGraphUpdate());
+
+            latencyTimer.update(
+                    getTimeToProcessInMillis(message.getTimestamp()),
+                    TimeUnit.MILLISECONDS
+            );
         } catch (WriteException e) {
             LOG.warn(
                     "Failed to process message on updated graph: {}, created graph(s): {},"
@@ -95,7 +104,7 @@ public class EquivalentContentStoreGraphUpdateWorker
         }
     }
 
-    private long getTimeToProcessInSeconds(AbstractMessage message) {
-        return (System.currentTimeMillis() - message.getTimestamp().millis()) / 1000L;
+    private long getTimeToProcessInMillis(Timestamp messageTimestamp) {
+        return System.currentTimeMillis() - messageTimestamp.millis();
     }
 }


### PR DESCRIPTION
- These measure the time between the moment the message was generated
  and the time it finished processing