### PR TITLE
Add filter to reject updates that would result in very large graphs

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphRejectionFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphRejectionFilter.java
@@ -1,0 +1,112 @@
+package org.atlasapi.equivalence;
+
+import org.atlasapi.entity.ResourceRef;
+
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This filter inspects the size of the equivalence graph in the update and decides whether to
+ * allow the update to be persisted or whether to reject it. This is to avoid downstream problems
+ * in the equivalent content and schedule stores that are caused by very large graphs that are the
+ * result of bugs in equivalence.
+ * <p>
+ * This filter has an alerting threshold and a rejection threshold.
+ * <p>
+ * If the graphs are over the alerting threshold it will emit a warning.
+ * <p>
+ * If they are also over the rejection threshold and the biggest graph in the update is bigger than
+ * the biggest existing graph in that set then it will emit a rejection. This is to avoid
+ * rejecting updates on already large graphs that would make them smaller.
+ */
+public class EquivalenceGraphRejectionFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            EquivalenceGraphRejectionFilter.class
+    );
+
+    private static final int GRAPH_SIZE_ALERTING_THRESHOLD = 150;
+    private static final int GRAPH_SIZE_REJECTING_THRESHOLD = 250;
+
+    private EquivalenceGraphRejectionFilter() {
+    }
+
+    public static EquivalenceGraphRejectionFilter create() {
+        return new EquivalenceGraphRejectionFilter();
+    }
+
+    public Decision shouldReject(
+            ResourceRef subject,
+            ImmutableSet<EquivalenceGraph> existingGraphs,
+            EquivalenceGraphUpdate graphUpdate
+    ) {
+        Decision decision = Decision.OK;
+
+        ImmutableList<EquivalenceGraph> graphsOverWarningThreshold = getGraphsOverAlertingThreshold(
+                subject,
+                graphUpdate
+        );
+
+        if (!graphsOverWarningThreshold.isEmpty()) {
+            decision = Decision.WARN;
+        }
+
+        if (shouldReject(existingGraphs, graphUpdate)) {
+            decision = Decision.FAIL;
+        }
+
+        return decision;
+    }
+
+    private ImmutableList<EquivalenceGraph> getGraphsOverAlertingThreshold(
+            ResourceRef subject,
+            EquivalenceGraphUpdate graphUpdate
+    ) {
+        ImmutableList<EquivalenceGraph> graphsOverWarningThreshold = graphUpdate.getAllGraphs()
+                .stream()
+                .filter(graph ->
+                        graph.getAdjacencyList().size() > GRAPH_SIZE_ALERTING_THRESHOLD)
+                .collect(MoreCollectors.toImmutableList());
+
+        graphsOverWarningThreshold
+                .forEach(graph -> log.warn(
+                        "Found large graph with id: {}, size: {}, update subject: {}",
+                        graph.getId().longValue(),
+                        graph.getAdjacencyList().size(),
+                        subject
+                ));
+
+        return graphsOverWarningThreshold;
+    }
+
+    private boolean shouldReject(
+            ImmutableSet<EquivalenceGraph> existingGraphs,
+            EquivalenceGraphUpdate graphUpdate
+    ) {
+        int largestExistingGraph = existingGraphs.stream()
+                .mapToInt(graph -> graph.getAdjacencyList().size())
+                .max()
+                .orElse(0);
+
+        int largestUpdatedGraph = graphUpdate.getAllGraphs()
+                .stream()
+                .mapToInt(graph -> graph.getAdjacencyList().size())
+                .max()
+                .orElse(0);
+
+        // Reject if the largest graph is greater than the threshold and if this update won't make
+        // the largest of the pre-existing graphs smaller
+        return largestUpdatedGraph > GRAPH_SIZE_REJECTING_THRESHOLD
+                && largestUpdatedGraph >= largestExistingGraph;
+    }
+
+    public enum Decision {
+        OK,
+        WARN,
+        FAIL
+    }
+}

