### PR TITLE
use source writer with ID's

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/system/SourcesModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/SourcesModule.java
@@ -1,14 +1,20 @@
 package org.atlasapi.system;
 
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import org.atlasapi.application.sources.SourceIdCodec;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SourcesModule {
 
+    private final NumberToShortStringCodec idCodec = SubstitutionTableNumberCodec.lowerCaseOnly();
+    private final SourceIdCodec sourceIdCodec = new SourceIdCodec(idCodec);
+
     @Bean
     public SystemSourcesController systemSourcesControllergit () {
-        return SystemSourcesController.create();
+        return SystemSourcesController.create(sourceIdCodec);
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/system/SystemSourcesController.java
+++ b/atlas-api/src/main/java/org/atlasapi/system/SystemSourcesController.java
@@ -1,5 +1,7 @@
 package org.atlasapi.system;
 
+import org.atlasapi.application.sources.SourceIdCodec;
+import org.atlasapi.application.writers.SourceWithIdWriter;
 import org.atlasapi.content.QueryParseException;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.EntityListWriter;
@@ -21,15 +23,16 @@ import java.io.IOException;
 @Controller
 public class SystemSourcesController {
 
-    private final ResponseWriterFactory writerResolver = new ResponseWriterFactory();
-    private final EntityListWriter<Publisher> sourcesWriter = SourceWriter.sourceListWriter("sources");
+    private final ResponseWriterFactory writerResolver;
+    private final EntityListWriter<Publisher> sourcesWriter;
 
-    private SystemSourcesController() {
-
+    private SystemSourcesController(SourceIdCodec sourceIdCodec) {
+        sourcesWriter = new SourceWithIdWriter(sourceIdCodec, "source", "sources");
+        writerResolver = new ResponseWriterFactory();
     }
 
-    public static SystemSourcesController create() {
-        return new SystemSourcesController();
+    public static SystemSourcesController create(SourceIdCodec sourceIdCodec) {
+        return new SystemSourcesController(sourceIdCodec);
     }
 
     @RequestMapping({ "/system/sources/{sid}.*", "/system/sources.*" })


### PR DESCRIPTION
The writer that was being used by /system/sources.json endpoint did not match the one used in  /4/admin/sources.json 