### PR TITLE
Add all broadcasts annotation

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -183,6 +183,7 @@ import org.springframework.context.annotation.Import;
 import static org.atlasapi.annotation.Annotation.ADVERTISED_CHANNELS;
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_AGGREGATED_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.ALL_MERGED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT_DETAIL;
@@ -1099,6 +1100,11 @@ public class QueryWebModule {
                                 channelResolver
                         ),
                         commonImplied
+                )
+                .register(
+                        ALL_MERGED_BROADCASTS,
+                        NullWriter.create(Content.class),
+                        ImmutableSet.of(BROADCASTS)
                 )
                 .register(
                         ALL_BROADCASTS,

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -1069,6 +1069,16 @@ public class QueryWebModule {
                         commonImplied
                 )
                 .register(
+                        ALL_MERGED_BROADCASTS,
+                        BroadcastsAnnotation.create(idCodec(), channelResolver),
+                        commonImplied
+                )
+                .register(
+                        ALL_BROADCASTS,
+                        BroadcastsAnnotation.create(idCodec(), channelResolver),
+                        commonImplied
+                )
+                .register(
                         UPCOMING_BROADCASTS,
                         UpcomingBroadcastsAnnotation.create(
                                 idCodec(),
@@ -1100,16 +1110,6 @@ public class QueryWebModule {
                                 channelResolver
                         ),
                         commonImplied
-                )
-                .register(
-                        ALL_MERGED_BROADCASTS,
-                        NullWriter.create(Content.class),
-                        ImmutableSet.of(BROADCASTS)
-                )
-                .register(
-                        ALL_BROADCASTS,
-                        NullWriter.create(Content.class),
-                        ImmutableSet.of(BROADCASTS)
                 )
                 .register(AVAILABLE_LOCATIONS, new AvailableLocationsAnnotation(
                                 persistenceModule.playerResolver(),

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -183,6 +183,7 @@ import org.springframework.context.annotation.Import;
 import static org.atlasapi.annotation.Annotation.ADVERTISED_CHANNELS;
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_AGGREGATED_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.ALL_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT_DETAIL;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_LOCATIONS;
@@ -1098,6 +1099,11 @@ public class QueryWebModule {
                                 channelResolver
                         ),
                         commonImplied
+                )
+                .register(
+                        ALL_BROADCASTS,
+                        NullWriter.create(Content.class),
+                        ImmutableSet.of(BROADCASTS)
                 )
                 .register(AVAILABLE_LOCATIONS, new AvailableLocationsAnnotation(
                                 persistenceModule.playerResolver(),

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/EquivalentScheduleQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/EquivalentScheduleQueryExecutorTest.java
@@ -1,6 +1,7 @@
 package org.atlasapi.query.v4.schedule;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -314,7 +315,8 @@ public class EquivalentScheduleQueryExecutorTest {
         when(equivalentsMerger.merge(
                 Optional.absent(),
                 ImmutableSet.of(scheduleItem, equivalentItem),
-                application
+                application,
+                context.getAnnotations().all()
         ))
                 .thenReturn(ImmutableList.of(equivalentItem));
         when(broadcastMatcher.findMatchingBroadcast(originalBroadcast, equivalentBroadcasts))
@@ -333,7 +335,8 @@ public class EquivalentScheduleQueryExecutorTest {
         verify(equivalentsMerger).merge(
                 Optional.<Id>absent(),
                 ImmutableSet.of(scheduleItem, equivalentItem),
-                application
+                application,
+                context.getAnnotations().all()
         );
 
     }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/ContentDeserializationVisitor.java
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_AGGREGATED_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.ALL_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.ALL_MERGED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT_DETAIL;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_LOCATIONS;
@@ -77,7 +79,9 @@ final class ContentDeserializationVisitor implements ContentVisitor<Content> {
             FIRST_BROADCASTS,
             NEXT_BROADCASTS,
             ALL_AGGREGATED_BROADCASTS,
-            AGGREGATED_BROADCASTS
+            AGGREGATED_BROADCASTS,
+            ALL_MERGED_BROADCASTS,
+            ALL_BROADCASTS
     );
     private static final Annotation SUB_ITEMS_ANNOTATIONS = SUB_ITEMS;
     private static final Annotation SUB_ITEM_SUMMARIES_ANNOTATION = SUB_ITEM_SUMMARIES;

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -31,7 +31,7 @@ public enum Annotation {
     KEY_PHRASES,
     ALL_AGGREGATED_BROADCASTS,
     AGGREGATED_BROADCASTS,
-    BROADCASTS,
+    BROADCASTS,     //all broadcasts from equiv set with same source + channel/tx start
     LOCATIONS,
     FIRST_BROADCASTS,
     NEXT_BROADCASTS,
@@ -79,8 +79,8 @@ public enum Annotation {
     CHANNEL_IDS,
     FUTURE_CHANNELS,
     CUSTOM_FIELDS,
-    ALL_MERGED_BROADCASTS,
-    ALL_BROADCASTS
+    ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merging on same channel/tx start
+    ALL_BROADCASTS  //all broadcasts from equiv set without merging on same channel/tx start
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -31,7 +31,7 @@ public enum Annotation {
     KEY_PHRASES,
     ALL_AGGREGATED_BROADCASTS,
     AGGREGATED_BROADCASTS,
-    BROADCASTS,     //all broadcasts from equiv set with same source + channel/tx start
+    BROADCASTS,             //all broadcasts from equiv set with same source + channel/tx start
     LOCATIONS,
     FIRST_BROADCASTS,
     NEXT_BROADCASTS,
@@ -80,7 +80,7 @@ public enum Annotation {
     FUTURE_CHANNELS,
     CUSTOM_FIELDS,
     ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merging on same channel/tx start
-    ALL_BROADCASTS  //all broadcasts from equiv set without merging on same channel/tx start
+    ALL_BROADCASTS          //all broadcasts from equiv set without merging on same channel/tx start
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -79,6 +79,7 @@ public enum Annotation {
     CHANNEL_IDS,
     FUTURE_CHANNELS,
     CUSTOM_FIELDS,
+    ALL_MERGED_BROADCASTS,
     ALL_BROADCASTS
     ;
 

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -79,6 +79,7 @@ public enum Annotation {
     CHANNEL_IDS,
     FUTURE_CHANNELS,
     CUSTOM_FIELDS,
+    ALL_BROADCASTS
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -31,15 +31,15 @@ public enum Annotation {
     KEY_PHRASES,
     ALL_AGGREGATED_BROADCASTS,
     AGGREGATED_BROADCASTS,
-    BROADCASTS,             //all broadcasts from equiv set with same source + channel/tx start
+    BROADCASTS, //all broadcasts from equiv set with same source with merge on same channel/tx start
     LOCATIONS,
     FIRST_BROADCASTS,
     NEXT_BROADCASTS,
     AVAILABLE_LOCATIONS,
     UPCOMING_BROADCASTS,
     CURRENT_AND_FUTURE_BROADCASTS,
-    ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merging on same channel/tx start
-    ALL_BROADCASTS,          //all broadcasts from equiv set without merging on same channel/tx start
+    ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merge on same channel/tx start
+    ALL_BROADCASTS,         //all broadcasts from equiv set without merge on same channel/tx start
     FILTERING_RESOURCE,
     CHANNEL,
     CHANNEL_GROUP,

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -38,6 +38,8 @@ public enum Annotation {
     AVAILABLE_LOCATIONS,
     UPCOMING_BROADCASTS,
     CURRENT_AND_FUTURE_BROADCASTS,
+    ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merging on same channel/tx start
+    ALL_BROADCASTS,          //all broadcasts from equiv set without merging on same channel/tx start
     FILTERING_RESOURCE,
     CHANNEL,
     CHANNEL_GROUP,
@@ -78,9 +80,7 @@ public enum Annotation {
     CHANNEL_GROUP_INFO,
     CHANNEL_IDS,
     FUTURE_CHANNELS,
-    CUSTOM_FIELDS,
-    ALL_MERGED_BROADCASTS,  //all broadcasts from equiv set with merging on same channel/tx start
-    ALL_BROADCASTS          //all broadcasts from equiv set without merging on same channel/tx start
+    CUSTOM_FIELDS
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/AnnotationBasedMergingEquivalentsResolver.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/AnnotationBasedMergingEquivalentsResolver.java
@@ -58,26 +58,26 @@ public class AnnotationBasedMergingEquivalentsResolver<E extends Equivalable<E>>
             } catch (InterruptedException | ExecutionException e) {
                 log.error("Failed to see into the future :(");
             }
-            return Futures.transform(unmerged, mergeUsing(application));
+            return Futures.transform(unmerged, mergeUsing(application, activeAnnotations));
         }
     }
 
     private Function<ResolvedEquivalents<E>, ResolvedEquivalents<E>> mergeUsing(
-            final Application application) {
+            final Application application, Set<Annotation> activeAnnotations) {
         return input -> {
 
             ResolvedEquivalents.Builder<E> builder = ResolvedEquivalents.builder();
             for (Map.Entry<Id, Collection<E>> entry : input.asMap().entrySet()) {
                 builder.putEquivalents(
                         entry.getKey(),
-                        merge(entry.getKey(), entry.getValue(), application)
+                        merge(entry.getKey(), entry.getValue(), application, activeAnnotations)
                 );
             }
             return builder.build();
         };
     }
 
-    private Iterable<E> merge(Id id, Collection<E> equivs, Application application) {
-        return merger.merge(Optional.of(id), equivs, application);
+    private Iterable<E> merge(Id id, Collection<E> equivs, Application application, Set<Annotation> activeAnnotations) {
+        return merger.merge(Optional.of(id), equivs, application, activeAnnotations);
     }
 }

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/ApplicationEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/ApplicationEquivalentsMerger.java
@@ -1,8 +1,11 @@
 package org.atlasapi.equivalence;
 
 import java.util.List;
+import java.util.Set;
 
 import com.metabroadcast.applications.client.model.internal.Application;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.entity.Id;
 
 import com.google.common.base.Optional;
@@ -10,6 +13,6 @@ import com.google.common.base.Optional;
 public interface ApplicationEquivalentsMerger<E extends Equivalable<E>> {
 
     <T extends E> List<T> merge(Optional<Id> id, Iterable<T> equivalents,
-            Application application);
+            Application application, Set<Annotation> activeAnnotations);
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
@@ -1,6 +1,10 @@
 package org.atlasapi.output;
 
+import java.util.Set;
+
 import com.metabroadcast.applications.client.model.internal.Application;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.equivalence.Equivalable;
 
 /**
@@ -13,8 +17,9 @@ public interface EquivalentsMergeStrategy<E extends Equivalable<E>> {
     /**
      * @param chosen      - resource in to which {@code equivalents} is merged.
      * @param equivalents - a set of resources equivalent to chosen.
+     * @param activeAnnotations - the annotations present on the call
      * @return merged resources.
      */
-    <T extends E> T merge(T chosen, Iterable<? extends T> equivalents, Application application);
-
+    <T extends E> T merge(T chosen, Iterable<? extends T> equivalents, Application application,
+            Set<Annotation> activeAnnotations);
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
@@ -628,7 +627,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 );
 
         //TODO write more comments on what/why (here and/or in JIRA ticket)
-        if(activeAnnotations.contains(Annotation.ALL_BROADCASTS)){
+        if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
             chosen.setBroadcasts(
                     all.stream()
                             .map(T::getBroadcasts)
@@ -637,52 +636,19 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             );
             return;
         }
-        //if all_annotation set:
-        //add all broadcasts from first to an ordered list of broadcasts
-        //for all broadcasts from not chosen (in order probably):
-        //add all broadcasts to the list which do not match channel / transmission time
-        //then do chosen.setBroadcasts with the list and carry on with the match and merge looping
-        //if annotation not set do the if(!first.isEmpty()) block
-//        if (activeAnnotations.contains(Annotation.ALL_MERGED_BROADCASTS)) {
-//            List<Broadcast> broadcastsOfFirst = first.stream()
-//                            .map(Item::getBroadcasts)
-//                            .flatMap(Collection::stream)
-//                            .collect(MoreCollectors.toImmutableList());
-//            HashSet<Broadcast> allBroadcasts = Sets.newHashSet(broadcastsOfFirst);
-//            for (T notChosenContent : notChosenOrdered) {
-//                if (notChosenContent.getBroadcasts() != null
-//                        && !notChosenContent.getBroadcasts().isEmpty()) {
-//                    for (Broadcast notChosenBroadcast : notChosenContent.getBroadcasts()) {
-//                        boolean anyExistingMatches = false;
-//                        for (Broadcast existingBroadcast : allBroadcasts) {
-//                            if (broadcastsMatch(existingBroadcast, notChosenBroadcast)) {
-//                                anyExistingMatches = true;
-//                                break;
-//                            }
-//                        }
-//                        if (!anyExistingMatches) {
-//                            //note: chosen's broadcasts won't be included? Only first + no chosens... sounds wrong
-//                            allBroadcasts.add(notChosenBroadcast);
-//                        }
-//                    }
-//                }
-//            }
-//            chosen.setBroadcasts(allBroadcasts);
-//        } else {
-            if (!first.isEmpty()) {
-                Publisher sourceForBroadcasts = Iterables.getOnlyElement(first).getSource();
-                chosen.setBroadcasts(
-                        all.stream()
-                        .filter(item ->
-                                activeAnnotations.contains(Annotation.ALL_MERGED_BROADCASTS)
-                                || item.getSource().equals(sourceForBroadcasts)
-                        )
-                        .map(T::getBroadcasts)
-                        .flatMap(Collection::stream)
-                        .collect(MoreCollectors.toImmutableSet())
-                );
-            }
-//        }
+        if (!first.isEmpty()) {
+            Publisher sourceForBroadcasts = Iterables.getOnlyElement(first).getSource();
+            chosen.setBroadcasts(
+                    all.stream()
+                            .filter(item ->
+                                    activeAnnotations.contains(Annotation.ALL_MERGED_BROADCASTS)
+                                            || item.getSource().equals(sourceForBroadcasts)
+                            )
+                            .map(T::getBroadcasts)
+                            .flatMap(Collection::stream)
+                            .collect(MoreCollectors.toImmutableSet())
+            );
+        }
 
         if (chosen.getBroadcasts() != null && !chosen.getBroadcasts().isEmpty()) {
             for (Broadcast chosenBroadcast : chosen.getBroadcasts()) {

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -606,12 +606,14 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Set<Annotation> activeAnnotations
     ) {
 
-        // Annotation of "broadcasts" behaviour: take broadcasts from the most precedent source with
+        // Behaviour of "broadcasts" annotation: take broadcasts from the most precedent source with
         // broadcasts, and merge them with broadcasts from less precedent sources
+        // NB: source <=> publisher
 
         List<T> all = ImmutableList.<T>builder().add(chosen).addAll(notChosen).build();
 
         if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
+            //return all broadcasts in the equiv set, from all sources and with no merging
             chosen.setBroadcasts(
                     all.stream()
                             .map(T::getBroadcasts)
@@ -626,6 +628,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 .onResultOf(Sourceds.toPublisher())
                 .sortedCopy(notChosen);
 
+        //first = piece of content with highest precedence source with broadcasts
         List<T> first = application.getConfiguration()
                 .getReadPrecedenceOrdering()
                 .onResultOf(Sourceds.toPublisher())
@@ -640,6 +643,8 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Publisher sourceForBroadcasts = Iterables.getOnlyElement(first).getSource();
             chosen.setBroadcasts(
                     all.stream()
+                            //if ALL_MERGED_BROADCASTS not present, then filter out the broadcasts
+                            //from sources that are different from the source of "first"
                             .filter(item ->
                                     activeAnnotations.contains(Annotation.ALL_MERGED_BROADCASTS)
                                             || item.getSource().equals(sourceForBroadcasts)

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -626,7 +626,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                         1
                 );
 
-        //TODO write more comments on what/why (here and/or in JIRA ticket)
         if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
             chosen.setBroadcasts(
                     all.stream()

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -624,6 +624,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                         1
                 );
 
+        //TODO write more comments on what/why (here and/or in JIRA ticket)
         //if all_annotation set:
         //add all broadcasts from first to an ordered list of broadcasts
         //for all broadcasts from not chosen (in order probably):

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -632,27 +632,30 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         //then do chosen.setBroadcasts with the list and carry on with the match and merge looping
         //if annotation not set do the if(!first.isEmpty()) block
         if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
-            if (!first.isEmpty()) {
-                Iterable<Broadcast> broadcastsOfFirst = Iterables.concat(Iterables.transform(
-                        first,
-                        Item::getBroadcasts
-                ));
-                HashSet<Broadcast> allBroadcasts = Sets.newHashSet(broadcastsOfFirst);
-                for (T notChosenContent : notChosenOrdered) {
-                    if (notChosenContent.getBroadcasts() != null
-                            && !notChosenContent.getBroadcasts()
-                            .isEmpty()) {
-                        for (Broadcast notChosenBroadcast : notChosenContent.getBroadcasts()) {
-                            for (Broadcast broadcastOfFirst : broadcastsOfFirst) {
-                                if (broadcastsMatch(broadcastOfFirst, notChosenBroadcast)) {
-                                    allBroadcasts.add(notChosenBroadcast);
-                                }
+            Iterable<Broadcast> broadcastsOfFirst = Iterables.concat(Iterables.transform(
+                    first,
+                    Item::getBroadcasts
+            ));
+            HashSet<Broadcast> allBroadcasts = Sets.newHashSet(broadcastsOfFirst);
+            for (T notChosenContent : notChosenOrdered) {
+                if (notChosenContent.getBroadcasts() != null
+                        && !notChosenContent.getBroadcasts()
+                        .isEmpty()) {
+                    for (Broadcast notChosenBroadcast : notChosenContent.getBroadcasts()) {
+                        boolean anyExistingMatches = false;
+                        for (Broadcast existingBroadcast : allBroadcasts) {
+                            if (broadcastsMatch(existingBroadcast, notChosenBroadcast)) {
+                                anyExistingMatches = true;
+                                break;
                             }
+                        }
+                        if(!anyExistingMatches){
+                            allBroadcasts.add(notChosenBroadcast);
                         }
                     }
                 }
-                chosen.setBroadcasts(allBroadcasts);
             }
+            chosen.setBroadcasts(allBroadcasts);
         } else {
             if (!first.isEmpty()) {
                 Publisher sourceForBroadcasts = Iterables.getOnlyElement(first).getSource();

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -606,8 +606,8 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Set<Annotation> activeAnnotations
     ) {
 
-        // Take broadcasts from the most precedent source with broadcasts, and
-        // merge them with broadcasts from less precedent sources.
+        // Annotation of "broadcasts" behaviour: take broadcasts from the most precedent source with
+        // broadcasts, and merge them with broadcasts from less precedent sources
 
         List<T> all = ImmutableList.<T>builder().add(chosen).addAll(notChosen).build();
 

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -611,6 +611,16 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
         List<T> all = ImmutableList.<T>builder().add(chosen).addAll(notChosen).build();
 
+        if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
+            chosen.setBroadcasts(
+                    all.stream()
+                            .map(T::getBroadcasts)
+                            .flatMap(Collection::stream)
+                            .collect(MoreCollectors.toImmutableSet())
+            );
+            return;
+        }
+
         List<T> notChosenOrdered = application.getConfiguration()
                 .getReadPrecedenceOrdering()
                 .onResultOf(Sourceds.toPublisher())
@@ -626,15 +636,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                         1
                 );
 
-        if (activeAnnotations.contains(Annotation.ALL_BROADCASTS)) {
-            chosen.setBroadcasts(
-                    all.stream()
-                            .map(T::getBroadcasts)
-                            .flatMap(Collection::stream)
-                            .collect(MoreCollectors.toImmutableSet())
-            );
-            return;
-        }
         if (!first.isEmpty()) {
             Publisher sourceForBroadcasts = Iterables.getOnlyElement(first).getSource();
             chosen.setBroadcasts(

--- a/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
@@ -1,8 +1,12 @@
 package org.atlasapi.output;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import com.metabroadcast.applications.client.model.internal.Application;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identifiable;
 import org.atlasapi.entity.Sourced;
@@ -29,7 +33,7 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
 
     @Override
     public <T extends E> List<T> merge(final Optional<Id> id, Iterable<T> equivalents,
-            Application application) {
+            Application application, Set<Annotation> activeAnnotations) {
         if (!application.getConfiguration().isPrecedenceEnabled()) {
             return ImmutableList.copyOf(equivalents);
         }
@@ -47,7 +51,8 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
                     strategy.merge(
                             Iterables.getFirst(sortedEquivalents, null),
                             ImmutableList.of(),
-                            application
+                            application,
+                            activeAnnotations
                     )
             );
         }
@@ -66,7 +71,7 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
                 sortedEquivalents,
                 Predicates.not(idIs(chosen.getId()))
         );
-        return ImmutableList.of(strategy.merge(chosen, notChosen, application));
+        return ImmutableList.of(strategy.merge(chosen, notChosen, application, activeAnnotations));
     }
 
     private boolean trivialMerge(ImmutableList<?> sortedEquivalents) {

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Iterables;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.metabroadcast.common.time.DateTimeZones.UTC;
@@ -47,7 +48,9 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application);
+        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
+                Collections.emptySet()
+        );
 
         assertTrue(notChosenItem.getBroadcasts().isEmpty());
     }
@@ -86,7 +89,9 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application);
+        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
+                Collections.emptySet()
+        );
 
         assertTrue(chosenItem.getBroadcasts().size() == 1);
     }
@@ -130,7 +135,9 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application);
+        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
+                Collections.emptySet()
+        );
 
         // ensure that the broadcast matched, 
         // and the fields on the non-chosen broadcast 
@@ -218,7 +225,8 @@ public class BroadcastMergingTest {
         executor.merge(
                 chosenItemWithoutBroadcasts,
                 ImmutableList.of(notChosenFirstBbcItem, notChosenBbcItem, notChosenFbItem),
-                application
+                application,
+                Collections.emptySet()
         );
 
         // ensure that the broadcast matched, 

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -2,6 +2,8 @@ package org.atlasapi.output;
 
 import com.metabroadcast.applications.client.model.internal.Application;
 import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.BlackoutRestriction;
 import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.Item;
@@ -15,9 +17,12 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.metabroadcast.common.time.DateTimeZones.UTC;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -239,6 +244,105 @@ public class BroadcastMergingTest {
         assertFalse(mergedBroadcast.getSurround());
         assertTrue(mergedBroadcast.getSubtitled());
         assertTrue(mergedBroadcast.getAliases().size() == 3);
+    }
+
+    @Test
+    public void testBroadcastMergingWithAllBroadcastsAnnotation(){
+
+        when(application.getConfiguration()).thenReturn(getConfigWithReads(defaultTestPublishers));
+
+        Item chosenItem = new Item();
+        chosenItem.setId(1L);
+        chosenItem.setPublisher(Publisher.BBC);
+        chosenItem.setCanonicalUri("chosenItem");
+        chosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC)
+        ));
+
+        Item notChosenItem = new Item();
+        notChosenItem.setId(2L);
+        notChosenItem.setPublisher(Publisher.BBC);
+        notChosenItem.setCanonicalUri("notChosenItem");
+        // different channel (should not match)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(1),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC)
+        ));
+        // different start time (should not match)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 5, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 5, 0, 0, 0, UTC)
+        ));
+        // same channel + start time (should not match because of annotation)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 1, 0, 0, 2, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 2, UTC)
+        ));
+
+        chosenItem.addEquivalentTo(notChosenItem);
+        notChosenItem.addEquivalentTo(chosenItem);
+
+        Set<Annotation> activeAnnotations = new HashSet<>();
+
+        //merge all broadcasts from all sources, even if different channel and start time
+        activeAnnotations.add(Annotation.ALL_BROADCASTS);
+        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application, activeAnnotations);
+        assertEquals(4, chosenItem.getBroadcasts().size());
+
+    }
+
+    @Test
+    public void testBroadcastMergingWithMergedBroadcastsAnnotation(){
+
+        when(application.getConfiguration()).thenReturn(getConfigWithReads(defaultTestPublishers));
+
+        Item chosenItem = new Item();
+        chosenItem.setId(1L);
+        chosenItem.setPublisher(Publisher.BBC);
+        chosenItem.setCanonicalUri("chosenItem");
+        chosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC)
+        ));
+
+        Item notChosenItem = new Item();
+        notChosenItem.setId(2L);
+        notChosenItem.setPublisher(Publisher.BARB_TRANSMISSIONS);
+        notChosenItem.setCanonicalUri("notChosenItem");
+        // different channel (should not match)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(1),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC)
+        ));
+        // different start time (should not match)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 5, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 5, 0, 0, 0, UTC)
+        ));
+        // same channel + start time (should be matched+merged)
+        notChosenItem.addBroadcast(new Broadcast(
+                Id.valueOf(2),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC),
+                new DateTime(2012, 1, 1, 0, 0, 0, UTC)
+        ));
+
+        chosenItem.addEquivalentTo(notChosenItem);
+        notChosenItem.addEquivalentTo(chosenItem);
+
+        Set<Annotation> activeAnnotations = new HashSet<>();
+        //get broadcasts from all sources, merging on matching channel+start time
+        activeAnnotations.add(Annotation.ALL_MERGED_BROADCASTS);
+        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application, activeAnnotations);
+
+        assertEquals(3, chosenItem.getBroadcasts().size());
     }
 
     private ApplicationConfiguration getConfigWithReads(List<Publisher> publishers) {

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -1,6 +1,7 @@
 package org.atlasapi.output;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +79,7 @@ public class OutputContentMergerTest {
         ImmutableList<Brand> contents = ImmutableList.of(one, two, three);
 
         for (List<Brand> contentList : Collections2.permutations(contents)) {
-            List<Brand> merged = merger.merge(application, contentList);
+            List<Brand> merged = merger.merge(application, contentList, Collections.emptySet());
             assertThat(merged.size(), is(1));
             if (contentList.get(0).equals(three)) {
                 assertThat(contentList.toString(), merged.get(0), is(contentList.get(1)));
@@ -135,7 +136,7 @@ public class OutputContentMergerTest {
                 Publisher.PA
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two), application);
+        Item merged = merger.merge(one, ImmutableList.of(two), application, Collections.emptySet());
         assertThat(merged.getAliases().size(), is(2));
     }
 
@@ -164,7 +165,9 @@ public class OutputContentMergerTest {
                 Publisher.PA
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Item merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         ImmutableSet<Image> images = merged.getImages().stream()
                 .filter(img -> img.getSource() != null)
@@ -198,7 +201,9 @@ public class OutputContentMergerTest {
                 Publisher.PA
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Item merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         ImmutableSet<Image> images = merged.getImages().stream()
                 .filter(img -> img.getSource() != null)
@@ -247,7 +252,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Item merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         List<SegmentEvent> mergedSegmentEvents = merged.getSegmentEvents();
 
@@ -297,7 +304,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         assertThat(merged.getUpcomingContent(), is(upcomingContent));
     }
@@ -339,7 +348,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         assertThat(merged.getItemSummaries(), is(itemSummaries));
     }
@@ -404,7 +415,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         Map<ItemRef, Iterable<LocationSummary>> expectedAvailableContent = ImmutableMap.<ItemRef, Iterable<LocationSummary>>builder()
                 .putAll(availableContent1)
@@ -439,7 +452,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application);
+        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+                Collections.emptySet()
+        );
 
         assertThat(
                 merged.getManifestedAs(),
@@ -459,7 +474,9 @@ public class OutputContentMergerTest {
         Item item2 = item(5L, "item2", Publisher.PA);
         item2.setImages(ImmutableSet.of(new Image("http://image2.org/")));
 
-        Content merged = merger.merge(item1, ImmutableList.of(item2), application);
+        Content merged = merger.merge(item1, ImmutableList.of(item2), application,
+                Collections.emptySet()
+        );
         assertThat(merged.getImages().size(), is(2));
     }
 
@@ -490,7 +507,9 @@ public class OutputContentMergerTest {
         item2.setImage(image2.getCanonicalUri());
         item2.setImages(ImmutableSet.of(image2));
 
-        Content merged = merger.merge(item2,  ImmutableList.of(item1), application);
+        Content merged = merger.merge(item2,  ImmutableList.of(item1), application,
+                Collections.emptySet()
+        );
         assertThat(merged.getImage(), is("http://image2.org/"));
         assertThat(Iterables.getOnlyElement(merged.getImages()).getCanonicalUri(), is("http://image2.org/"));
     }
@@ -522,7 +541,9 @@ public class OutputContentMergerTest {
         item2.setImage(image2.getCanonicalUri());
         item2.setImages(ImmutableSet.of(image2));
 
-        Content merged = merger.merge(item2,  ImmutableList.of(item1), application);
+        Content merged = merger.merge(item2,  ImmutableList.of(item1), application,
+                Collections.emptySet()
+        );
         assertThat(merged.getImage(), is("http://image1.org/"));
         assertThat(Iterables.getOnlyElement(merged.getImages()).getCanonicalUri(), is("http://image1.org/"));
     }
@@ -554,7 +575,9 @@ public class OutputContentMergerTest {
         item2.setImage(image2.getCanonicalUri());
         item2.setImages(ImmutableSet.of(image2));
 
-        Content merged = merger.merge(item2,  ImmutableList.of(item1), application);
+        Content merged = merger.merge(item2,  ImmutableList.of(item1), application,
+                Collections.emptySet()
+        );
         assertNull(merged.getImage());
         assertThat(merged.getImages().size(), is(0));
     }
@@ -602,7 +625,9 @@ public class OutputContentMergerTest {
         );
         item3.setBroadcasts(ImmutableSet.of(b3));
 
-        Item merged = merger.merge(item1, ImmutableList.of(item2, item3), application);
+        Item merged = merger.merge(item1, ImmutableList.of(item2, item3), application,
+                Collections.emptySet()
+        );
         assertThat(merged.getBroadcasts().size(), is(2));
     }
 
