### PR TITLE
Show years on items in Deer, not just episodes/films

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ContentDescriptionAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ContentDescriptionAnnotation.java
@@ -67,14 +67,12 @@ public class ContentDescriptionAnnotation extends DescriptionAnnotation<Content>
                     writeField("episode_number", episode.getEpisodeNumber());
                 }
                 writeField("series_number", episode.getSeriesNumber());
-                writeField("year", episode.getYear());
                 return null;
             }
 
             @Override
             public Void visit(Film film) {
                 visit((Item) film);
-                writeField("year", film.getYear());
                 return null;
             }
 
@@ -90,6 +88,7 @@ public class ContentDescriptionAnnotation extends DescriptionAnnotation<Content>
 
             @Override
             public Void visit(Item item) {
+                writeField("year", item.getYear());
                 writeObject(displayTitleWriter, item, ctxt);
                 return null;
             }


### PR DESCRIPTION
When you queried Deer for a piece of content, the `year` field was not visible if the content type was item. This change makes that field visible. (ENG-683)