### PR TITLE
Fix/single aggregated broadcast bug

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/channel/Channel.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Channel.java
@@ -179,6 +179,10 @@ public class Channel extends Identified implements Sourced {
         return advertiseFrom;
     }
 
+    public ChannelRef toRef() {
+        return new ChannelRef(getId(), getSource());
+    }
+
     public static Builder builder(Publisher publisher) {
         return new Builder(publisher);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
@@ -85,6 +85,8 @@ public class BroadcastAggregator {
                         dateTime,
                         aggregateBroadcastsInternal(sameTimeBroadcasts)
                 );
+            } else {
+                aggregatedBroadcasts.put(dateTime, Iterables.getOnlyElement(sameTimeBroadcasts));
             }
         }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
@@ -1,5 +1,6 @@
 package org.atlasapi.content;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -102,9 +103,15 @@ public class BroadcastAggregator {
         // Map parent channels to parent
         Multimap<ChannelRef, ResolvedBroadcast> parentChannelMap = broadcasts.stream()
                 .collect(MoreCollectors.toImmutableListMultiMap(
-                        resolvedBroadcast -> resolvedBroadcast.getResolvedChannel()
-                                .getChannel()
-                                .getParent(),
+                        resolvedBroadcast -> MoreObjects.firstNonNull(
+                                resolvedBroadcast.getResolvedChannel()
+                                        .getChannel()
+                                        .getParent(),
+                                new ChannelRef(
+                                        resolvedBroadcast.getResolvedChannel().getChannel().getId(),
+                                        resolvedBroadcast.getResolvedChannel().getChannel().getSource()
+                                )
+                        ),
                         resolvedBroadcast -> resolvedBroadcast
                 ));
 

--- a/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
@@ -107,10 +107,9 @@ public class BroadcastAggregator {
                                 resolvedBroadcast.getResolvedChannel()
                                         .getChannel()
                                         .getParent(),
-                                new ChannelRef(
-                                        resolvedBroadcast.getResolvedChannel().getChannel().getId(),
-                                        resolvedBroadcast.getResolvedChannel().getChannel().getSource()
-                                )
+                                resolvedBroadcast.getResolvedChannel()
+                                        .getChannel()
+                                        .toRef()
                         ),
                         resolvedBroadcast -> resolvedBroadcast
                 ));

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -70,6 +70,10 @@ public class BroadcastAggregatorTest {
 
     }
 
+    public void aggregatedBroadcastUsesOwnChannelIfNoParent() throws Exception {
+        //TODO: write this test
+    }
+
     @Test
     public void singleBroadcastIsReturnedNormally() throws Exception {
 

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
@@ -66,6 +67,36 @@ public class BroadcastAggregatorTest {
 
         includedVariantIds = ImmutableSet.of(Id.valueOf(111L), Id.valueOf(222L), Id.valueOf(333L));
         excludedVariantIds = ImmutableSet.of(Id.valueOf(444L), Id.valueOf(555L));
+
+    }
+
+    @Test
+    public void singleBroadcastIsReturnedNormally() throws Exception {
+
+        Broadcast broadcast = getFutureBroadcast(444L, 1, 2);
+
+        Set<ResolvedBroadcast> resolvedBroadcasts = broadcastAggregator.aggregateBroadcasts(
+                ImmutableSet.of(broadcast),
+                Optional.empty(),
+                ImmutableList.of()
+        );
+
+        assertThat(Iterables.getOnlyElement(resolvedBroadcasts).getBroadcast(), is(broadcast));
+
+    }
+
+    @Test
+    public void broadcastOnSameChannelAtDifferentTimesDoNotAggregate() throws Exception {
+        Broadcast firstBroadcast = getFutureBroadcast(444L, 1, 2);
+        Broadcast secondBroadcast = getFutureBroadcast(444L, 5, 6);
+
+        Set<ResolvedBroadcast> resolvedBroadcasts = broadcastAggregator.aggregateBroadcasts(
+                ImmutableSet.of(firstBroadcast, secondBroadcast),
+                Optional.empty(),
+                ImmutableList.of()
+        );
+
+        assertThat(resolvedBroadcasts.size(), is(2));
 
     }
 


### PR DESCRIPTION
Fixed single broadcasts from being ignored.
Fixed NPE when trying to find parent on a broadcasts channel when it didn't have one.