@@ -635,7 +660,9 @@ public class OutputContentMergerTest {
         item2.setBroadcasts(ImmutableSet.of(b2));
         b2.addAlias(new Alias("ns2", "v2"));
 
-        Item merged = merger.merge(item1, ImmutableList.of(item2), application);
+        Item merged = merger.merge(item1, ImmutableList.of(item2), application,
+                Collections.emptySet()
+        );
         assertThat(Iterables.getOnlyElement(merged.getBroadcasts()).getAliases().size(), is(2));
     }
 
@@ -669,7 +696,9 @@ public class OutputContentMergerTest {
         secondItem.addBroadcast(secondItemBroadcast);
 
 
-        Item merged = merger.merge(firstItem, ImmutableList.of(secondItem), application);
+        Item merged = merger.merge(firstItem, ImmutableList.of(secondItem), application,
+                Collections.emptySet()
+        );
 
         Broadcast actualBroadcast = Iterables.getOnlyElement(merged.getBroadcasts());
         assertThat(
@@ -707,7 +736,9 @@ public class OutputContentMergerTest {
         // chosenItem is mutated by merge, so calculate this first
         int expectedReviewsCount = expectedReviews.size();
 
-        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application);
+        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application,
+                Collections.emptySet()
+        );
 
         assertThat(merged.getReviews().size(), is(expectedReviewsCount));
         assertThat(merged.getReviews().containsAll(expectedReviews), is(true));
@@ -748,7 +779,9 @@ public class OutputContentMergerTest {
         // chosenItem is mutated by merge, so calculate this first
         int expectedRatingsCount = expectedRatings.size();
 
-        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application);
+        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application,
+                Collections.emptySet()
+        );
 
         assertThat(merged.getRatings().size(), is(expectedRatingsCount));
         assertThat(merged.getRatings().containsAll(expectedRatings), is(true));
