### PR TITLE
Added customFields field

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/generation/generated/model/IdentifiedInfo.java
+++ b/atlas-api/src/main/java/org/atlasapi/generation/generated/model/IdentifiedInfo.java
@@ -1,13 +1,12 @@
 package org.atlasapi.generation.generated.model;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.entity.Identified;
 import org.atlasapi.generation.model.FieldInfo;
 import org.atlasapi.generation.model.JsonType;
 import org.atlasapi.generation.model.ModelClassInfo;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 
 public class IdentifiedInfo implements ModelClassInfo {
 
@@ -170,6 +169,16 @@ public class IdentifiedInfo implements ModelClassInfo {
                             .withIsMultiple(false)
                             .withIsModelType(false)
                             .withJsonType(JsonType.STRING)
+                            .build()
+            )
+            .add(
+                    FieldInfo.builder()
+                            .withName("custom_fields")
+                            .withDescription("")
+                            .withType("<String, String>")
+                            .withIsMultiple(true)
+                            .withIsModelType(false)
+                            .withJsonType(JsonType.MAP)
                             .build()
             )
             .build();

--- a/atlas-api/src/main/java/org/atlasapi/generation/model/JsonType.java
+++ b/atlas-api/src/main/java/org/atlasapi/generation/model/JsonType.java
@@ -8,7 +8,9 @@ public enum JsonType {
     STRING("String"),
     BOOLEAN("Boolean"),
     ARRAY("Array"),
-    OBJECT("Object"),;
+    OBJECT("Object"),
+    MAP("Map")
+    ;
 
     private final String value;
 

--- a/atlas-api/src/main/java/org/atlasapi/output/FieldWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/FieldWriter.java
@@ -1,9 +1,9 @@
 package org.atlasapi.output;
 
-import java.io.IOException;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * <p>In a certain format, a FieldWriter writes a value in a particular named field either directly
@@ -75,5 +75,15 @@ public interface FieldWriter {
      */
     <T> void writeList(EntityListWriter<? super T> listWriter,
             Iterable<T> list, OutputContext ctxt) throws IOException;
+
+    /**
+     * <p>Writes a map of values to a single field.</p>
+     *
+     * @param field  - the field name to use
+     * @param map    - the map of values
+     * @param ctxt   - the context of the write
+     * @throws IOException if the field cannot be written
+     */
+    <K, V> void writeMap(String field, Map<K, V> map, OutputContext ctxt) throws IOException;
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/CustomFieldsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/CustomFieldsAnnotation.java
@@ -11,7 +11,7 @@ public class CustomFieldsAnnotation extends OutputAnnotation<Identified> {
     @Override
     public void write(Identified entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        writer.writeField("custom_fields", entity.getCustomFields());
+        writer.writeMap("custom_fields", entity.getCustomFields(), ctxt);
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/CustomFieldsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/CustomFieldsAnnotation.java
@@ -1,0 +1,17 @@
+package org.atlasapi.output.annotation;
+
+import org.atlasapi.entity.Identified;
+import org.atlasapi.output.FieldWriter;
+import org.atlasapi.output.OutputContext;
+
+import java.io.IOException;
+
+public class CustomFieldsAnnotation extends OutputAnnotation<Identified> {
+
+    @Override
+    public void write(Identified entity, FieldWriter writer, OutputContext ctxt)
+            throws IOException {
+        writer.writeField("custom_fields", entity.getCustomFields());
+    }
+
+}

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -53,6 +53,7 @@ import org.atlasapi.output.annotation.ClipsAnnotation;
 import org.atlasapi.output.annotation.ContainerSummaryAnnotation;
 import org.atlasapi.output.annotation.ContentDescriptionAnnotation;
 import org.atlasapi.output.annotation.CurrentAndFutureBroadcastsAnnotation;
+import org.atlasapi.output.annotation.CustomFieldsAnnotation;
 import org.atlasapi.output.annotation.DescriptionAnnotation;
 import org.atlasapi.output.annotation.EndpointInfoAnnotation;
 import org.atlasapi.output.annotation.EventAnnotation;
@@ -199,6 +200,7 @@ import static org.atlasapi.annotation.Annotation.CLIPS;
 import static org.atlasapi.annotation.Annotation.CONTENT_DETAIL;
 import static org.atlasapi.annotation.Annotation.CONTENT_SUMMARY;
 import static org.atlasapi.annotation.Annotation.CURRENT_AND_FUTURE_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.CUSTOM_FIELDS;
 import static org.atlasapi.annotation.Annotation.DESCRIPTION;
 import static org.atlasapi.annotation.Annotation.EVENT;
 import static org.atlasapi.annotation.Annotation.EVENT_DETAILS;
@@ -1189,6 +1191,7 @@ public class QueryWebModule {
                         new RatingsWriter(SourceWriter.sourceWriter("source")))
                 )
                 .register(MODIFIED_DATES, new ModifiedDatesAnnotation())
+                .register(CUSTOM_FIELDS, new CustomFieldsAnnotation())
                 .build();
     }
 

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
@@ -1,9 +1,11 @@
 package org.atlasapi.content;
 
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Ordering;
+import com.metabroadcast.common.intl.Countries;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
@@ -23,14 +25,12 @@ import org.atlasapi.serialization.protobuf.ContentProtos;
 import org.atlasapi.serialization.protobuf.ContentProtos.Subtitle;
 import org.atlasapi.serialization.protobuf.ContentProtos.Synopsis;
 import org.atlasapi.source.Sources;
-
-import com.metabroadcast.common.intl.Countries;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
-import com.google.common.collect.Ordering;
 import org.joda.time.Duration;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_AGGREGATED_BROADCASTS;
@@ -124,6 +124,12 @@ final class ContentDeserializationVisitor implements ContentVisitor<Content> {
             ));
         }
         identified.setEquivalentTo(equivRefs.build());
+
+        Map<String, String> customFields = Maps.newHashMap();
+        for (CommonProtos.CustomFieldEntry customFieldEntry : msg.getCustomFieldsList()) {
+            customFields.put(customFieldEntry.getKey(), customFieldEntry.getValue());
+        }
+        identified.setCustomFields(customFields);
         return identified;
     }
 

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentSerializationVisitor.java
@@ -1,12 +1,8 @@
 package org.atlasapi.content;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import com.google.common.base.MoreObjects;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Award;
 import org.atlasapi.entity.AwardSerializer;
