### PR TITLE
Add cache bypass query parameter

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -9,7 +9,6 @@ import com.metabroadcast.common.query.Selection;
 import com.metabroadcast.common.query.Selection.SelectionBuilder;
 import com.metabroadcast.common.time.SystemClock;
 import com.metabroadcast.representative.client.RepIdClient;
-
 import org.atlasapi.AtlasPersistenceModule;
 import org.atlasapi.LicenseModule;
 import org.atlasapi.annotation.Annotation;
@@ -603,6 +602,10 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.HIGHER_READ_CONSISTENCY,
                                 BooleanCoercer.create()
+                        ),
+                        QueryAtomParser.create(
+                                Attributes.T,
+                                StringCoercer.create()
                         )
                 )
         );
@@ -766,7 +769,7 @@ public class QueryWebModule {
                                 IdCoercer.create(idCodec())
                         ),
                         QueryAtomParser.create(
-                                Attributes.CHANNEL_GROUP_REQUEST_TIMESTAMP,
+                                Attributes.T,
                                 StringCoercer.create()
                         )
                 )
@@ -827,6 +830,10 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.REFRESH_CACHE,
                                 StringCoercer.create()
+                        ),
+                        QueryAtomParser.create(
+                                Attributes.T,
+                                StringCoercer.create()
                         )
                 )
         );
@@ -862,6 +869,10 @@ public class QueryWebModule {
                                 QueryAtomParser.create(
                                         Attributes.ALIASES_VALUE,
                                         StringCoercer.create()
+                                ),
+                                QueryAtomParser.create(
+                                        Attributes.T,
+                                        StringCoercer.create()
                                 )
                         )
                 ),
@@ -895,6 +906,10 @@ public class QueryWebModule {
                                 QueryAtomParser.create(
                                         Attributes.ALIASES_VALUE,
                                         StringCoercer.create()
+                                ),
+                                QueryAtomParser.create(
+                                        Attributes.T,
+                                        StringCoercer.create()
                                 )
                         )
                 ),
@@ -914,6 +929,10 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.ID,
                                 IdCoercer.create(idCodec())
+                        ),
+                        QueryAtomParser.create(
+                                Attributes.T,
+                                StringCoercer.create()
                         )
                 )),
                 idCodec(), contextParser

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -602,10 +602,6 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.HIGHER_READ_CONSISTENCY,
                                 BooleanCoercer.create()
-                        ),
-                        QueryAtomParser.create(
-                                Attributes.T,
-                                StringCoercer.create()
                         )
                 )
         );
@@ -767,10 +763,6 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.CHANNEL_GROUP_IDS,
                                 IdCoercer.create(idCodec())
-                        ),
-                        QueryAtomParser.create(
-                                Attributes.T,
-                                StringCoercer.create()
                         )
                 )
         );
@@ -830,10 +822,6 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.REFRESH_CACHE,
                                 StringCoercer.create()
-                        ),
-                        QueryAtomParser.create(
-                                Attributes.T,
-                                StringCoercer.create()
                         )
                 )
         );
@@ -869,10 +857,6 @@ public class QueryWebModule {
                                 QueryAtomParser.create(
                                         Attributes.ALIASES_VALUE,
                                         StringCoercer.create()
-                                ),
-                                QueryAtomParser.create(
-                                        Attributes.T,
-                                        StringCoercer.create()
                                 )
                         )
                 ),
@@ -906,10 +890,6 @@ public class QueryWebModule {
                                 QueryAtomParser.create(
                                         Attributes.ALIASES_VALUE,
                                         StringCoercer.create()
-                                ),
-                                QueryAtomParser.create(
-                                        Attributes.T,
-                                        StringCoercer.create()
                                 )
                         )
                 ),
@@ -929,10 +909,6 @@ public class QueryWebModule {
                         QueryAtomParser.create(
                                 Attributes.ID,
                                 IdCoercer.create(idCodec())
-                        ),
-                        QueryAtomParser.create(
-                                Attributes.T,
-                                StringCoercer.create()
                         )
                 )),
                 idCodec(), contextParser