@@ -841,7 +874,9 @@ public class OutputContentMergerTest {
                 Publisher.RADIO_TIMES
         );
 
-        Item merged = merger.merge(chosen, ImmutableSet.<Item>builder().add(notChosen).build(), application);
+        Item merged = merger.merge(chosen, ImmutableSet.<Item>builder().add(notChosen).build(), application,
+                Collections.emptySet()
+        );
 
         assertEquals(merged.getDescription(), correctDescription);
     }
@@ -871,7 +906,7 @@ public class OutputContentMergerTest {
     private void mergePermutations(ImmutableList<Brand> contents, Application application,
             Brand expectedContent, Id expectedId) {
         for (List<Brand> contentList : Collections2.permutations(contents)) {
-            List<Brand> merged = merger.merge(application, contentList);
+            List<Brand> merged = merger.merge(application, contentList, Collections.emptySet());
             Brand mergedBrand = Iterables.getOnlyElement(merged);
             assertThat(mergedBrand, is(expectedContent));
             assertThat(mergedBrand.getId(), is(expectedId));
@@ -917,7 +952,9 @@ public class OutputContentMergerTest {
                 Publisher.BBC
         );
 
-        Item merged = merger.merge(chosen, ImmutableList.of(notChosen), application);
+        Item merged = merger.merge(chosen, ImmutableList.of(notChosen), application,
+                Collections.emptySet()
+        );
 
         return Iterables
                 .getOnlyElement(merged.getBroadcasts())

--- a/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.Brand;
 import org.atlasapi.content.Content;
 import org.atlasapi.entity.Id;
@@ -19,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -92,7 +94,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
                 argThat(is(application)),
-                Collections.emptySet()
+                Matchers.anySetOf(Annotation.class)
         );
     }
 
@@ -112,7 +114,7 @@ public class StrategyBackedEquivalentsMergerTest {
                     argThat(any(Content.class)),
                     anyCollectionOf(Content.class),
                     argThat(is(mergingApplication)),
-                    Collections.emptySet()
+                    Matchers.anySetOf(Annotation.class)
             )).thenReturn(one);
 
             merger.merge(Optional.of(one.getId()), contentList, mergingApplication,
@@ -124,7 +126,7 @@ public class StrategyBackedEquivalentsMergerTest {
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
                                 argThat(is(mergingApplication)),
-                                Collections.emptySet()
+                                Matchers.anySetOf(Annotation.class)
                         );
             } else if (contentList.get(0).equals(two)) {
                 verify(strategy)
@@ -132,7 +134,7 @@ public class StrategyBackedEquivalentsMergerTest {
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
                                 argThat(is(mergingApplication)),
-                                Collections.emptySet()
+                                Matchers.anySetOf(Annotation.class)
                         );
             } else {
                 verify(strategy)
@@ -140,7 +142,7 @@ public class StrategyBackedEquivalentsMergerTest {
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
                                 argThat(is(mergingApplication)),
-                                Collections.emptySet()
+                                Matchers.anySetOf(Annotation.class)
                         );
             }
 
