### PR TITLE
ENG-629 - Changing deprecated TopChildrenQuery to HasChildQuery in ElasticSearch

### DIFF
--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTitleSearcher.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTitleSearcher.java
@@ -32,7 +32,6 @@ import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.FilterBuilders.typeFilter;
 import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
 import static org.elasticsearch.index.query.QueryBuilders.hasChildQuery;
-import static org.elasticsearch.index.query.QueryBuilders.topChildrenQuery;
 
 public class EsContentTitleSearcher implements ContentTitleSearcher {
 

--- a/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTitleSearcher.java
+++ b/atlas-elasticsearch/src/main/java/org/atlasapi/content/EsContentTitleSearcher.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.index.query.FilterBuilders.andFilter;
 import static org.elasticsearch.index.query.FilterBuilders.termFilter;
 import static org.elasticsearch.index.query.FilterBuilders.typeFilter;
 import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
+import static org.elasticsearch.index.query.QueryBuilders.hasChildQuery;
 import static org.elasticsearch.index.query.QueryBuilders.topChildrenQuery;
 
 public class EsContentTitleSearcher implements ContentTitleSearcher {
@@ -106,8 +107,8 @@ public class EsContentTitleSearcher implements ContentTitleSearcher {
                         )
                 )
                 .should(
-                        topChildrenQuery(EsContent.CHILD_ITEM, contentQuery)
-                                .score("sum")
+                        hasChildQuery(EsContent.CHILD_ITEM, contentQuery)
+                                .scoreType("sum")
                 );
 
         final SettableFuture<SearchResults> result = SettableFuture.create();


### PR DESCRIPTION
TopChildrenQuery is deprecated and in some sense broken, as it is causes an ArrayIndexOutOfBoundsException on certain queries, amounting to around 20,000 errors per day. ElasticSearch documentation recommends using HasChildQuery instead, which works in a similar way, but should prevent this problem from occurring.