### PR TITLE
Merging bug

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/content/Described.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Described.java
@@ -32,6 +32,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.joda.time.DateTime;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Optional.ofNullable;
+
 public abstract class Described extends Identified implements Sourced {
 
     private String title;
@@ -346,8 +349,45 @@ public abstract class Described extends Identified implements Sourced {
         return to;
     }
 
+
+    /**
+     * Same as above except would prefer any value over nulls when copying
+     * Needed in the case of barb overrides as they overwrite their equivs
+     * data with nulls.
+     */
+    public static Described copyToPreferNonNulls(Described from, Described to) {
+        Identified.copyToPreferNonNull(from, to);
+        to.description = isNullOrEmpty(from.description) ? to.description : from.description;
+        to.firstSeen = ofNullable(from.firstSeen).orElse(to.firstSeen);
+        to.genres = from.genres.isEmpty() ? to.genres : ImmutableSet.copyOf(from.genres);
+        to.image = isNullOrEmpty(from.image) ? to.image : from.image;
+        to.lastFetched = ofNullable(from.lastFetched).orElse(to.lastFetched);
+        to.mediaType = ofNullable(from.mediaType).orElse(to.mediaType);
+        to.publisher = ofNullable(from.publisher).orElse(to.publisher);
+        to.specialization = ofNullable(from.specialization).orElse(to.specialization);
+        to.thisOrChildLastUpdated = ofNullable(from.thisOrChildLastUpdated).orElse(to.thisOrChildLastUpdated);
+        to.thumbnail = isNullOrEmpty(from.thumbnail) ? to.thumbnail : from.thumbnail;
+        to.title = isNullOrEmpty(from.title) ? to.title : from.title;
+        to.scheduleOnly = from.scheduleOnly;
+        to.presentationChannel = isNullOrEmpty(from.presentationChannel) ? to.presentationChannel : from.presentationChannel;
+        to.images = from.images.isEmpty() ? to.images : from.images;
+        to.shortDescription = isNullOrEmpty(from.shortDescription) ? to.shortDescription : from.shortDescription;
+        to.mediumDescription = isNullOrEmpty(from.mediumDescription) ? to.mediumDescription : from.mediumDescription;
+        to.longDescription = isNullOrEmpty(from.longDescription) ? to.longDescription : from.longDescription;
+        to.activelyPublished = from.activelyPublished;
+        to.reviews = from.reviews.isEmpty() ? to.reviews : from.reviews;
+        to.ratings = from.ratings.isEmpty() ? to.ratings : from.ratings;
+        to.awards = from.awards.isEmpty() ? to.awards : from.awards;
+        return to;
+    }
+
     public <T extends Described> T copyTo(T to) {
         copyTo(this, to);
+        return to;
+    }
+
+    public <T extends Described> T copyToPreferNonNulls(T to) {
+        copyToPreferNonNulls(this, to);
         return to;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
@@ -21,6 +21,8 @@ import com.google.common.primitives.Ints;
 import org.joda.time.DateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Optional.ofNullable;
 
 /**
  * Base type for descriptions of resources.
@@ -243,6 +245,22 @@ public class Identified implements Identifiable, Aliased {
         to.equivalentTo = Sets.newHashSet(from.equivalentTo);
         to.lastUpdated = from.lastUpdated;
         to.equivalenceUpdate = from.equivalenceUpdate;
+    }
+
+    /**
+     * Same as above except would prefer any value over nulls when copying
+     * Needed in the case of barb overrides as they overwrite their equivs
+     * data with nulls.
+     */
+    public static void copyToPreferNonNull(Identified from, Identified to) {
+        to.id = ofNullable(from.id).orElse(to.id);
+        to.canonicalUri = isNullOrEmpty(from.canonicalUri) ? to.canonicalUri : from.canonicalUri;
+        to.curie = isNullOrEmpty(from.curie) ? to.curie : from.curie;
+        to.aliasUrls = from.aliasUrls.isEmpty() ? to.aliasUrls : ImmutableSet.copyOf(from.aliasUrls);
+        to.aliases = from.aliases.isEmpty() ? to.aliases : ImmutableSet.copyOf(from.aliases);
+        to.equivalentTo = from.equivalentTo.isEmpty() ? to.equivalentTo : Sets.newHashSet(from.equivalentTo);
+        to.lastUpdated = ofNullable(from.lastUpdated).orElse(to.lastUpdated);
+        to.equivalenceUpdate = ofNullable(from.equivalenceUpdate).orElse(to.lastUpdated);
     }
 
     public static <T extends Identified> List<T> sort(List<T> content,

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -175,7 +175,8 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             }
         }
         // But then we need as many settings as possible from the most precedent source.
-        chosen.copyTo(best);
+        // But without overwriting with nulls
+        chosen.copyToPreferNonNulls(best);
         return best;
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/debug/ContentDebugController.java
@@ -402,7 +402,7 @@ public class ContentDebugController {
 
     private void migrateContentById(
             boolean migrateEquivalents,
-            boolean migrateHierachy,
+            boolean migrateHierarchy,
             HttpServletResponse response,
             String id
     ) throws IOException {
@@ -412,11 +412,11 @@ public class ContentDebugController {
             Content content = resolveLegacyContent(decodedId);
 
             ContentBootstrapListener listener;
-            if(migrateEquivalents && migrateHierachy){
+            if(migrateEquivalents && migrateHierarchy){
                 listener = contentEquivAndHierarchyBootstrapListener;
             } else if(migrateEquivalents){
                 listener = contentAndEquivBootstrapListener;
-            } else if(migrateHierachy){
+            } else if(migrateHierarchy){
                 listener = contentAndHierarchyBootstrapListener;
             } else {
                 listener = contentBootstrapListener;


### PR DESCRIPTION
Barb overrides were copying all their nulls over to a less precedenced equiv item before the merging logic had a chance to decide what fields should go where. This still copies over the data but prefers non null fields during the process