### PR TITLE
Filter item summaries

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -6,8 +6,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -3,7 +3,10 @@ package org.atlasapi.content;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;
@@ -292,12 +295,14 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
             );
         }
 
-        builder.addAllItemSummaries(
-                Iterables.transform(
-                        container.getItemSummaries(),
-                        is -> itemSummarySerializer.serialize(is).build()
-                )
-        );
+        if (container.getItemSummaries() != null) {
+            builder.addAllItemSummaries(
+                    container.getItemSummaries().stream()
+                            .filter(is -> !Strings.isNullOrEmpty(is.getTitle()))    // Summaries without titles cannot be serialized
+                            .map(is -> itemSummarySerializer.serialize(is).build()) // which causes the brand to fail to update.
+                            .collect(Collectors.toList())
+            );
+        }
 
         if (container.getCertificates() != null) {
             builder.addAllCertificates(container.getCertificates().stream()


### PR DESCRIPTION
Trying to serialize a brand that contains an ItemSummary without a title causes throws
an exception which interrupts the update of the Brand. This change is intended to log
the offending ItemSummary ID and allow the process to continue without it.
