### PR TITLE
Move multiple schedule logic to correct executor

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleListWriter.java
@@ -2,10 +2,8 @@ package org.atlasapi.query.v4.schedule;
 
 import java.io.IOException;
 
-import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.ItemAndBroadcast;
-import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.EntityWriter;
 import org.atlasapi.output.FieldWriter;
@@ -28,7 +26,7 @@ public class ScheduleListWriter implements EntityListWriter<ChannelSchedule> {
             throws IOException {
         ResolvedChannel resolvedChannel = ResolvedChannel.builder(entity.getChannel()).build();
         writer.writeObject(channelWriter, resolvedChannel, ctxt);
-        writer.writeField("source", resolvedChannel.getChannel().getSource());
+        writer.writeField("source", entity.getSource());
         writer.writeList(entryWriter, entity.getEntries(), ctxt);
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/schedule/ChannelSchedule.java
+++ b/atlas-core/src/main/java/org/atlasapi/schedule/ChannelSchedule.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.atlasapi.channel.Channel;
 import org.atlasapi.content.ItemAndBroadcast;
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 
 import com.google.common.base.Function;
@@ -21,22 +22,34 @@ public class ChannelSchedule {
     }
 
     private static final Function<ChannelSchedule, ImmutableList<ItemAndBroadcast>> TO_ENTRIES
-            = new Function<ChannelSchedule, ImmutableList<ItemAndBroadcast>>() {
-
-        @Override
-        public ImmutableList<ItemAndBroadcast> apply(ChannelSchedule input) {
-            return input.entries;
-        }
-    };
+            = input -> input.entries;
 
     private final Channel channel;
     private final Interval interval;
     private final ImmutableList<ItemAndBroadcast> entries;
+    private final Publisher source;
 
-    public ChannelSchedule(Channel channel, Interval interval, Iterable<ItemAndBroadcast> entries) {
+    public ChannelSchedule(
+            Channel channel,
+            Interval interval,
+            Iterable<ItemAndBroadcast> entries
+    ) {
         this.channel = checkNotNull(channel);
         this.interval = checkNotNull(interval);
         this.entries = Ordering.natural().immutableSortedCopy(entries);
+        this.source = null;
+    }
+
+    private ChannelSchedule(
+            Channel channel,
+            Interval interval,
+            Iterable<ItemAndBroadcast> entries,
+            Publisher source
+    ) {
+        this.channel = checkNotNull(channel);
+        this.interval = checkNotNull(interval);
+        this.entries = Ordering.natural().immutableSortedCopy(entries);
+        this.source = source;
     }
 
     @FieldName("channel")
@@ -54,8 +67,16 @@ public class ChannelSchedule {
         return entries;
     }
 
+    public Publisher getSource() {
+        return source;
+    }
+
     public ChannelSchedule copyWithEntries(Iterable<ItemAndBroadcast> entries) {
-        return new ChannelSchedule(channel, interval, entries);
+        return new ChannelSchedule(channel, interval, entries, source);
+    }
+
+    public ChannelSchedule copyWithScheduleSource(Publisher source) {
+        return new ChannelSchedule(channel, interval, entries, source);
     }
 
     @Override


### PR DESCRIPTION
* Moved logic to correct executor - EquivalentScheduleQueryExecutor
* Reverted old executor back to pre-feature state - ScheduleQueryExecutorImpl
* Added schedule source to ChannelSchedule
* Fixed schedule fallback bug if EBS schedule fails to be resolved