### PR TITLE
Add legacy content resolver to bootstrap controller

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapController.java
@@ -105,6 +105,7 @@ public class ContentBootstrapController {
                 .withContentWriter(builder.write)
                 .withEquivalenceMigrator(builder.equivalenceMigrator)
                 .withEquivalentContentStore(builder.equivalentContentStore)
+                .withSegmentMigratorAndContentResolver(null, legacyResolver)
                 .withContentIndex(contentIndex)
                 .build();
 
@@ -112,6 +113,7 @@ public class ContentBootstrapController {
                 .withContentWriter(builder.write)
                 .withEquivalenceMigrator(builder.equivalenceMigrator)
                 .withEquivalentContentStore(builder.equivalentContentStore)
+                .withSegmentMigratorAndContentResolver(null, legacyResolver)
                 .withContentIndex(contentIndex)
                 .withMigrateEquivalents(builder.equivalenceGraphStore)
                 .build();

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
@@ -364,21 +364,13 @@ public class ContentBootstrapListener
     }
 
     private Content resolveLegacyContent(Id id) {
-        try {
-            Content content = Iterables.getOnlyElement(
-                    Futures.getUnchecked(
-                            legacyContentResolver.resolveIds(
-                                    ImmutableList.of(id)
-                            )
-                    ).getResources()
-            );
-
-            return content;
-
-        } catch (NullPointerException e) {
-            log.error("Failed to resolve legacy content: {}", id, e);
-            throw new RuntimeException(e);
-        }
+        return Iterables.getOnlyElement(
+                Futures.getUnchecked(
+                        legacyContentResolver.resolveIds(
+                                ImmutableList.of(id)
+                        )
+                ).getResources()
+        );
     }
 
     private void logResult(Id id, Result result) {


### PR DESCRIPTION
Missing the content resolver was causing failures to migrate as
part of the process is resolving the content from owl to call migrates
on children of the currently migrating item.