### PR TITLE
Publisher specific metrics

### DIFF
--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorker.java
@@ -1,26 +1,24 @@
 package org.atlasapi.messaging;
 
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.common.queue.RecoverableException;
+import com.metabroadcast.common.queue.Worker;
+import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.time.Timestamp;
 import org.atlasapi.content.Content;
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.content.Item;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
-
-import com.metabroadcast.common.queue.RecoverableException;
-import com.metabroadcast.common.queue.Worker;
-import com.metabroadcast.common.stream.MoreCollectors;
-import com.metabroadcast.common.time.Timestamp;
-
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,6 +35,12 @@ public class EquivalentScheduleStoreContentUpdateWorker
     private final Meter messageReceivedMeter;
     private final Meter failureMeter;
     private final Timer latencyTimer;
+    private final String publisherExecutionTimerName;
+    private final String publisherMeterName;
+    private final String publisherLatencyTimerName;
+
+    private final MetricRegistry metricRegistry;
+
 
     private EquivalentScheduleStoreContentUpdateWorker(
             EquivalentContentStore contentStore,
@@ -47,10 +51,15 @@ public class EquivalentScheduleStoreContentUpdateWorker
         this.contentStore = checkNotNull(contentStore);
         this.scheduleWriter = checkNotNull(scheduleWriter);
 
+        this.metricRegistry = metricRegistry;
+
         this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
         this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
         this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
         this.latencyTimer = metricRegistry.timer(metricPrefix + "timer.latency");
+        this.publisherMeterName = metricPrefix + "source.%s.meter.received";
+        this.publisherExecutionTimerName = metricPrefix + "source.%s.timer.execution";
+        this.publisherLatencyTimerName = metricPrefix + "source.%s.timer.latency";
     }
 
     public static EquivalentScheduleStoreContentUpdateWorker create(
@@ -69,15 +78,25 @@ public class EquivalentScheduleStoreContentUpdateWorker
 
     @Override
     public void process(EquivalentContentUpdatedMessage message) throws RecoverableException {
+        long start = System.currentTimeMillis();
+
         messageReceivedMeter.mark();
 
         LOG.debug("Processing message on id: {}, took: PT{}S, message: {}",
                 message.getEquivalentSetId(),
-                getTimeToProcessInMIllis(message.getTimestamp()) / 1000L,
+                getTimeToProcessInMillis(message.getTimestamp()) / 1000L,
                 message
         );
 
+        String metricSourceName = message.getContentRef().getSource().key().replace('.', '_');
+
+        metricRegistry.meter(String.format(publisherMeterName, metricSourceName)).mark();
+
+        Timer publisherExecutionTimer = metricRegistry.timer(String.format(publisherExecutionTimerName, metricSourceName));
+        Timer publisherLatencyTimer = metricRegistry.timer(String.format(publisherLatencyTimerName, metricSourceName));
+
         Timer.Context time = executionTimer.time();
+        Timer.Context publisherTime = publisherExecutionTimer.time();
 
         Set<Content> content = Futures.get(
                 contentStore.resolveEquivalentSet(message.getEquivalentSetId()),
@@ -96,19 +115,28 @@ public class EquivalentScheduleStoreContentUpdateWorker
                             .collect(MoreCollectors.toImmutableSet())
             );
 
-            latencyTimer.update(
-                    getTimeToProcessInMIllis(message.getTimestamp()),
-                    TimeUnit.MILLISECONDS
+            long timeToProcessInMillis = getTimeToProcessInMillis(message.getTimestamp());
+
+            latencyTimer.update(timeToProcessInMillis, TimeUnit.MILLISECONDS);
+            publisherLatencyTimer.update(timeToProcessInMillis, TimeUnit.MILLISECONDS);
+
+            long end = System.currentTimeMillis();
+            LOG.info(
+                    "Timings - Source: {}, Execution Time (ms): {}, Latency (ms): {}",
+                    message.getContentRef().getSource().key(),
+                    end - start,
+                    timeToProcessInMillis
             );
         } catch (WriteException e) {
             failureMeter.mark();
             throw new RecoverableException(e);
         } finally {
             time.stop();
+            publisherTime.stop();
         }
     }
 
-    private long getTimeToProcessInMIllis(Timestamp messageTimestamp) {
+    private long getTimeToProcessInMillis(Timestamp messageTimestamp) {
         return System.currentTimeMillis() - messageTimestamp.millis();
     }
 }

--- a/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/messaging/EquivalentScheduleStoreScheduleUpdateWorker.java
@@ -1,20 +1,18 @@
 package org.atlasapi.messaging;
 
-import java.util.concurrent.TimeUnit;
-
-import org.atlasapi.entity.util.WriteException;
-import org.atlasapi.schedule.EquivalentScheduleWriter;
-import org.atlasapi.schedule.ScheduleUpdateMessage;
-
-import com.metabroadcast.common.queue.RecoverableException;
-import com.metabroadcast.common.queue.Worker;
-import com.metabroadcast.common.time.Timestamp;
-
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.metabroadcast.common.queue.RecoverableException;
+import com.metabroadcast.common.queue.Worker;
+import com.metabroadcast.common.time.Timestamp;
+import org.atlasapi.entity.util.WriteException;
+import org.atlasapi.schedule.EquivalentScheduleWriter;
+import org.atlasapi.schedule.ScheduleUpdateMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,6 +27,11 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
     private final Meter messageReceivedMeter;
     private final Meter failureMeter;
     private final Timer latencyTimer;
+    private final String publisherExecutionTimerName;
+    private final String publisherMeterName;
+    private final String publisherLatencyTimerName;
+
+    private final MetricRegistry metricRegistry;
 
     private EquivalentScheduleStoreScheduleUpdateWorker(
             EquivalentScheduleWriter scheduleWriter,
@@ -37,10 +40,15 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
     ) {
         this.scheduleWriter = checkNotNull(scheduleWriter);
 
+        this.metricRegistry = metricRegistry;
+
         this.executionTimer = metricRegistry.timer(metricPrefix + "timer.execution");
         this.messageReceivedMeter = metricRegistry.meter(metricPrefix + "meter.received");
         this.failureMeter = metricRegistry.meter(metricPrefix + "meter.failure");
         this.latencyTimer = metricRegistry.timer(metricPrefix + "timer.latency");
+        this.publisherMeterName = metricPrefix + "source.%s.meter.received";
+        this.publisherExecutionTimerName = metricPrefix + "source.%s.timer.execution";
+        this.publisherLatencyTimerName = metricPrefix + "source.%s.timer.latency";
     }
 
     public static EquivalentScheduleStoreScheduleUpdateWorker create(
@@ -55,6 +63,8 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
 
     @Override
     public void process(ScheduleUpdateMessage message) throws RecoverableException {
+        long start = System.currentTimeMillis();
+
         messageReceivedMeter.mark();
 
         LOG.debug("Processing message on id {}, took: PT{}S, message: {}",
@@ -63,20 +73,37 @@ public class EquivalentScheduleStoreScheduleUpdateWorker implements Worker<Sched
                 message
         );
 
+        String metricSourceName = message.getScheduleUpdate().getSource().key().replace('.', '_');
+
+        metricRegistry.meter(String.format(publisherMeterName, metricSourceName)).mark();
+
+        Timer publisherExecutionTimer = metricRegistry.timer(String.format(publisherExecutionTimerName, metricSourceName));
+        Timer publisherLatencyTimer = metricRegistry.timer(String.format(publisherLatencyTimerName, metricSourceName));
+
         Timer.Context time = executionTimer.time();
+        Timer.Context publisherTime = publisherExecutionTimer.time();
 
         try {
             scheduleWriter.updateSchedule(message.getScheduleUpdate());
 
-            latencyTimer.update(
-                    getTimeToProcessInMillis(message.getTimestamp()),
-                    TimeUnit.MILLISECONDS
+            long timeToProcessInMillis = getTimeToProcessInMillis(message.getTimestamp());
+
+            latencyTimer.update(timeToProcessInMillis, TimeUnit.MILLISECONDS);
+            publisherLatencyTimer.update(timeToProcessInMillis, TimeUnit.MILLISECONDS);
+
+            long end = System.currentTimeMillis();
+            LOG.info(
+                    "Timings - Source: {}, Execution Time (ms): {}, Latency (ms): {}",
+                    message.getScheduleUpdate().getSource().key(),
+                    end - start,
+                    timeToProcessInMillis
             );
         } catch (WriteException e) {
             failureMeter.mark();
             throw new RecoverableException("update failed for " + message.getScheduleUpdate(), e);
         } finally {
             time.stop();
+            publisherTime.stop();
         }
     }
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/BootstrapWorkersModule.java
@@ -106,7 +106,10 @@ public class BootstrapWorkersModule {
 
     private final Set<Publisher> ignoredScheduleSources = Sets.difference(
             Publisher.all(),
-            ImmutableSet.of(Publisher.PA, Publisher.BBC_NITRO, Publisher.BT_BLACKOUT)
+            ImmutableSet.of(
+                    Publisher.PA, Publisher.BBC_NITRO, Publisher.BT_BLACKOUT,
+                    Publisher.YOUVIEW, Publisher.YOUVIEW_SCOTLAND_RADIO, Publisher.YOUVIEW_BT
+            )
     );
 
     @Autowired

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/ScheduleReadWriteWorker.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/workers/ScheduleReadWriteWorker.java
@@ -154,7 +154,7 @@ public class ScheduleReadWriteWorker implements Worker<ScheduleUpdateMessage> {
                     interval
             ).call();
             LOG.debug("{}: processed: {}", updateMsg, result);
-            if (!Publisher.PA.equals(src)) {
+            if (Publisher.BBC_NITRO.equals(src) || Publisher.BT_BLACKOUT.equals(src)) {
                 updatePaSchedule(updateMsg, resolvedChannel, interval);
             }
 

--- a/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorkerTest.java
+++ b/atlas-processing/src/test/java/org/atlasapi/messaging/EquivalentScheduleStoreContentUpdateWorkerTest.java
@@ -1,25 +1,23 @@
 package org.atlasapi.messaging;
 
-import java.util.UUID;
-
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.common.time.Timestamp;
 import org.atlasapi.content.Brand;
 import org.atlasapi.content.EquivalentContentStore;
 import org.atlasapi.content.Item;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.schedule.EquivalentScheduleWriter;
-
-import com.metabroadcast.common.time.Timestamp;
-
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.Futures;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,6 +47,7 @@ public class EquivalentScheduleStoreContentUpdateWorkerTest {
     public void testProcess() throws Exception {
         Long equivalentSetId = 1L;
         Item item1 = new Item(Id.valueOf(1L), Publisher.METABROADCAST);
+        item1.setThisOrChildLastUpdated(DateTime.now());
         Item item2 = new Item(Id.valueOf(2L), Publisher.METABROADCAST);
 
         when(contentStore.resolveEquivalentSet(equivalentSetId))
@@ -62,7 +61,7 @@ public class EquivalentScheduleStoreContentUpdateWorkerTest {
                         UUID.randomUUID().toString(),
                         Timestamp.of(DateTime.now()),
                         equivalentSetId,
-                        null
+                        item1.toRef()
                 )
         );
 
@@ -74,6 +73,7 @@ public class EquivalentScheduleStoreContentUpdateWorkerTest {
     public void testFiltersOutNonItems() throws Exception {
         Long equivalentSetId = 1L;
         Item item1 = new Item(Id.valueOf(1L), Publisher.METABROADCAST);
+        item1.setThisOrChildLastUpdated(DateTime.now());
         Item item2 = new Item(Id.valueOf(2L), Publisher.METABROADCAST);
         Brand brand = new Brand(Id.valueOf(3L), Publisher.METABROADCAST);
 
@@ -88,7 +88,7 @@ public class EquivalentScheduleStoreContentUpdateWorkerTest {
                         UUID.randomUUID().toString(),
                         Timestamp.of(DateTime.now()),
                         equivalentSetId,
-                        null
+                        item1.toRef()
                 )
         );
 


### PR DESCRIPTION
Also enable schedule migration of YouView related publishers to test latencies for possible switch of PA to YouView schedule data for BT.