### PR TITLE
Fix/class cast exception on new locations

### DIFF
--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
@@ -362,29 +362,13 @@ public class EsContentTranslator {
 
         ImmutableList<Map<String, Object>> newLocations = locations.stream()
                 .filter(location -> filter.apply(location.getPolicy()))
-                .map(location -> newLocationPolicyToMap(location.getPolicy()))
+                .map(EsLocation::toMap)
                 .collect(MoreCollectors.toImmutableList());
 
         return ImmutableList.<Map<String, Object>>builder()
                 .addAll(nonNullExistingLocations)
                 .addAll(newLocations)
                 .build();
-    }
-
-    private Map<String, Object> newLocationPolicyToMap(Policy policy) {
-        ImmutableList.Builder<Map<String, String>> aliases = ImmutableList.builder();
-
-        policy.getAliases().forEach(alias -> aliases.add(ImmutableMap.of(
-                EsAlias.NAMESPACE, alias.getNamespace(),
-                EsAlias.VALUE, alias.getValue())
-        ));
-
-        return ImmutableMap.of(
-                EsLocation.ALIASES, aliases.build(),
-                EsLocation.AVAILABILITY_END_TIME, policy.getAvailabilityEnd(),
-                EsLocation.AVAILABILITY_TIME, policy.getAvailabilityStart()
-        );
-
     }
 
     private ImmutableList<Policy> fromEsLocations(List<Map<String, Object>> existingLocations) {

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
@@ -362,7 +362,7 @@ public class EsContentTranslator {
 
         ImmutableList<Map<String, Object>> newLocations = locations.stream()
                 .filter(location -> filter.apply(location.getPolicy()))
-                .map(location -> existingLocationPolicyToMap(location.getPolicy()))
+                .map(location -> newLocationPolicyToMap(location.getPolicy()))
                 .collect(MoreCollectors.toImmutableList());
 
         return ImmutableList.<Map<String, Object>>builder()
@@ -371,7 +371,7 @@ public class EsContentTranslator {
                 .build();
     }
 
-    private Map<String, Object> existingLocationPolicyToMap(Policy policy) {
+    private Map<String, Object> newLocationPolicyToMap(Policy policy) {
         ImmutableList.Builder<Map<String, String>> aliases = ImmutableList.builder();
 
         policy.getAliases().forEach(alias -> aliases.add(ImmutableMap.of(

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTranslator.java
@@ -16,6 +16,7 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.util.ElasticsearchUtils;
+import org.atlasapi.util.EsAlias;
 import org.atlasapi.util.EsObject;
 import org.atlasapi.util.SecondaryIndex;
 
@@ -374,14 +375,14 @@ public class EsContentTranslator {
         ImmutableList.Builder<Map<String, String>> aliases = ImmutableList.builder();
 
         policy.getAliases().forEach(alias -> aliases.add(ImmutableMap.of(
-                "namespace", alias.getNamespace(),
-                "value", alias.getValue())
+                EsAlias.NAMESPACE, alias.getNamespace(),
+                EsAlias.VALUE, alias.getValue())
         ));
 
         return ImmutableMap.of(
-                "aliases", aliases.build(),
-                "availabilityEndTime", policy.getAvailabilityEnd(),
-                "availabilityTime", policy.getAvailabilityStart()
+                EsLocation.ALIASES, aliases.build(),
+                EsLocation.AVAILABILITY_END_TIME, policy.getAvailabilityEnd(),
+                EsLocation.AVAILABILITY_TIME, policy.getAvailabilityStart()
         );
 
     }

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsLocation.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsLocation.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.util.EsAlias;
 import org.atlasapi.util.EsObject;
@@ -16,6 +18,8 @@ import com.google.common.collect.Iterables;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.joda.time.DateTime;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class EsLocation extends EsObject {
 
@@ -87,6 +91,22 @@ public class EsLocation extends EsObject {
             );
         }
         return esLocation;
+    }
+
+    public static Map<String, Object> toMap(Location location) {
+        Policy policy = checkNotNull(location.getPolicy());
+        ImmutableList.Builder<Map<String, String>> aliases = ImmutableList.builder();
+
+        policy.getAliases().forEach(alias -> aliases.add(ImmutableMap.of(
+                EsAlias.NAMESPACE, alias.getNamespace(),
+                EsAlias.VALUE, alias.getValue())
+        ));
+
+        return ImmutableMap.of(
+                ALIASES, aliases.build(),
+                AVAILABILITY_END_TIME, policy.getAvailabilityEnd(),
+                AVAILABILITY_TIME, policy.getAvailabilityStart()
+        );
     }
 
 }

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsLocation.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsLocation.java
@@ -80,11 +80,11 @@ public class EsLocation extends EsObject {
         }
 
         if (map.get(ALIASES) != null) {
-                esLocation.aliasesFromEs(
-                        (List<EsAlias>) ((List<Map>)map.get(ALIASES)).stream()
-                                .map(EsAlias::fromMap)
-                                .collect(Collectors.toList())
-                );
+            esLocation.aliasesFromEs(
+                    (List<EsAlias>) ((List<Map>) map.get(ALIASES)).stream()
+                            .map(EsAlias::fromMap)
+                            .collect(Collectors.toList())
+            );
         }
         return esLocation;
     }


### PR DESCRIPTION
New locations were converted to EsObjects and then added to the list
of existing locations which were still Maps. This caused an additional casting conflict.
Instead of mapping the new locations to EsObjects, they are now translated
to maps to be mapped to EsObjects later on with the existing ones.