### PR TITLE
Filter channels not on platform when provided

### DIFF
--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -262,11 +262,6 @@ public class BroadcastAggregatorTest {
     }
 
     @Test
-    public void aggregatedBroadcastDoesNotHaveExcludedVariantsFromAnotherPlatform() throws Exception {
-
-    }
-
-    @Test
     public void childTitlesAreParsedCorrectlyFromParent() throws Exception {
         String parent = "BBC One";
 

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -225,7 +225,7 @@ public class BroadcastAggregatorTest {
     }
 
     @Test
-    public void GetsAllExcludedVariantRefsWithNoPlatform() throws Exception {
+    public void getsAllExcludedVariantRefsWithNoPlatform() throws Exception {
 
         List<ChannelVariantRef> excludedRefs = broadcastAggregator.resolveExcludedVariantRefs(
                 variantRefParent,

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -225,20 +225,45 @@ public class BroadcastAggregatorTest {
     }
 
     @Test
-    public void onlyGetsAllExcludedVariantRefs() throws Exception {
+    public void GetsAllExcludedVariantRefsWithNoPlatform() throws Exception {
 
         List<ChannelVariantRef> excludedRefs = broadcastAggregator.resolveExcludedVariantRefs(
                 variantRefParent,
-                includedVariantIds
+                includedVariantIds,
+                Optional.empty()
         );
 
         assertThat(excludedRefs.size(), is(2));
-        assertThat(
+        assertTrue(
                 excludedRefs.stream().allMatch(channelVariantRef ->
                         excludedVariantIds.contains(channelVariantRef.getId())
-                ),
-                is(true)
+                )
         );
+    }
+
+    @Test
+    public void onlyGetsExcludedVariantRefsFromPlatformWhenProvided() throws Exception {
+
+        Platform platform = mock(Platform.class);
+        ChannelNumbering channelNumbering = mock(ChannelNumbering.class);
+        ChannelRef channelRef = new ChannelRef(Id.valueOf(444L), Publisher.METABROADCAST);
+
+        when(channelNumbering.getChannel()).thenReturn(channelRef);
+        when(platform.getChannels()).thenReturn(ImmutableList.of(channelNumbering));
+
+        List<ChannelVariantRef> excludedRefs = broadcastAggregator.resolveExcludedVariantRefs(
+                variantRefParent,
+                includedVariantIds,
+                Optional.of(platform)
+        );
+
+        assertThat(excludedRefs.size(), is(1));
+        assertThat(excludedRefs.get(0).getId(), is(channelRef.getId()));
+    }
+
+    @Test
+    public void aggregatedBroadcastDoesNotHaveExcludedVariantsFromAnotherPlatform() throws Exception {
+
     }
 
     @Test


### PR DESCRIPTION
Previously, channels not on the platform were being included in the
excluded variants list which was undesired behaviour. Now, only channels
that are on the platform will be included in the excluded variant list of the parent.