### PR TITLE
Fix missing publisher on some RT reviews

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ReviewsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ReviewsAnnotation.java
@@ -1,10 +1,17 @@
 package org.atlasapi.output.annotation;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.content.Content;
 import org.atlasapi.entity.Review;
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.EntityListWriter;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
@@ -21,6 +28,30 @@ public class ReviewsAnnotation extends OutputAnnotation<Content> {
 
     @Override
     public void write(Content entity, FieldWriter writer, OutputContext ctxt) throws IOException {
-        writer.writeList(reviewsWriter, entity.getReviews(), ctxt);
+        writer.writeList(
+                reviewsWriter,
+                populateMissingReviewSources(entity.getReviews(), entity.getSource()),
+                ctxt
+        );
+    }
+
+    Iterable<Review> populateMissingReviewSources(Set<Review> reviews, Publisher publisher) {
+
+        return reviews.stream()
+                .map(review -> {
+                    if (!review.getSource().isPresent()) {
+                        return Review.builder(review.getReview())
+                                .withLocale(review.getLocale())
+                                .withDate(review.getDate())
+                                .withAuthorInitials(review.getAuthorInitials())
+                                .withAuthor(review.getAuthor())
+                                .withRating(review.getRating())
+                                .withReviewType(review.getReviewType())
+                                .withSource(Optional.of(publisher))
+                                .build();
+                    }
+                    return review;
+                })
+                .collect(MoreCollectors.toImmutableSet());
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/writers/ReviewsWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/ReviewsWriter.java
@@ -49,6 +49,9 @@ public class ReviewsWriter implements EntityListWriter<Review> {
         writer.writeField("date", entity.getDate());
         writer.writeField("review_type", reviewType);
 
-        writer.writeObject(sourceWriter, entity.getSource().orElse(null), ctxt);
+        Optional<Publisher> source = entity.getSource();
+        if (source.isPresent()) {
+            writer.writeObject(sourceWriter, source.get(), ctxt);
+        }
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/writers/ReviewsWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/writers/ReviewsWriter.java
@@ -49,9 +49,6 @@ public class ReviewsWriter implements EntityListWriter<Review> {
         writer.writeField("date", entity.getDate());
         writer.writeField("review_type", reviewType);
 
-        Optional<Publisher> source = entity.getSource();
-        if (source.isPresent()) {
-            writer.writeObject(sourceWriter, source.get(), ctxt);
-        }
+        writer.writeObject(sourceWriter, entity.getSource().orElse(null), ctxt);
     }
 }

--- a/atlas-api/src/test/java/org/atlasapi/output/annotation/ReviewsAnnotationTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/annotation/ReviewsAnnotationTest.java
@@ -1,0 +1,72 @@
+package org.atlasapi.output.annotation;
+
+import com.google.common.collect.ImmutableSet;
+import org.atlasapi.content.Content;
+import org.atlasapi.content.Film;
+import org.atlasapi.entity.Review;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.output.EntityListWriter;
+import org.atlasapi.output.EntityWriter;
+import org.atlasapi.output.writers.ReviewsWriter;
+import org.atlasapi.output.writers.SourceWriter;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReviewsAnnotationTest {
+
+    private Content content;
+    private ReviewsAnnotation reviewsAnnotation;
+
+    @Before
+    public void setUp() {
+        content = mock(Film.class);
+
+        EntityWriter<Publisher> publisherWriter = SourceWriter.sourceWriter("source");
+        EntityListWriter<Review> reviewWriter = new ReviewsWriter(publisherWriter);
+        reviewsAnnotation = new ReviewsAnnotation(reviewWriter);
+
+        when(content.getReviews()).thenReturn(populateReviews());
+        when(content.getSource()).thenReturn(Publisher.RADIO_TIMES);
+
+    }
+
+    @Test
+    public void missingSourcesAreAddedToReviews() throws Exception {
+        Iterable<Review> actualReviews = reviewsAnnotation.populateMissingReviewSources(
+                content.getReviews(),
+                content.getSource()
+        );
+
+        for (Review review : actualReviews) {
+            assertTrue(review.getSource().isPresent());
+
+            if (review.getReview().equals("No publisher")) {
+                assertThat(review.getSource().get(), is(content.getSource()));
+            } else {
+                assertThat(review.getSource().get(), is(Publisher.BBC));
+            }
+        }
+    }
+
+    private Set<Review> populateReviews() {
+        return ImmutableSet.of(
+                Review.builder("No publisher").build(),
+                Review.builder("Has publisher")
+                        .withSource(Optional.of(Publisher.BBC))
+                        .build(),
+                Review.builder("No publisher").build(),
+                Review.builder("Has publisher")
+                        .withSource(Optional.of(Publisher.BBC))
+                        .build()
+        );
+    }
+}

--- a/atlas-api/src/test/java/org/atlasapi/output/annotation/ReviewsAnnotationTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/annotation/ReviewsAnnotationTest.java
@@ -40,7 +40,7 @@ public class ReviewsAnnotationTest {
     }
 
     @Test
-    public void missingSourcesAreAddedToReviews() throws Exception {
+    public void missingSourcesAreAddedToReviewsFromContent() throws Exception {
         Iterable<Review> actualReviews = reviewsAnnotation.populateMissingReviewSources(
                 content.getReviews(),
                 content.getSource()


### PR DESCRIPTION
If content was removed from the feed, it will not have a source
as that field is now passed through from the ingester rather than
being populated in Deer. This defaults the publisher to match the
content publisher in the case where it is absent.