@@ -158,7 +160,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
                 argThat(is(mergingApplication)),
-                Collections.emptySet()
+                Matchers.anySetOf(Annotation.class)
         )).thenReturn(retrieved1);
 
         merger.merge(
@@ -173,7 +175,7 @@ public class StrategyBackedEquivalentsMergerTest {
                         argThat(is(retrieved1)),
                         argThat(contains(retrieved2)),
                         argThat(is(mergingApplication)),
-                        Collections.emptySet()
+                        Matchers.anySetOf(Annotation.class)
                 );
     }
 
@@ -197,7 +199,7 @@ public class StrategyBackedEquivalentsMergerTest {
                         argThat(is(one)),
                         argThat(contains(two, three)),
                         argThat(is(mergingApplication)),
-                        Collections.emptySet()
+                        Matchers.anySetOf(Annotation.class)
                 );
         reset(strategy);
         setUpMockStrategyToReturn(one);
@@ -210,7 +212,7 @@ public class StrategyBackedEquivalentsMergerTest {
                         argThat(is(two)),
                         argThat(contains(one, three)),
                         argThat(is(mergingApplication)),
-                        Collections.emptySet()
+                        Matchers.anySetOf(Annotation.class)
                 );
         reset(strategy);
         setUpMockStrategyToReturn(one);
