### PR TITLE
Fix null pointer future

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -358,12 +358,16 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                 Collection<Row> graphRowsForId = graphRows.get(id);
                 for (Row row : setRowsForId) {
                     for (int i = 0; i < row.getColumnDefinitions().size(); i++) {
-                        rowBytes += row.getBytesUnsafe(i).remaining();
+                        if (row.getBytesUnsafe(i) != null) {
+                            rowBytes += row.getBytesUnsafe(i).remaining();
+                        }
                     }
                 }
                 for (Row row : graphRowsForId) {
                     for (int i = 0; i < row.getColumnDefinitions().size(); i++) {
-                        rowBytes += row.getBytesUnsafe(i).remaining();
+                        if (row.getBytesUnsafe(i) != null) {
+                            rowBytes += row.getBytesUnsafe(i).remaining();
+                        }
                     }
                 }
                 if(rowBytes > 100000) {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -469,6 +469,11 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                     .map(Content::getId)
                     .collect(MoreCollectors.toImmutableSet());
 
+            java.util.Optional<EquivalenceGraph> graph = graphs.get(setId);
+            if (graph == null) {
+                log.warn("Graph was expected to exist as an optional, but was null. SetId: {}.", setId);
+            }
+
             ImmutableSet<Content> filteredContent = content.get(setId)
                     .stream()
                     .filter(EquivalenceGraphFilter
@@ -478,10 +483,7 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                                     // times from different IDs then arbitrarily pick one
                                     inverseIndex.get(setId).iterator().next()
                             )))
-                            .withGraph(graphs.get(setId) == null
-                                    ? java.util.Optional.empty()
-                                    : graphs.get(setId)
-                            )
+                            .withGraph(graph)
                             .withSelectedSources(selectedSources)
                             .withSelectedGraphSources(selectedSources)
                             .withIds(ids)

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -478,7 +478,10 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                                     // times from different IDs then arbitrarily pick one
                                     inverseIndex.get(setId).iterator().next()
                             )))
-                            .withGraph(graphs.get(setId))
+                            .withGraph(graphs.get(setId) == null
+                                    ? java.util.Optional.empty()
+                                    : graphs.get(setId)
+                            )
                             .withSelectedSources(selectedSources)
                             .withSelectedGraphSources(selectedSources)
                             .withIds(ids)

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -471,7 +471,11 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
 
             java.util.Optional<EquivalenceGraph> graph = graphs.get(setId);
             if (graph == null) {
-                log.warn("Graph was expected to exist as an optional, but was null. SetId: {}.", setId);
+                log.warn("Graph was expected to exist as an optional, but was null for SetId: {}."
+                         + "\nContent keyset: {}\n Graph keyset: {}",
+                        setId,
+                        content.keySet(),
+                        graphs.keySet());
             }
 
             ImmutableSet<Content> filteredContent = content.get(setId)

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
@@ -29,9 +29,37 @@ public class EquivalenceGraphFilter implements Predicate<Content> {
         this.selectedSources = ImmutableSet.copyOf(builder.selectedSources);
         this.allowUnpublishedIds = ImmutableSet.copyOf(builder.allowUnpublishedIds);
 
-        if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
-            this.selectedIds = ImmutableSet.copyOf(builder.ids);
-            return;
+        try {
+            if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
+                //log.info("No problem with graph or graph entry id.");
+            }
+        } catch (Exception e) {
+
+            if (builder.graph == null) {
+                log.error("Builder graph is the problem.");
+                log.warn("graphEntryId:{}\ngraph:{}\nallowUnpublishedIds:{}\nids:{}\nselectedGraphSources:{}\nselectedSources{}",
+                        builder.graphEntryId,
+                        builder.graph,
+                        builder.allowUnpublishedIds,
+                        builder.ids,
+                        builder.selectedGraphSources,
+                        builder.selectedSources);
+            }
+            if (builder.graphEntryId == null) {
+                log.error("Builder graph entry id is the problem.");
+                log.warn("graphEntryId:{}\ngraph:{}\nallowUnpublishedIds:{}\nids:{}\nselectedGraphSources:{}\nselectedSources{}",
+                        builder.graphEntryId,
+                        builder.graph,
+                        builder.allowUnpublishedIds,
+                        builder.ids,
+                        builder.selectedGraphSources,
+                        builder.selectedSources);
+            }
+
+            if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
+                this.selectedIds = ImmutableSet.copyOf(builder.ids);
+                return;
+            }
         }
 
         if (!builder.ids.contains(builder.graphEntryId.get())) {

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
@@ -29,35 +29,9 @@ public class EquivalenceGraphFilter implements Predicate<Content> {
         this.selectedSources = ImmutableSet.copyOf(builder.selectedSources);
         this.allowUnpublishedIds = ImmutableSet.copyOf(builder.allowUnpublishedIds);
 
-        try {
-            if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
-                this.selectedIds = ImmutableSet.copyOf(builder.ids);
-                return;
-            }
-        } catch (Exception e) {
-
-            if (builder.graph == null) {
-                log.error("Builder graph is the problem.");
-                log.warn("graphEntryId:{}\ngraph:{}\nallowUnpublishedIds:{}\nids:{}\nselectedGraphSources:{}\nselectedSources{}",
-                        builder.graphEntryId,
-                        builder.graph,
-                        builder.allowUnpublishedIds,
-                        builder.ids,
-                        builder.selectedGraphSources,
-                        builder.selectedSources);
-            }
-            if (builder.graphEntryId == null) {
-                log.error("Builder graph entry id is the problem.");
-                log.warn("graphEntryId:{}\ngraph:{}\nallowUnpublishedIds:{}\nids:{}\nselectedGraphSources:{}\nselectedSources{}",
-                        builder.graphEntryId,
-                        builder.graph,
-                        builder.allowUnpublishedIds,
-                        builder.ids,
-                        builder.selectedGraphSources,
-                        builder.selectedSources);
-            }
-
-            throw new NullPointerException("Equiv Graph Filter problem");
+        if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
+            this.selectedIds = ImmutableSet.copyOf(builder.ids);
+            return;
         }
 
         if (!builder.ids.contains(builder.graphEntryId.get())) {

--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphFilter.java
@@ -31,7 +31,8 @@ public class EquivalenceGraphFilter implements Predicate<Content> {
 
         try {
             if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
-                //log.info("No problem with graph or graph entry id.");
+                this.selectedIds = ImmutableSet.copyOf(builder.ids);
+                return;
             }
         } catch (Exception e) {
 
@@ -56,10 +57,7 @@ public class EquivalenceGraphFilter implements Predicate<Content> {
                         builder.selectedSources);
             }
 
-            if (!builder.graph.isPresent() || !builder.graphEntryId.isPresent()) {
-                this.selectedIds = ImmutableSet.copyOf(builder.ids);
-                return;
-            }
+            throw new NullPointerException("Equiv Graph Filter problem");
         }
 
         if (!builder.ids.contains(builder.graphEntryId.get())) {


### PR DESCRIPTION
EquivalenceGraphFilter was causing NullPointerException when trying to get the value of an equivalence graph, added null check for this.
Also added null check for calculating unsafe bytes method.