--- a/atlas-core/src/test/java/org/atlasapi/equivalence/EquivalenceGraphRejectionFilterTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/equivalence/EquivalenceGraphRejectionFilterTest.java
@@ -1,0 +1,144 @@
+package org.atlasapi.equivalence;
+
+import java.util.stream.IntStream;
+
+import org.atlasapi.content.ItemRef;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class EquivalenceGraphRejectionFilterTest {
+
+    private EquivalenceGraphRejectionFilter rejectionFilter;
+
+    private ResourceRef subject;
+
+    @Before
+    public void setUp() throws Exception {
+        rejectionFilter = EquivalenceGraphRejectionFilter.create();
+
+        subject = new ItemRef(
+                Id.valueOf(0L),
+                Publisher.METABROADCAST,
+                "",
+                DateTime.now()
+        );
+    }
+
+    @Test
+    public void returnOkForUpdateWithGraphsSmallerThanAlertingThreshold() throws Exception {
+        EquivalenceGraphRejectionFilter.Decision decision = rejectionFilter.shouldReject(
+                subject,
+                ImmutableSet.of(),
+                EquivalenceGraphUpdate
+                        .builder(getGraphOfSize(50))
+                        .build()
+        );
+
+        assertThat(decision, is(EquivalenceGraphRejectionFilter.Decision.OK));
+    }
+
+    @Test
+    public void returnOkForUpdateWithGraphsSmallerThanAlertingThresholdIfExistingAreLarge()
+            throws Exception {
+        EquivalenceGraphRejectionFilter.Decision decision = rejectionFilter.shouldReject(
+                subject,
+                ImmutableSet.of(getGraphOfSize(500)),
+                EquivalenceGraphUpdate
+                        .builder(getGraphOfSize(50))
+                        .build()
+        );
+
+        assertThat(decision, is(EquivalenceGraphRejectionFilter.Decision.OK));
+    }
+
+    @Test
+    public void returnWarnForUpdateWithGraphsOverTheWarningThresholdButUnderRejectThreshold()
+            throws Exception {
+        EquivalenceGraphRejectionFilter.Decision decision = rejectionFilter.shouldReject(
+                subject,
+                ImmutableSet.of(),
+                EquivalenceGraphUpdate
+                        .builder(getGraphOfSize(50))
+                        .withCreated(ImmutableSet.of(getGraphOfSize(200)))
+                        .build()
+        );
+
+        assertThat(decision, is(EquivalenceGraphRejectionFilter.Decision.WARN));
+    }
+
+    @Test
+    public void returnFailForUpdateWithGraphsOverTheRejectThresholdThatHaveGrown()
+            throws Exception {
+        EquivalenceGraphRejectionFilter.Decision decision = rejectionFilter.shouldReject(
+                subject,
+                ImmutableSet.of(getGraphOfSize(100)),
+                EquivalenceGraphUpdate
+                        .builder(getGraphOfSize(50))
+                        .withCreated(ImmutableSet.of(getGraphOfSize(300)))
+                        .build()
+        );
+
+        assertThat(decision, is(EquivalenceGraphRejectionFilter.Decision.FAIL));
+    }
+
+    @Test
+    public void returnWarnForUpdateWithGraphsOverTheRejectThresholdThatHaveShrunk()
+            throws Exception {
+        EquivalenceGraphRejectionFilter.Decision decision = rejectionFilter.shouldReject(
+                subject,
+                ImmutableSet.of(getGraphOfSize(301)),
+                EquivalenceGraphUpdate
+                        .builder(getGraphOfSize(50))
+                        .withCreated(ImmutableSet.of(getGraphOfSize(300)))
+                        .build()
+        );
+
+        assertThat(decision, is(EquivalenceGraphRejectionFilter.Decision.WARN));
+    }
+
+    private EquivalenceGraph getGraphOfSize(int size) {
+        ResourceRef entryPoint = new ItemRef(
+                Id.valueOf(0L),
+                Publisher.METABROADCAST,
+                "",
+                DateTime.now()
+        );
+
+        ImmutableSet<ResourceRef> refs = IntStream.range(1, size)
+                .mapToObj(index -> new ItemRef(
+                        Id.valueOf(index),
+                        Publisher.METABROADCAST,
+                        "",
+                        DateTime.now()
+                ))
+                .collect(MoreCollectors.toImmutableSet());
+
+        EquivalenceGraph.Adjacents entryPointAdjacent = EquivalenceGraph.Adjacents
+                .valueOf(entryPoint)
+                .copyWithOutgoing(ImmutableSet.<ResourceRef>builder()
+                        .add(entryPoint)
+                        .addAll(refs)
+                        .build());
+
+        ImmutableSet<EquivalenceGraph.Adjacents> adjacents = refs.stream()
+                .map(EquivalenceGraph.Adjacents::valueOf)
+                .map(adjacent -> adjacent.copyWithIncoming(entryPoint))
+                .collect(MoreCollectors.toImmutableSet());
+
+        return EquivalenceGraph.valueOf(ImmutableSet.<EquivalenceGraph.Adjacents>builder()
+                .add(entryPointAdjacent)
+                .addAll(adjacents)
+                .build());
+    }
+}


### PR DESCRIPTION
- These graphs are the result of bugs in equivalence and they cause
  significant problems in the downstream equivalent content and
  schedule stores. This prevents these graphs from being generated in
  Deer and also adds monitoring so we can have visibility when this
  happens