### PR TITLE
Add support for serving schedules from PA & EBS to BT

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
@@ -28,6 +28,7 @@ public class ScheduleListWriter implements EntityListWriter<ChannelSchedule> {
             throws IOException {
         ResolvedChannel resolvedChannel = ResolvedChannel.builder(entity.getChannel()).build();
         writer.writeObject(channelWriter, resolvedChannel, ctxt);
+        writer.writeField("source", resolvedChannel.getChannel().getSource());
         writer.writeList(entryWriter, entity.getEntries(), ctxt);
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleQueryExecutorImpl.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleQueryExecutorImpl.java
@@ -1,13 +1,14 @@
 package org.atlasapi.query.v4.schedule;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import org.apache.avro.generic.GenericData;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.application.ApplicationAccessRole;
 import org.atlasapi.application.ApplicationSources;
@@ -30,19 +31,12 @@ import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.schedule.ChannelSchedule;
 import org.atlasapi.schedule.Schedule;
 import org.atlasapi.schedule.ScheduleResolver;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.AsyncFunction;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.joda.time.Interval;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleQueryExecutorImpl.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleQueryExecutorImpl.java
@@ -1,9 +1,15 @@
 package org.atlasapi.query.v4.schedule;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import org.apache.avro.generic.GenericData;
 import org.atlasapi.annotation.Annotation;
+import org.atlasapi.application.ApplicationAccessRole;
 import org.atlasapi.application.ApplicationSources;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelResolver;
@@ -16,6 +22,7 @@ import org.atlasapi.entity.Identifiables;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.equivalence.MergingEquivalentsResolver;
 import org.atlasapi.equivalence.ResolvedEquivalents;
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.NotFoundException;
 import org.atlasapi.query.common.QueryContext;
 import org.atlasapi.query.common.QueryExecutionException;
@@ -23,6 +30,8 @@ import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.schedule.ChannelSchedule;
 import org.atlasapi.schedule.Schedule;
 import org.atlasapi.schedule.ScheduleResolver;
+
+import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
@@ -63,38 +72,46 @@ public class ScheduleQueryExecutorImpl implements ScheduleQueryExecutor {
     public QueryResult<ChannelSchedule> execute(ScheduleQuery query)
             throws QueryExecutionException {
 
-        Iterable<Channel> channels = resolveChannels(query);
         if (!query.getEnd().isPresent()) {
             throw new UnsupportedOperationException(
                     "'count' parameter not supported in non-equivalent schedule store. Please specify 'to' parameter in your request");
         }
-        ListenableFuture<Schedule> schedule = scheduleResolver.resolve(
-                channels,
-                new Interval(query.getStart(), query.getEnd().get()),
-                query.getSource()
-        );
+
+        Iterable<Channel> channels = resolveChannels(query);
+
+        List<Channel> defaultChannels = Lists.newArrayList(channels);
+        List<Channel> ebsChannels = new ArrayList<>();
+
+        if (query.getContext().getApplicationSources().getAccessRoles().contains(
+                ApplicationAccessRole.PREFER_EBS_SCHEDULE)) {
+
+            ebsChannels = defaultChannels.stream()
+                    .filter(channel -> channel.getAvailableFrom().contains(Publisher.BT_SPORT_EBS))
+                    .collect(Collectors.toList());
+
+            defaultChannels.removeAll(ebsChannels);
+        }
+
+        List<ChannelSchedule> channelScheduleList = getChannelScheduleList(ebsChannels, defaultChannels, query);
 
         if (query.isMultiChannel()) {
-            List<ChannelSchedule> channelSchedules = channelSchedules(schedule, query);
             return QueryResult.listResult(
-                    channelSchedules,
+                    channelScheduleList,
                     query.getContext(),
-                    channelSchedules.size()
+                    channelScheduleList.size()
             );
         }
+
         return QueryResult.singleResult(
-                Iterables.getOnlyElement(channelSchedules(schedule, query)),
+                Iterables.getOnlyElement(channelScheduleList),
                 query.getContext()
         );
     }
 
     private Iterable<Channel> resolveChannels(ScheduleQuery query) throws QueryExecutionException {
-        Iterable<Id> channelIds;
-        if (query.isMultiChannel()) {
-            channelIds = query.getChannelIds();
-        } else {
-            channelIds = ImmutableSet.of(query.getChannelId());
-        }
+        Iterable<Id> channelIds = query.isMultiChannel() ?
+                query.getChannelIds() : ImmutableSet.of(query.getChannelId());
+
         Resolved<Channel> resolvedChannels = Futures.get(
                 channelResolver.resolveIds(channelIds),
                 1,
@@ -121,13 +138,7 @@ public class ScheduleQueryExecutorImpl implements ScheduleQueryExecutor {
     }
 
     private AsyncFunction<Schedule, Schedule> toEquivalentEntries(final ScheduleQuery query) {
-        return new AsyncFunction<Schedule, Schedule>() {
-
-            @Override
-            public ListenableFuture<Schedule> apply(Schedule input) {
-                return resolveEquivalents(input, query.getContext());
-            }
-        };
+        return input -> resolveEquivalents(input, query.getContext());
     }
 
     private ListenableFuture<Schedule> resolveEquivalents(Schedule schedule,
@@ -149,34 +160,62 @@ public class ScheduleQueryExecutorImpl implements ScheduleQueryExecutor {
     }
 
     private Function<ResolvedEquivalents<Content>, Schedule> intoSchedule(final Schedule schedule) {
-        return new Function<ResolvedEquivalents<Content>, Schedule>() {
-
-            @Override
-            public Schedule apply(ResolvedEquivalents<Content> input) {
-                ImmutableList.Builder<ChannelSchedule> transformed = ImmutableList.builder();
-                for (ChannelSchedule cs : schedule.channelSchedules()) {
-                    transformed.add(cs.copyWithEntries(replaceItems(cs.getEntries(), input)));
-                }
-                return new Schedule(transformed.build(), schedule.interval());
+        return input -> {
+            ImmutableList.Builder<ChannelSchedule> transformed = ImmutableList.builder();
+            for (ChannelSchedule cs : schedule.channelSchedules()) {
+                transformed.add(cs.copyWithEntries(replaceItems(cs.getEntries(), input)));
             }
+            return new Schedule(transformed.build(), schedule.interval());
         };
     }
 
     private List<ItemAndBroadcast> replaceItems(List<ItemAndBroadcast> entries,
             final ResolvedEquivalents<Content> equivs) {
-        return Lists.transform(entries, new Function<ItemAndBroadcast, ItemAndBroadcast>() {
-
-            @Override
-            public ItemAndBroadcast apply(ItemAndBroadcast input) {
-                Item item = (Item) Iterables.getOnlyElement(equivs.get(input.getItem().getId()));
-                replaceBroadcasts(item, input.getBroadcast());
-                return new ItemAndBroadcast(item, input.getBroadcast());
-            }
-
+        return Lists.transform(entries, input -> {
+            Item item = (Item) Iterables.getOnlyElement(equivs.get(input.getItem().getId()));
+            replaceBroadcasts(item, input.getBroadcast());
+            return new ItemAndBroadcast(item, input.getBroadcast());
         });
     }
 
     private void replaceBroadcasts(Item item, Broadcast broadcast) {
         item.setBroadcasts(ImmutableSet.of(broadcast));
+    }
+
+    private List<ChannelSchedule> getChannelScheduleList(
+            List<Channel> ebsChannels,
+            List<Channel> defaultChannels,
+            ScheduleQuery query
+    ) throws ScheduleQueryExecutionException {
+
+        List<ChannelSchedule> ebsChannelSchedule = new ArrayList<>();
+        List<ChannelSchedule> defaultChannelSchedule = new ArrayList<>();
+
+        if (!ebsChannels.isEmpty()) {
+
+            ListenableFuture<Schedule> ebsSchedule = scheduleResolver.resolve(
+                    ebsChannels,
+                    new Interval(query.getStart(), query.getEnd().get()),
+                    Publisher.BT_SPORT_EBS
+            );
+
+            ebsChannelSchedule = channelSchedules(ebsSchedule, query);
+        }
+
+        if (!defaultChannels.isEmpty()) {
+
+            ListenableFuture<Schedule> baseSchedule = scheduleResolver.resolve(
+                    defaultChannels,
+                    new Interval(query.getStart(), query.getEnd().get()),
+                    query.getSource()
+            );
+
+            defaultChannelSchedule = channelSchedules(baseSchedule, query);
+        }
+
+        return ImmutableList.<ChannelSchedule>builder()
+                .addAll(ebsChannelSchedule)
+                .addAll(defaultChannelSchedule)
+                .build();
     }
 }

--- a/atlas-core/src/main/java/org/atlasapi/application/ApplicationAccessRole.java
+++ b/atlas-core/src/main/java/org/atlasapi/application/ApplicationAccessRole.java
@@ -26,7 +26,12 @@ public enum ApplicationAccessRole {
      * This role is intended to allow privileged applications an extended grace period to
      * adjust to the API changes before their access is cut-off as well.
      */
-    SUNSETTED_API_FEATURES_ACCESS("sunsetted-api-features-access");
+    SUNSETTED_API_FEATURES_ACCESS("sunsetted-api-features-access"),
+
+    /**
+     * Application prefers EBS schedule data
+     */
+    PREFER_EBS_SCHEDULE("prefer-ebs-schedule");
 
     private final String role;
 


### PR DESCRIPTION
* Application access role added to determine whether functionality is
needed for the requesting application

* "source" field added to schedule output for channels to show where
the source of the channel data

* Application access role checking in the executor resolves channels from
EBS if that is the applications preferred source