--- a/atlas-api/src/main/java/org/atlasapi/query/common/validation/AbstractRequestParameterValidator.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/common/validation/AbstractRequestParameterValidator.java
@@ -1,15 +1,19 @@
 package org.atlasapi.query.common.validation;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import org.atlasapi.query.common.exceptions.InvalidParameterException;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.Collection;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.atlasapi.query.common.exceptions.InvalidParameterException;
-
-import com.google.common.base.Joiner;
-
 public abstract class AbstractRequestParameterValidator {
+
+    // This attribute is used only to prevent browsers from using a cached result for the same request
+    public static final String T_PARAM = "t";
+
+    public static final Set<String> ALWAYS_OPTIONAL_PARAMS = ImmutableSet.of(T_PARAM);
 
     protected static final Joiner commaJoiner = Joiner.on(", ");
 

--- a/atlas-api/src/main/java/org/atlasapi/query/common/validation/QueryRequestParameterValidator.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/common/validation/QueryRequestParameterValidator.java
@@ -1,20 +1,19 @@
 package org.atlasapi.query.common.validation;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.query.common.ParameterNameProvider;
-import org.atlasapi.query.common.attributes.PrefixInTree;
-import org.atlasapi.query.common.attributes.QueryAttributeParser;
-
 import com.google.api.client.repackaged.com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.atlasapi.query.common.ParameterNameProvider;
+import org.atlasapi.query.common.attributes.PrefixInTree;
+import org.atlasapi.query.common.attributes.QueryAttributeParser;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.not;
@@ -33,7 +32,7 @@ public class QueryRequestParameterValidator extends AbstractRequestParameterVali
     ) {
         this.attributeParameters = initAttributeParams(attributeParser);
         this.requiredParameters = ImmutableSet.copyOf(requiredParameters);
-        this.optionalParameters = ImmutableSet.copyOf(optionalParameters);
+        this.optionalParameters = Sets.union(optionalParameters, ALWAYS_OPTIONAL_PARAMS).immutableCopy();
         this.replacementSuggestion = ReplacementSuggestion.create(
                 allParams(),
                 "Invalid parameters: ",

--- a/atlas-api/src/main/java/org/atlasapi/query/common/validation/SetBasedRequestParameterValidator.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/common/validation/SetBasedRequestParameterValidator.java
@@ -1,11 +1,11 @@
 package org.atlasapi.query.common.validation;
 
-import java.util.Collection;
-import java.util.Set;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+
+import java.util.Collection;
+import java.util.Set;
 
 public class SetBasedRequestParameterValidator extends AbstractRequestParameterValidator {
 
@@ -23,7 +23,7 @@ public class SetBasedRequestParameterValidator extends AbstractRequestParameterV
             Set<String> requiredAlternativeParams
     ) {
         this.requiredParams = ImmutableSet.copyOf(requiredParams);
-        this.optionalParams = ImmutableSet.copyOf(optionalParams);
+        this.optionalParams = Sets.union(optionalParams, ALWAYS_OPTIONAL_PARAMS).immutableCopy();
         this.requiredAlternativeParams = ImmutableSet.copyOf(requiredAlternativeParams);
         this.allParams = ImmutableSet.copyOf(
                 Sets.union(

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleRequestParser.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleRequestParser.java
@@ -1,13 +1,16 @@
 package org.atlasapi.query.v4.schedule;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
-
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
 import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.time.Clock;
+import com.metabroadcast.common.webapp.query.DateTimeInQueryParser;
 import org.atlasapi.application.ApplicationFetcher;
 import org.atlasapi.application.ApplicationResolutionException;
 import org.atlasapi.content.QueryParseException;
@@ -20,21 +23,15 @@ import org.atlasapi.query.common.exceptions.InvalidAnnotationException;
 import org.atlasapi.query.common.exceptions.MissingAnnotationException;
 import org.atlasapi.query.common.validation.SetBasedRequestParameterValidator;
 import org.atlasapi.source.Sources;
-
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.time.Clock;
-import com.metabroadcast.common.webapp.query.DateTimeInQueryParser;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Range;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.metabroadcast.common.webapp.query.DateTimeInQueryParser.queryDateTimeParser;
@@ -57,6 +54,7 @@ class ScheduleRequestParser {
     private static final String CALLBACK_PARAM = "callback";
     private static final String ID_PARAM = "id";
     private static final String ORDER_BY = "order_by";
+    private static final String TIMESTAMP_PARAM = "t";
 
     private final ApplicationFetcher applicationFetcher;
 
@@ -101,7 +99,7 @@ class ScheduleRequestParser {
         return SetBasedRequestParameterValidator.builder()
             .withRequiredParameters(required.toArray(new String[required.size()]))
             .withOptionalParameters(
-                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM)
+                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM, TIMESTAMP_PARAM)
             .withRequiredAlternativeParameters(TO_PARAM, COUNT_PARAM)
             .build();
     }
@@ -116,7 +114,7 @@ class ScheduleRequestParser {
         return SetBasedRequestParameterValidator.builder()
             .withRequiredParameters(required.toArray(new String[required.size()]))
             .withOptionalParameters(
-                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM)
+                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM, TIMESTAMP_PARAM)
             .withRequiredAlternativeParameters(TO_PARAM, COUNT_PARAM)
             .build();
     }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleRequestParser.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/ScheduleRequestParser.java
@@ -54,7 +54,6 @@ class ScheduleRequestParser {
     private static final String CALLBACK_PARAM = "callback";
     private static final String ID_PARAM = "id";
     private static final String ORDER_BY = "order_by";
-    private static final String TIMESTAMP_PARAM = "t";
 
     private final ApplicationFetcher applicationFetcher;
 
@@ -99,7 +98,7 @@ class ScheduleRequestParser {
         return SetBasedRequestParameterValidator.builder()
             .withRequiredParameters(required.toArray(new String[required.size()]))
             .withOptionalParameters(
-                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM, TIMESTAMP_PARAM)
+                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM)
             .withRequiredAlternativeParameters(TO_PARAM, COUNT_PARAM)
             .build();
     }
@@ -114,7 +113,7 @@ class ScheduleRequestParser {
         return SetBasedRequestParameterValidator.builder()
             .withRequiredParameters(required.toArray(new String[required.size()]))
             .withOptionalParameters(
-                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM, TIMESTAMP_PARAM)
+                    ANNOTATIONS_PARAM, CALLBACK_PARAM, ORDER_BY, OVERRIDE_SOURCE_PARAM)
             .withRequiredAlternativeParameters(TO_PARAM, COUNT_PARAM)
             .build();
     }

--- a/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
+++ b/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
@@ -124,11 +124,6 @@ public class Attributes {
             "ids",
             ChannelGroup.class
     );
-    // This attribute is used only to prevent browsers from using a cached result for the same request
-    public static final Attribute<String> T = StringAttribute.list(
-            "t",
-            Identified.class
-    );
     public static final Attribute<String> Q = StringAttribute.single(
             "q",
             Identified.class

--- a/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
+++ b/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
@@ -124,11 +124,10 @@ public class Attributes {
             "ids",
             ChannelGroup.class
     );
-    // This attribute is used only to avoid Chrome caching the same channel group request and load
-    // the cached result
-    public static final Attribute<String> CHANNEL_GROUP_REQUEST_TIMESTAMP = StringAttribute.list(
+    // This attribute is used only to prevent browsers from using a cached result for the same request
+    public static final Attribute<String> T = StringAttribute.list(
             "t",
-            ChannelGroup.class
+            Identified.class
     );
     public static final Attribute<String> Q = StringAttribute.single(
             "q",


### PR DESCRIPTION
The query parameter is added for all endpoints and is simply named 't', and can be used to bypass any caching when required.