@@ -22,16 +18,15 @@ import org.atlasapi.segment.SegmentEvent;
 import org.atlasapi.serialization.protobuf.CommonProtos;
 import org.atlasapi.serialization.protobuf.ContentProtos;
 import org.atlasapi.serialization.protobuf.ContentProtos.Content.Builder;
-
-import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class ContentSerializationVisitor implements ContentVisitor<Builder> {
 
@@ -81,6 +76,14 @@ public final class ContentSerializationVisitor implements ContentVisitor<Builder
             builder.addEquivs(CommonProtos.Reference.newBuilder()
                     .setId(equivRef.getId().longValue())
                     .setSource(equivRef.getSource().key())
+            );
+        }
+        for (Map.Entry<String, String> customFieldEntry : ided.getCustomFields().entrySet()) {
+            builder.addCustomFields(
+                    CommonProtos.CustomFieldEntry.newBuilder()
+                            .setKey(customFieldEntry.getKey())
+                            .setValue(customFieldEntry.getValue())
+                            .build()
             );
         }
         return builder;

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Clip.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Clip.java
@@ -1,9 +1,9 @@
 package org.atlasapi.content.v2.model;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.content.v2.model.udt.Alias;
 import org.atlasapi.content.v2.model.udt.Award;
 import org.atlasapi.content.v2.model.udt.Broadcast;
