### PR TITLE
Filter item summaries

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -329,7 +329,11 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
         try {
             return itemSummarySerializer.serialize(itemSummary).build();
         } catch (Exception e) {
-            log.error("Failed to serialize ItemSummary: {}", itemSummary.getItemRef().getId(), e);
+            log.error(
+                    "Failed to serialize ItemSummary: {}",
+                    itemSummary.getItemRef().getId(),
+                    e.getMessage()
+            );
             return null;
         }
     }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -6,8 +6,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -3,7 +3,10 @@ package org.atlasapi.content;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;
@@ -292,12 +295,14 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
             );
         }
 
-        builder.addAllItemSummaries(
-                Iterables.transform(
-                        container.getItemSummaries(),
-                        is -> itemSummarySerializer.serialize(is).build()
-                )
-        );
+        if (container.getItemSummaries() != null) {
+            builder.addAllItemSummaries(
+                    container.getItemSummaries().stream()
+                            .filter(is -> !Strings.isNullOrEmpty(is.getTitle()))    // Summaries without titles cannot be serialized
+                            .map(is -> itemSummarySerializer.serialize(is).build()) // which causes the brand to fail to update.
+                            .collect(Collectors.toList())
+            );
+        }
 
         if (container.getCertificates() != null) {
             builder.addAllCertificates(container.getCertificates().stream()

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.base.MoreObjects;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;
@@ -28,6 +29,9 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
 
 public final class ContentSerializationVisitor implements ContentVisitor<Builder> {
 
@@ -301,14 +305,7 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
         if (container.getItemSummaries() != null) {
             builder.addAllItemSummaries(
                     container.getItemSummaries().stream()
-                            .map(is -> {
-                                try {
-                                    return itemSummarySerializer.serialize(is).build();
-                                } catch (Exception e) {
-                                    log.error("ItemSummary without title: {}", is.getItemRef().getId(), e);
-                                    return null;
-                                }
-                            })
+                            .map(this::serializeItemSummary)
                             .filter(Objects::nonNull)
                             .collect(Collectors.toList())
             );
@@ -325,6 +322,16 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
         }
 
         return builder;
+    }
+
+    @Nullable
+    private ContentProtos.ItemSummary serializeItemSummary(ItemSummary itemSummary) {
+        try {
+            return itemSummarySerializer.serialize(itemSummary).build();
+        } catch (Exception e) {
+            log.error("Failed to serialize ItemSummary: {}", itemSummary.getItemRef().getId(), e);
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Trying to serialize a brand that contains an ItemSummary without a title cases throws
an exception which interrupts the update of the Brand. This change is intended to log
the offending ItemSummary ID and allow the process to continue without it.