### PR TITLE
Add dynamically generated graph blacklist

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/equivalence/CassandraEquivalenceGraphStore.java
@@ -247,10 +247,4 @@ public final class CassandraEquivalenceGraphStore extends AbstractEquivalenceGra
     protected GroupLock<Id> lock() {
         return lock;
     }
-
-    @Override
-    protected Logger log() {
-        return log;
-    }
-
 }

--- a/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/equivalence/AbstractEquivalenceGraphStoreTest.java
@@ -18,8 +18,8 @@ import org.atlasapi.entity.Sourced;
 import org.atlasapi.entity.Sourceds;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.equivalence.EquivalenceGraph.Adjacents;
-import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.locks.GroupLock;
+import org.atlasapi.media.entity.Publisher;
 
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;
@@ -843,11 +843,6 @@ public class AbstractEquivalenceGraphStoreTest {
                     store.put(id, graph);
                 }
             }
-        }
-
-        @Override
-        protected Logger log() {
-            return log;
         }
 
         @Override


### PR DESCRIPTION
- The blacklist contains a list of graphs to be blocked and is
  updated with all the nodes in that graph every time it is
  encountered. Over time it should grow to contain all IDs in a
  snapshot of the given graphs