### PR TITLE
Add test that we can remove a content's container and container summary

### DIFF
--- a/atlas-cassandra/src/test/java/org/atlasapi/content/AstyanaxCassandraContentStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/AstyanaxCassandraContentStoreIT.java
@@ -2,6 +2,8 @@ package org.atlasapi.content;
 
 import com.codahale.metrics.MetricRegistry;
 import com.netflix.astyanax.model.ConsistencyLevel;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -18,5 +20,12 @@ public class AstyanaxCassandraContentStoreIT extends CassandraContentStoreIT {
                 .withMetricRegistry(new MetricRegistry())
                 .withMetricPrefix("test.AstyanaxCassandraContentStore.")
                 .build();
+    }
+
+    @Ignore("This is a known bug. Given this store is due to be decommissioned it is only being "
+            + "fixed in the CqlContentStore")
+    @Test
+    @Override
+    public void writingContentWithoutContainerRemovesExistingContainer() throws Exception {
     }
 }

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/v2/CqlContentStoreIT.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/v2/CqlContentStoreIT.java
@@ -44,6 +44,12 @@ public class CqlContentStoreIT extends CassandraContentStoreIT {
     @Override
     public void testWritingResolvingContainerWhichOnlyChildRefsThrowsCorrectException() {}
 
+    @Ignore("MBST-17328")
+    @Test
+    @Override
+    public void writingContentWithoutContainerRemovesExistingContainer() throws Exception {
+    }
+
     @Test
     public void writesSegmentsWithDescription() throws Exception {
         when(clock.now()).thenReturn(DateTime.now());


### PR DESCRIPTION
- Currently this behaviour is broken in the
  AstyanaxCassandraContentStore (neither the containerRef not the
  containerSummary are being removed) and partially broken in the
  CqlContentStore (only the containerRef is being removed). There is
  a bug raised for addressing the CqlContentStore issue. The
  AstyanaxCassandraContentStore is due for decommission so this will
  only be fixed on the new version.