@@ -25,13 +25,11 @@ import org.atlasapi.content.v2.model.udt.SegmentEvent;
 import org.atlasapi.content.v2.model.udt.Synopses;
 import org.atlasapi.content.v2.model.udt.Tag;
 import org.atlasapi.content.v2.model.udt.UpdateTimes;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.Instant;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Clip implements ContentIface {
 
@@ -88,6 +86,7 @@ public class Clip implements ContentIface {
     private Set<Review> reviews;
     private Set<Rating> ratings;
     private Encoding.Wrapper encodings;
+    private Map<String, String> customFields;
 
     public Long getId() {
         return id;
@@ -541,6 +540,16 @@ public class Clip implements ContentIface {
 
     public void setClipOf(String clipOf) {
         this.clipOf = clipOf;
+    }
+
+    @Override
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    @Override
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 
     public static class Wrapper {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Content.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Content.java
@@ -1,9 +1,11 @@
 package org.atlasapi.content.v2.model;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Frozen;
+import com.datastax.driver.mapping.annotations.FrozenKey;
+import com.datastax.driver.mapping.annotations.FrozenValue;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
 import org.atlasapi.content.v2.model.udt.Alias;
 import org.atlasapi.content.v2.model.udt.Award;
 import org.atlasapi.content.v2.model.udt.Broadcast;
@@ -14,11 +16,11 @@ import org.atlasapi.content.v2.model.udt.ContentGroupRef;
 import org.atlasapi.content.v2.model.udt.CrewMember;
 import org.atlasapi.content.v2.model.udt.Image;
 import org.atlasapi.content.v2.model.udt.Interval;
-import org.atlasapi.content.v2.model.udt.PartialItemRef;
 import org.atlasapi.content.v2.model.udt.ItemRefAndBroadcastRefs;
 import org.atlasapi.content.v2.model.udt.ItemRefAndItemSummary;
 import org.atlasapi.content.v2.model.udt.ItemRefAndLocationSummaries;
 import org.atlasapi.content.v2.model.udt.KeyPhrase;
+import org.atlasapi.content.v2.model.udt.PartialItemRef;
 import org.atlasapi.content.v2.model.udt.Priority;
 import org.atlasapi.content.v2.model.udt.Rating;
 import org.atlasapi.content.v2.model.udt.Ref;
@@ -31,14 +33,11 @@ import org.atlasapi.content.v2.model.udt.SeriesRef;
 import org.atlasapi.content.v2.model.udt.Synopses;
 import org.atlasapi.content.v2.model.udt.Tag;
 import org.atlasapi.content.v2.model.udt.UpdateTimes;
-
-import com.datastax.driver.mapping.annotations.Column;
-import com.datastax.driver.mapping.annotations.Frozen;
-import com.datastax.driver.mapping.annotations.FrozenKey;
-import com.datastax.driver.mapping.annotations.FrozenValue;
-import com.datastax.driver.mapping.annotations.PartitionKey;
-import com.datastax.driver.mapping.annotations.Table;
 import org.joda.time.Instant;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Table(name = "content_v2")
 public class Content implements ContentIface {
@@ -285,6 +284,9 @@ public class Content implements ContentIface {
 
     @Column(name = "encodings")
     private Encoding.Wrapper encodings;
+
+    @Column(name = "custom_fields")
+    private Map<String, String> customFields;
 
     @Override
     public Long getId() {
@@ -722,6 +724,16 @@ public class Content implements ContentIface {
     @Override
     public void setEncodings(Encoding.Wrapper encodings) {
         this.encodings = encodings;
+    }
+
+    @Override
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    @Override
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 
     public String getIsrc() {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Encoding.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/Encoding.java
@@ -1,14 +1,14 @@
 package org.atlasapi.content.v2.model;
 
-import java.util.Set;
-
-import org.atlasapi.content.v2.model.udt.Alias;
-import org.atlasapi.content.v2.model.pojo.Location;
-import org.atlasapi.content.v2.model.udt.Ref;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.atlasapi.content.v2.model.pojo.Location;
+import org.atlasapi.content.v2.model.udt.Alias;
+import org.atlasapi.content.v2.model.udt.Ref;
 import org.joda.time.Instant;
+
+import java.util.Map;
+import java.util.Set;
 
 public class Encoding implements Identified {
 
@@ -44,6 +44,7 @@ public class Encoding implements Identified {
     private String quality;
     private String qualityDetail;
     private String versionId;
+    private Map<String, String> customFields;
 
     public Long getId() {
         return id;
@@ -299,6 +300,14 @@ public class Encoding implements Identified {
 
     public void setEquivalenceUpdate(Instant equivalenceUpdate) {
         this.equivalenceUpdate = equivalenceUpdate;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 
     public static class Wrapper {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/IdentifiedWithoutUpdateTimes.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/IdentifiedWithoutUpdateTimes.java
@@ -1,9 +1,10 @@
 package org.atlasapi.content.v2.model;
 
-import java.util.Set;
-
 import org.atlasapi.content.v2.model.udt.Alias;
 import org.atlasapi.content.v2.model.udt.Ref;
+
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @see Identified
@@ -34,4 +35,8 @@ public interface IdentifiedWithoutUpdateTimes {
     Set<Ref> getEquivalentTo();
 
     void setEquivalentTo(Set<Ref> equivalentTo);
+
+    Map<String, String> getCustomFields();
+
+    public void setCustomFields(Map<String, String> customFields);
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/pojo/Location.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/pojo/Location.java
@@ -1,12 +1,12 @@
 package org.atlasapi.content.v2.model.pojo;
 
-import java.util.Set;
-
 import org.atlasapi.content.v2.model.Identified;
 import org.atlasapi.content.v2.model.udt.Alias;
 import org.atlasapi.content.v2.model.udt.Ref;
-
 import org.joda.time.Instant;
+
+import java.util.Map;
+import java.util.Set;
 
 public class Location implements Identified {
 
@@ -26,6 +26,7 @@ public class Location implements Identified {
     private String embedCode;
     private String embedId;
     private Policy policy;
+    private Map<String, String> customFields;
 
     public Long getId() {
         return id;
@@ -153,5 +154,13 @@ public class Location implements Identified {
 
     public void setEquivalenceUpdate(Instant equivalenceUpdate) {
         this.equivalenceUpdate = equivalenceUpdate;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/pojo/Policy.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/pojo/Policy.java
@@ -1,13 +1,13 @@
 package org.atlasapi.content.v2.model.pojo;
 
-import java.util.List;
-import java.util.Set;
-
 import org.atlasapi.content.v2.model.Identified;
 import org.atlasapi.content.v2.model.udt.Alias;
 import org.atlasapi.content.v2.model.udt.Ref;
-
 import org.joda.time.Instant;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Policy implements Identified {
 
@@ -33,6 +33,7 @@ public class Policy implements Identified {
     private String platform;
     private String network;
     private Instant actualAvailabilityStart;
+    private Map<String, String> customFields;
 
     public Long getId() {
         return id;
@@ -208,5 +209,13 @@ public class Policy implements Identified {
 
     public void setEquivalenceUpdate(Instant equivalenceUpdate) {
         this.equivalenceUpdate = equivalenceUpdate;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/Broadcast.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/Broadcast.java
@@ -1,13 +1,13 @@
 package org.atlasapi.content.v2.model.udt;
 
-import java.util.Set;
-
-import org.atlasapi.content.v2.model.Identified;
-
 import com.datastax.driver.mapping.annotations.Field;
 import com.datastax.driver.mapping.annotations.UDT;
+import org.atlasapi.content.v2.model.Identified;
 import org.joda.time.Instant;
 import org.joda.time.LocalDate;
+
+import java.util.Map;
+import java.util.Set;
 
 @UDT(name = "broadcast")
 public class Broadcast implements Identified {
@@ -44,6 +44,7 @@ public class Broadcast implements Identified {
     @Field(name = "thd") private Boolean is3d;
     @Field(name = "br") private Boolean blackoutRestriction;
     @Field(name = "rr") private Boolean revisedRepeat;
+    @Field(name = "cf") private Map<String, String> customFields;
 
 
     public Broadcast() {}
@@ -294,5 +295,13 @@ public class Broadcast implements Identified {
 
     public void setRevisedRepeat(Boolean revisedRepeat) {
         this.revisedRepeat = revisedRepeat;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/CrewMember.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/CrewMember.java
@@ -1,12 +1,12 @@
 package org.atlasapi.content.v2.model.udt;
 
-import java.util.Set;
-
-import org.atlasapi.content.v2.model.Identified;
-
 import com.datastax.driver.mapping.annotations.Field;
 import com.datastax.driver.mapping.annotations.UDT;
+import org.atlasapi.content.v2.model.Identified;
 import org.joda.time.Instant;
+
+import java.util.Map;
+import java.util.Set;
 
 @UDT(name = "crewmember")
 public class CrewMember implements Identified {
@@ -24,6 +24,7 @@ public class CrewMember implements Identified {
     @Field(name = "publisher") private String publisher;
     @Field(name = "type") private String type;
     @Field(name = "character") private String character;
+    @Field(name = "custom_fields") private Map<String, String> customFields;
 
     public CrewMember() {}
 
@@ -129,5 +130,13 @@ public class CrewMember implements Identified {
 
     public void setCharacter(String character) {
         this.character = character;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/Restriction.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/Restriction.java
@@ -1,11 +1,11 @@
 package org.atlasapi.content.v2.model.udt;
 
-import java.util.Set;
-
-import org.atlasapi.content.v2.model.IdentifiedWithoutUpdateTimes;
-
 import com.datastax.driver.mapping.annotations.Field;
 import com.datastax.driver.mapping.annotations.UDT;
+import org.atlasapi.content.v2.model.IdentifiedWithoutUpdateTimes;
+
+import java.util.Map;
+import java.util.Set;
 
 @UDT(name = "restriction")
 public class Restriction implements IdentifiedWithoutUpdateTimes {
@@ -22,6 +22,7 @@ public class Restriction implements IdentifiedWithoutUpdateTimes {
     @Field(name = "message") private String message;
     @Field(name = "authority") private String authority;
     @Field(name = "rating") private String rating;
+    @Field(name = "custom_fields") private Map<String, String> customFields;
 
     public Restriction() {}
 
@@ -111,5 +112,13 @@ public class Restriction implements IdentifiedWithoutUpdateTimes {
 
     public void setRating(String rating) {
         this.rating = rating;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/SegmentEvent.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/model/udt/SegmentEvent.java
@@ -1,12 +1,12 @@
 package org.atlasapi.content.v2.model.udt;
 
-import java.util.Set;
-
-import org.atlasapi.content.v2.model.Identified;
-
 import com.datastax.driver.mapping.annotations.Field;
 import com.datastax.driver.mapping.annotations.UDT;
+import org.atlasapi.content.v2.model.Identified;
 import org.joda.time.Instant;
+
+import java.util.Map;
+import java.util.Set;
 
 @UDT(name = "segmentevent")
 public class SegmentEvent implements Identified {
@@ -27,6 +27,7 @@ public class SegmentEvent implements Identified {
     @Field(name = "segment_ref") private Ref segmentRef;
     @Field(name = "version_id") private String versionId;
     @Field(name = "publisher") private String publisher;
+    @Field(name = "custom_fields") private Map<String, String> customFields;
 
     public SegmentEvent() {}
 
@@ -148,5 +149,13 @@ public class SegmentEvent implements Identified {
 
     public void setLastUpdated(Instant lastUpdated) {
         this.lastUpdated = lastUpdated;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/v2/serialization/setters/IdentifiedWithoutUpdateTimesSetter.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/v2/serialization/setters/IdentifiedWithoutUpdateTimesSetter.java
@@ -1,9 +1,6 @@
 package org.atlasapi.content.v2.serialization.setters;
 
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.content.v2.model.IdentifiedWithoutUpdateTimes;
 import org.atlasapi.content.v2.model.udt.Ref;
 import org.atlasapi.content.v2.serialization.AliasSerialization;
@@ -13,7 +10,10 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identified;
 import org.atlasapi.equivalence.EquivalenceRef;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class IdentifiedWithoutUpdateTimesSetter {
 
@@ -45,6 +45,9 @@ public class IdentifiedWithoutUpdateTimesSetter {
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet()));
         }
+
+        internal.setCustomFields(identified.getCustomFields());
+
     }
 
     public void deserialize(Identified identified, IdentifiedWithoutUpdateTimes internal) {
@@ -73,6 +76,11 @@ public class IdentifiedWithoutUpdateTimesSetter {
             identified.setEquivalentTo(equivalentTo.stream()
                     .map(equivRef::deserialize)
                     .collect(Collectors.toSet()));
+        }
+
+        Map<String, String> customFields = internal.getCustomFields();
+        if (customFields != null) {
+            identified.setCustomFields(customFields);
         }
     }
 }

--- a/atlas-cassandra/src/main/java/org/atlasapi/entity/IdentifiedSerializer.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/entity/IdentifiedSerializer.java
@@ -1,13 +1,15 @@
 package org.atlasapi.entity;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.Maps;
 import org.atlasapi.equivalence.EquivalenceRef;
 import org.atlasapi.serialization.protobuf.CommonProtos;
 import org.atlasapi.serialization.protobuf.CommonProtos.Reference;
 import org.atlasapi.source.Sources;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 import org.joda.time.DateTime;
+
+import java.util.Map;
 
 public class IdentifiedSerializer<T extends Identified> {
 
@@ -42,6 +44,15 @@ public class IdentifiedSerializer<T extends Identified> {
         if (identified.getEquivalenceUpdate() != null) {
             id.setEquivalenceUpdate(CommonProtos.DateTime.newBuilder()
                     .setMillis(identified.getEquivalenceUpdate().getMillis()));
+        }
+
+        for (Map.Entry<String, String> customFieldEntry : identified.getCustomFields().entrySet()) {
+            id.addCustomFields(
+                    CommonProtos.CustomFieldEntry.newBuilder()
+                            .setKey(customFieldEntry.getKey())
+                            .setValue(customFieldEntry.getValue())
+                            .build()
+            );
         }
         return id.build();
     }
@@ -114,6 +125,12 @@ public class IdentifiedSerializer<T extends Identified> {
         if (msg.hasEquivalenceUpdate()) {
             builder.withEquivalenceUpdate(dateTimeSerializer.deserialize(msg.getEquivalenceUpdate()));
         }
+
+        Map<String, String> customFields = Maps.newHashMap();
+        for (CommonProtos.CustomFieldEntry customFieldEntry : msg.getCustomFieldsList()) {
+            customFields.put(customFieldEntry.getKey(), customFieldEntry.getValue());
+        }
+        builder.withCustomFields(customFields);
         return builder;
     }
 }

--- a/atlas-cassandra/src/main/protobuf/common.proto
+++ b/atlas-cassandra/src/main/protobuf/common.proto
@@ -5,6 +5,11 @@ option java_package = "org.atlasapi.serialization.protobuf";
 option java_outer_classname = "CommonProtos";
 option optimize_for = SPEED;
 
+message CustomFieldEntry {
+  optional string key = 1;
+  optional string value = 2;
+}
+
 message DateTime {
     required int64 millis = 1;
 }
@@ -25,6 +30,7 @@ message Identification {
     optional string uri = 9;
     optional string curie = 10;
     optional DateTime equivalenceUpdate = 11;
+    repeated CustomFieldEntry custom_fields = 12;
 }
 
 message BroadcastRef {

--- a/atlas-cassandra/src/main/protobuf/content.proto
+++ b/atlas-cassandra/src/main/protobuf/content.proto
@@ -113,6 +113,8 @@ message Content {
     repeated common.Review reviews = 70 [(column)=DESC];
 
     optional bool special = 71 [(column)=DESC];
+
+    repeated common.CustomFieldEntry custom_fields = 72 [(column)=IDENT];
 }
 
 message Restriction {

--- a/atlas-cassandra/src/main/resources/content_v2.schema
+++ b/atlas-cassandra/src/main/resources/content_v2.schema
@@ -133,7 +133,8 @@ CREATE TYPE IF NOT EXISTS CrewMember (
   name text,
   publisher text,
   type text,
-  character text
+  character text,
+  custom_fields map<text, text>
 );
 
 CREATE TYPE IF NOT EXISTS LocationSummary (
@@ -179,7 +180,8 @@ CREATE TYPE IF NOT EXISTS Broadcast (
   co boolean,
   thd boolean,
   br boolean,
-  rr boolean
+  rr boolean,
+  cf map<text, text>
 );
 
 CREATE TYPE IF NOT EXISTS Description (
@@ -204,7 +206,8 @@ CREATE TYPE IF NOT EXISTS SegmentEvent (
   descr frozen<Description>,
   segment_ref frozen<Ref>,
   version_id text,
-  publisher text
+  publisher text,
+  custom_fields map<text, text>
 );
 
 CREATE TYPE IF NOT EXISTS Restriction (
@@ -218,7 +221,8 @@ CREATE TYPE IF NOT EXISTS Restriction (
   minimum_age int,
   message text,
   authority text,
-  rating text
+  rating text,
+  custom_fields map<text, text>
 );
 
 CREATE TYPE IF NOT EXISTS Review (
@@ -345,5 +349,7 @@ CREATE TABLE IF NOT EXISTS content_v2 (
   ratings set<frozen<Rating>>,
 
   clips text,
-  encodings text
+  encodings text,
+
+  custom_fields map<text, text>
 );

--- a/atlas-cassandra/src/test/java/org/atlasapi/content/v2/serialization/ContentSerializationImplTest.java
+++ b/atlas-cassandra/src/test/java/org/atlasapi/content/v2/serialization/ContentSerializationImplTest.java
@@ -1,18 +1,17 @@
 package org.atlasapi.content.v2.serialization;
 
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.beanutils.PropertyUtils;
+import org.atlasapi.content.Content;
+import org.atlasapi.content.v2.CqlContentGenerator;
+import org.junit.Before;
+import org.junit.Test;
+import org.unitils.reflectionassert.ReflectionComparatorMode;
+
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
-
-import org.atlasapi.content.Content;
-import org.atlasapi.content.v2.CqlContentGenerator;
-
-import com.google.common.collect.ImmutableSet;
-import org.apache.commons.beanutils.PropertyUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.unitils.reflectionassert.ReflectionComparatorMode;
 
 import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 
@@ -58,7 +57,8 @@ public class ContentSerializationImplTest {
                 "upcomingContent", // takes an iterable, can't be set to null
                 "availableContent", // takes an iterable, can't be set to null
                 "Song#specialization", // explicitly initialised to MUSIC
-                "Film#specialization" // explicitly initialised to FILM
+                "Film#specialization", // explicitly initialised to FILM,
+                "customFields" //explicitly initialised to an empty map
         );
 
         for (Content original : contents) {

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -77,7 +77,8 @@ public enum Annotation {
     MODIFIED_DATES,
     CHANNEL_GROUP_INFO,
     CHANNEL_IDS,
-    FUTURE_CHANNELS
+    FUTURE_CHANNELS,
+    CUSTOM_FIELDS,
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
@@ -1,5 +1,22 @@
 package org.atlasapi.entity;
 
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import org.atlasapi.content.Content;
+import org.atlasapi.equivalence.Equivalable;
+import org.atlasapi.equivalence.EquivalenceRef;
+import org.atlasapi.meta.annotations.FieldName;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -8,26 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import org.atlasapi.content.Content;
-import org.atlasapi.equivalence.Equivalable;
-import org.atlasapi.equivalence.EquivalenceRef;
-import org.atlasapi.meta.annotations.FieldName;
-
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
-import org.joda.time.DateTime;
-
-import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -216,6 +213,7 @@ public class Identified implements Identifiable, Aliased {
         return customFields.containsKey(key);
     }
 
+    @FieldName("custom_fields")
     public Map<String, String> getCustomFields() {
         return new HashMap<>(customFields);
     }

--- a/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/Identified.java
@@ -2,9 +2,15 @@ package org.atlasapi.entity;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.atlasapi.content.Content;
 import org.atlasapi.equivalence.Equivalable;
 import org.atlasapi.equivalence.EquivalenceRef;
@@ -19,6 +25,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -35,6 +44,7 @@ public class Identified implements Identifiable, Aliased {
     private @Deprecated Set<String> aliasUrls = Sets.newHashSet();
     private ImmutableSet<Alias> aliases = ImmutableSet.of();
     private Set<EquivalenceRef> equivalentTo = Sets.newHashSet();
+    private Map<String, String> customFields = Maps.newHashMap();
     /**
      * Records the time that the 3rd party reported that the {@link Identified} was last updated
      */
@@ -65,6 +75,7 @@ public class Identified implements Identifiable, Aliased {
         this.canonicalUri = builder.canonicalUri;
         this.aliases = ImmutableSet.copyOf(builder.aliases);
         this.equivalentTo = Sets.newHashSet(builder.equivalentTo);
+        this.customFields = Maps.newHashMap(builder.customFields);
         this.lastUpdated = builder.lastUpdated;
         this.equivalenceUpdate = builder.equivalenceUpdate;
         this.curie = builder.curie;
@@ -168,6 +179,62 @@ public class Identified implements Identifiable, Aliased {
         return this;
     }
 
+    public void setCustomFields(@NotNull Map<String, String> customFields) {
+        this.customFields = Maps.newHashMap(checkNotNull(customFields));
+    }
+
+    /**
+     * Adds a key-value custom field, if the key already exists it will be overwritten
+     * Since merging logic will combine all custom fields for everything in the equiv set proper key namespacing
+     * may be required to avoid a custom field being ignored in favour of a higher precedence sharing the custom field.
+     * @param key the name of the custom field
+     * @param value the value of the custom field
+     */
+    public void addCustomField(@NotNull String key, @Nullable String value) {
+        if(value == null) {
+            return;
+        }
+        customFields.put(checkNotNull(key), value);
+    }
+
+    /**
+     * Adds each key-value entry as a custom field, overwriting existing customFields which share the same key
+     * @param customFields the map containing the key-value custom fields to add
+     */
+    public void addCustomFields(@NotNull Map<String, String> customFields) {
+        for(Map.Entry<String, String> entry : customFields.entrySet()) {
+            addCustomField(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Nullable
+    public String getCustomField(@NotNull String key) {
+        return customFields.getOrDefault(checkNotNull(key), null);
+    }
+
+    public boolean containsCustomFieldKey(@NotNull String key) {
+        return customFields.containsKey(key);
+    }
+
+    public Map<String, String> getCustomFields() {
+        return new HashMap<>(customFields);
+    }
+
+    public Set<String> getCustomFieldKeys() {
+        return getCustomFieldKeys(null);
+    }
+
+    public Set<String> getCustomFieldKeys(@Nullable String regex) {
+        if(regex == null) {
+            return customFields.keySet();
+        }
+        Pattern regexPattern = Pattern.compile(regex);
+        return customFields.keySet()
+                .stream()
+                .filter(key -> regexPattern.matcher(key).matches())
+                .collect(Collectors.toSet());
+    }
+
     @FieldName("last_updated")
     public DateTime getLastUpdated() {
         return lastUpdated;
@@ -243,6 +310,7 @@ public class Identified implements Identifiable, Aliased {
         to.aliasUrls = Sets.newHashSet(from.aliasUrls);
         to.aliases = ImmutableSet.copyOf(from.aliases);
         to.equivalentTo = Sets.newHashSet(from.equivalentTo);
+        to.customFields = Maps.newHashMap(from.customFields);
         to.lastUpdated = from.lastUpdated;
         to.equivalenceUpdate = from.equivalenceUpdate;
     }
@@ -259,6 +327,7 @@ public class Identified implements Identifiable, Aliased {
         to.aliasUrls = from.aliasUrls.isEmpty() ? to.aliasUrls : ImmutableSet.copyOf(from.aliasUrls);
         to.aliases = from.aliases.isEmpty() ? to.aliases : ImmutableSet.copyOf(from.aliases);
         to.equivalentTo = from.equivalentTo.isEmpty() ? to.equivalentTo : Sets.newHashSet(from.equivalentTo);
+        to.customFields = from.customFields.isEmpty() ? to.customFields : Maps.newHashMap(from.customFields);
         to.lastUpdated = ofNullable(from.lastUpdated).orElse(to.lastUpdated);
         to.equivalenceUpdate = ofNullable(from.equivalenceUpdate).orElse(to.lastUpdated);
     }
@@ -306,6 +375,7 @@ public class Identified implements Identifiable, Aliased {
         private @Deprecated ImmutableSet<String> aliasUrls = ImmutableSet.of();
         private ImmutableSet<Alias> aliases = ImmutableSet.of();
         private ImmutableSet<EquivalenceRef> equivalentTo = ImmutableSet.of();
+        private Map<String, String> customFields = Maps.newHashMap();
         private DateTime lastUpdated;
         private DateTime equivalenceUpdate;
 
@@ -344,6 +414,11 @@ public class Identified implements Identifiable, Aliased {
 
         public B withEquivalentTo(Iterable<EquivalenceRef> equivalentTo) {
             this.equivalentTo = ImmutableSet.copyOf(equivalentTo);
+            return self();
+        }
+
+        public B withCustomFields(Map<String, String> customFields) {
+            this.customFields = Maps.newHashMap(customFields);
             return self();
         }
 

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -303,6 +303,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     private <T extends Described> void mergeDescribed(Application application, T chosen,
             Iterable<T> notChosen) {
+        mergeCustomFields(chosen, notChosen);
         applyImagePrefs(application, chosen, notChosen);
         chosen.setRelatedLinks(projectFieldFromEquivalents(
                 chosen,
@@ -338,6 +339,19 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         }
         if (chosen.getShortDescription() == null) {
             chosen.setShortDescription(first(notChosen, TO_SHORT_DESCRIPTION));
+        }
+    }
+
+    private <T extends Identified> void mergeCustomFields(
+            T chosen,
+            Iterable<T> notChosen
+    ) {
+        for(T identified : notChosen) {
+            for(Map.Entry<String, String> customField : identified.getCustomFields().entrySet()) {
+                if (!chosen.containsCustomFieldKey(customField.getKey())) {
+                    chosen.addCustomField(customField.getKey(), customField.getValue());
+                }
+            }
         }
     }
 

--- a/atlas-core/src/test/java/org/atlasapi/hashing/HashValueExtractorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/hashing/HashValueExtractorTest.java
@@ -396,6 +396,7 @@ public class HashValueExtractorTest {
         );
         identified.setLastUpdated(DateTime.now());
         identified.setEquivalenceUpdate(DateTime.now());
+        identified.addCustomField("testField", "testValue");
     }
 
     private void setDescribedFields(Described described) {

--- a/atlas-legacy/src/main/java/org/atlasapi/system/legacy/BaseLegacyResourceTransformer.java
+++ b/atlas-legacy/src/main/java/org/atlasapi/system/legacy/BaseLegacyResourceTransformer.java
@@ -114,6 +114,7 @@ public abstract class BaseLegacyResourceTransformer<F, T extends org.atlasapi.en
         target.setEquivalentTo(source.getEquivalentTo().stream()
                 .map(ref -> new EquivalenceRef(Id.valueOf(ref.id()), ref.publisher()))
                 .collect(Collectors.toSet()));
+        target.setCustomFields(source.getCustomFields());
         target.setLastUpdated(source.getLastUpdated());
         target.setEquivalenceUpdate(source.getEquivalenceUpdate());
     }

--- a/atlas-legacy/src/main/java/org/atlasapi/system/legacy/DescribedLegacyResourceTransformer.java
+++ b/atlas-legacy/src/main/java/org/atlasapi/system/legacy/DescribedLegacyResourceTransformer.java
@@ -1,12 +1,7 @@
 package org.atlasapi.system.legacy;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.atlasapi.content.MediaType;
 import org.atlasapi.content.PriorityScoreReasons;
@@ -17,19 +12,22 @@ import org.atlasapi.entity.Award;
 import org.atlasapi.entity.Rating;
 import org.atlasapi.entity.Review;
 import org.atlasapi.entity.ReviewType;
-import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Clip;
+import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Topic;
 import org.atlasapi.media.entity.Version;
-
 import org.atlasapi.source.Sources;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class DescribedLegacyResourceTransformer<F extends Described, T extends org.atlasapi.content.Described>
         extends BaseLegacyResourceTransformer<F, T> {
@@ -109,6 +107,8 @@ public abstract class DescribedLegacyResourceTransformer<F extends Described, T 
         } else {
             i.setLastUpdated(DateTime.now());
         }
+
+        i.setCustomFields(input.getCustomFields());
     }
 
     protected abstract T createDescribed(F input);


### PR DESCRIPTION
The field is intended to be used for arbitrary data
that does not fit within the confines of the regular
atlas model e.g. additional title fields or customer-specific
fields.

Added merging logic for customFields which will
merge fields from each map into the highest-precedence
customFields map where the field does not already exist.
This is to mimic behaviour of merging logic of regular
fields.

Added a custom_fields annotation which will be used to output
the field.