### PR TITLE
Change content debug endpoints to use Jackson

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
@@ -223,7 +223,8 @@ public class ContentDebugController {
                 .resolveIds(ImmutableList.of(Id.valueOf(lowercase.decode(id))));
         Resolved<Content> resolved = Futures.get(resolving, Exception.class);
         Content content = Iterables.getOnlyElement(resolved.getResources());
-        gson.toJson(content, response.getWriter());
+
+        jackson.writeValue(response.getWriter(), content);
     }
 
     /* Returns the JSON representation of a piece of content stored in the Cassandra store */
@@ -238,7 +239,8 @@ public class ContentDebugController {
                 contentStore.resolveIds(ids), 1, TimeUnit.MINUTES, Exception.class
         );
         Content content = result.getResources().first().orNull();
-        gson.toJson(content, response.getWriter());
+
+        jackson.writeValue(response.getWriter(), content);
     }
 
     /* Returns the JSON representation of a piece of content stored in the equivalent content store */


### PR DESCRIPTION
- These were using gson contrary to everything else we have and it
  was not configured to handle Guava optionals so those weren't printed
  correctly