@@ -223,7 +225,7 @@ public class StrategyBackedEquivalentsMergerTest {
                         argThat(is(one)),
                         argThat(contains(two, three)),
                         argThat(is(mergingApplication)),
-                        Collections.emptySet()
+                        Matchers.anySetOf(Annotation.class)
                 );
         reset(strategy);
     }
@@ -233,7 +235,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
                 argThat(is(mergingApplication)),
-                Collections.emptySet()
+                Matchers.anySetOf(Annotation.class)
         )).thenReturn(content);
     }
 

--- a/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
@@ -1,5 +1,6 @@
 package org.atlasapi.output;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,7 +58,7 @@ public class StrategyBackedEquivalentsMergerTest {
     public void testDoesntMergeForNonMergingConfig() {
         Id id = Id.valueOf(1234);
         List<Content> merged = merger.merge(Optional.of(id), ImmutableSet.of(),
-                nonMergingApplication
+                nonMergingApplication, Collections.emptySet()
         );
 
         assertTrue(merged.isEmpty());
@@ -68,7 +69,7 @@ public class StrategyBackedEquivalentsMergerTest {
     public void testDoesntMergeForEmptyEquivalenceSet() {
         Id id = Id.valueOf(1234);
         List<Content> merged = merger.merge(Optional.of(id), ImmutableSet.<Content>of(),
-                mergingApplication
+                mergingApplication, Collections.emptySet()
         );
 
         assertTrue(merged.isEmpty());
@@ -78,9 +79,9 @@ public class StrategyBackedEquivalentsMergerTest {
     @Test
     public void testDoesntMergeForSingletonEquivalenceSet() {
         Content brand = new Brand(Id.valueOf(1), Publisher.BBC);
-        when(strategy.merge(brand, ImmutableList.of(), mergingApplication)).thenReturn(brand);
+        when(strategy.merge(brand, ImmutableList.of(), mergingApplication, Collections.emptySet())).thenReturn(brand);
         List<Content> merged = merger.merge(Optional.of(brand.getId()), ImmutableSet.of(brand),
-                mergingApplication
+                mergingApplication, Collections.emptySet()
         );
 
         assertThat(merged.size(), is(1));
@@ -90,7 +91,8 @@ public class StrategyBackedEquivalentsMergerTest {
         verify(strategy, never()).merge(
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
-                argThat(is(application))
+                argThat(is(application)),
+                Collections.emptySet()
         );
     }
 
@@ -109,31 +111,36 @@ public class StrategyBackedEquivalentsMergerTest {
             when(strategy.merge(
                     argThat(any(Content.class)),
                     anyCollectionOf(Content.class),
-                    argThat(is(mergingApplication))
+                    argThat(is(mergingApplication)),
+                    Collections.emptySet()
             )).thenReturn(one);
 
-            merger.merge(Optional.of(one.getId()), contentList, mergingApplication);
+            merger.merge(Optional.of(one.getId()), contentList, mergingApplication,
+                    Collections.emptySet());
 
             if (contentList.get(0).equals(one)) {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
-                                argThat(is(mergingApplication))
+                                argThat(is(mergingApplication)),
+                                Collections.emptySet()
                         );
             } else if (contentList.get(0).equals(two)) {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
-                                argThat(is(mergingApplication))
+                                argThat(is(mergingApplication)),
+                                Collections.emptySet()
                         );
             } else {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
                                 argThat(contains(two, three)),
-                                argThat(is(mergingApplication))
+                                argThat(is(mergingApplication)),
+                                Collections.emptySet()
                         );
             }
 
@@ -150,20 +157,23 @@ public class StrategyBackedEquivalentsMergerTest {
         when(strategy.merge(
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
-                argThat(is(mergingApplication))
+                argThat(is(mergingApplication)),
+                Collections.emptySet()
         )).thenReturn(retrieved1);
 
         merger.merge(
                 Optional.of(retrieved1.getId()),
                 ImmutableList.of(retrieved1, retrieved2),
-                mergingApplication
+                mergingApplication,
+                Collections.emptySet()
         );
 
         verify(strategy)
                 .merge(
                         argThat(is(retrieved1)),
                         argThat(contains(retrieved2)),
-                        argThat(is(mergingApplication))
+                        argThat(is(mergingApplication)),
+                        Collections.emptySet()
                 );
     }
 
@@ -178,38 +188,42 @@ public class StrategyBackedEquivalentsMergerTest {
         List<Content> merged = merger.merge(
                 Optional.of(one.getId()),
                 ImmutableSet.of(one, two, three),
-                mergingApplication
+                mergingApplication,
+                Collections.emptySet()
         );
 
         verify(strategy)
                 .merge(
                         argThat(is(one)),
                         argThat(contains(two, three)),
-                        argThat(is(mergingApplication))
+                        argThat(is(mergingApplication)),
+                        Collections.emptySet()
                 );
         reset(strategy);
         setUpMockStrategyToReturn(one);
         merged = merger.merge(Optional.of(two.getId()), ImmutableSet.of(one, two, three),
-                mergingApplication
+                mergingApplication, Collections.emptySet()
         );
 
         verify(strategy)
                 .merge(
                         argThat(is(two)),
                         argThat(contains(one, three)),
-                        argThat(is(mergingApplication))
+                        argThat(is(mergingApplication)),
+                        Collections.emptySet()
                 );
         reset(strategy);
         setUpMockStrategyToReturn(one);
         merged = merger.merge(Optional.of(three.getId()), ImmutableSet.of(one, two, three),
-                mergingApplication
+                mergingApplication, Collections.emptySet()
         );
 
         verify(strategy)
                 .merge(
                         argThat(is(one)),
                         argThat(contains(two, three)),
-                        argThat(is(mergingApplication))
+                        argThat(is(mergingApplication)),
+                        Collections.emptySet()
                 );
         reset(strategy);
     }
@@ -218,7 +232,8 @@ public class StrategyBackedEquivalentsMergerTest {
         when(strategy.merge(
                 argThat(any(Content.class)),
                 anyCollectionOf(Content.class),
-                argThat(is(mergingApplication))
+                argThat(is(mergingApplication)),
+                Collections.emptySet()
         )).thenReturn(content);
     }
 


### PR DESCRIPTION
Add annotations with more relaxed filters. Purpose is to fix issue where we only show broadcasts from highest-precedence source in cases where it has only very old broadcasts, while there are lower-precedence sources with more recent (including upcoming) broadcasts.

https://metabroadcast.atlassian.net/browse/ENG-302