### PR TITLE
extract executor config for telescope

### DIFF
--- a/atlas-processing/Dockerfile
+++ b/atlas-processing/Dockerfile
@@ -111,6 +111,9 @@ CMD java \
     -Dredux.password="$REDUX_PASSWORD" \
     -Dredux.username="$REDUX_USERNAME" \
     -Dreporting.columbus-telescope.host="$REPORTING_COLUMBUS_TELESCOPE_HOST" \
+    -Dreporting.columbus-telescope.thread.capacity: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_CAPACITY" \
+    -Dreporting.columbus-telescope.thread.pool.size: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE" \
+    -Dreporting.columbus-telescope.thread.pool.size.max: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE_MAX" \
     -Drp.password.unique="$RP_PASSWORD_UNIQUE" \
     -Ds3.access="$S3_ACCESS" \
     -Ds3.secret="$S3_SECRET" \

--- a/atlas-processing/Dockerfile
+++ b/atlas-processing/Dockerfile
@@ -111,9 +111,9 @@ CMD java \
     -Dredux.password="$REDUX_PASSWORD" \
     -Dredux.username="$REDUX_USERNAME" \
     -Dreporting.columbus-telescope.host="$REPORTING_COLUMBUS_TELESCOPE_HOST" \
-    -Dreporting.columbus-telescope.thread.capacity: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_CAPACITY" \
-    -Dreporting.columbus-telescope.thread.pool.size: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE" \
-    -Dreporting.columbus-telescope.thread.pool.size.max: "$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE_MAX" \
+    -Dreporting.columbus-telescope.thread.capacity="$REPORTING_COLUMBUS_TELESCOPE_THREAD_CAPACITY" \
+    -Dreporting.columbus-telescope.thread.pool.size="$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE" \
+    -Dreporting.columbus-telescope.thread.pool.size.max="$REPORTING_COLUMBUS_TELESCOPE_THREAD_POOL_SIZE_MAX" \
     -Drp.password.unique="$RP_PASSWORD_UNIQUE" \
     -Ds3.access="$S3_ACCESS" \
     -Ds3.secret="$S3_SECRET" \


### PR DESCRIPTION
Thread pool is reaching its limit and throwing runtime exceptions rejecting items from the queue. Config has been extracted for easier tuning.
Also removed known usages of deprecated telescope constructor.