### PR TITLE
Fix lowest id messing source precedence data

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -582,32 +582,29 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Iterable<T> notChosen) {
 
         if (application.getConfiguration().isImagePrecedenceEnabled()) {
-            T top = null;
 
             // ENG-675: chosen's publisher and id have been modified at this point and so might have become
             // lower precedence. We perform this check separately so that we can keep the chosen content's image
             // if applicable, since it will be highest precedence.
             if(HAS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER_SET.apply(chosen)) {
-                top = chosen;
-            } else {
-                Iterable<T> all = Iterables.concat(ImmutableList.of(chosen), notChosen);
-                List<T> topImageMatches = application.getConfiguration()
-                        .getImageReadPrecedenceOrdering()
-                        .onResultOf(Sourceds.toPublisher())
-                        .leastOf(
-                                Iterables.filter(
-                                        all,
-                                        HAS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER_SET
-                                ),
-                                1
-                        );
-
-                if (!topImageMatches.isEmpty()) {
-                    top = topImageMatches.get(0);
-                }
+                // We're not setting the image source here since we don't know the actual publisher at this point
+                return;
             }
 
-            if (top != null) {
+            Iterable<T> all = Iterables.concat(ImmutableList.of(chosen), notChosen);
+            List<T> topImageMatches = application.getConfiguration()
+                    .getImageReadPrecedenceOrdering()
+                    .onResultOf(Sourceds.toPublisher())
+                    .leastOf(
+                            Iterables.filter(
+                                    all,
+                                    HAS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER_SET
+                            ),
+                            1
+                    );
+
+            if (!topImageMatches.isEmpty()) {
+                T top = topImageMatches.get(0);
                 Publisher source = top.getSource();
                 top.getImages().forEach(img -> img.setSource(source));
                 chosen.setImages(top.getImages());

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -584,8 +584,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         if (application.getConfiguration().isImagePrecedenceEnabled()) {
             T top = null;
 
-            // chosen might already have highest precedence source image, so no need to look for others
-            // (looking for others might even give us an incorrect result; see ENG-675)
+            // ENG-675: chosen's publisher and id have been modified at this point and so might have become
+            // lower precedence. We perform this check separately so that we can keep the chosen content's image
+            // if applicable, since it will be highest precedence.
             if(HAS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER_SET.apply(chosen)) {
                 top = chosen;
             } else {

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -580,6 +580,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     private <T extends Described> void applyImagePrefs(Application application, T chosen,
             Iterable<T> notChosen) {
+
+        // chosen might already have highest precedence source image, so no need to look for others
+        // (looking for others might even give us an incorrect result; see ENG-675)
         if(chosen.getImage() != null && isImageAvailableAndNotGenericImageContentPlayer(chosen.getImage(), chosen.getImages())) {
             return;
         }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -605,8 +605,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
             if (!topImageMatches.isEmpty()) {
                 T top = topImageMatches.get(0);
-                Publisher source = top.getSource();
-                top.getImages().forEach(img -> img.setSource(source));
+                top.getImages().forEach(img -> img.setSource(top.getSource()));
                 chosen.setImages(top.getImages());
                 chosen.setImage(top.getImage());
                 chosen.setThumbnail(top.getThumbnail());

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -219,9 +219,12 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     }
 
     @Override
-    public <T extends Content> T merge(T chosen, final Iterable<? extends T> equivalents,
+    public <T extends Content> T merge(
+            T chosen,
+            final Iterable<? extends T> equivalents,
             final Application application,
-            Set<Annotation> activeAnnotations) {
+            Set<Annotation> activeAnnotations
+    ) {
         chosen = createChosen(chosen, equivalents);
         chosen = mergeIdAndEquivTo(chosen);
         return chosen.accept(new ContentVisitorAdapter<T>() {
@@ -577,6 +580,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     private <T extends Described> void applyImagePrefs(Application application, T chosen,
             Iterable<T> notChosen) {
+        if(chosen.getImage() != null && isImageAvailableAndNotGenericImageContentPlayer(chosen.getImage(), chosen.getImages())) {
+            return;
+        }
         Iterable<T> all = Iterables.concat(ImmutableList.of(chosen), notChosen);
         if (application.getConfiguration().isImagePrecedenceEnabled()) {
 

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -581,9 +581,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     private <T extends Described> void applyImagePrefs(Application application, T chosen,
             Iterable<T> notChosen) {
 
-        Iterable<T> all = Iterables.concat(ImmutableList.of(chosen), notChosen);
         if (application.getConfiguration().isImagePrecedenceEnabled()) {
-
             T top = null;
 
             // chosen might already have highest precedence source image, so no need to look for others
@@ -591,6 +589,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             if(HAS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER_SET.apply(chosen)) {
                 top = chosen;
             } else {
+                Iterable<T> all = Iterables.concat(ImmutableList.of(chosen), notChosen);
                 List<T> topImageMatches = application.getConfiguration()
                         .getImageReadPrecedenceOrdering()
                         .onResultOf(Sourceds.toPublisher())


### PR DESCRIPTION
(branch name is misleading)

This is to solve a merging logic bug where data from highest precedence source gets overwritten because of a weird, hacky coding related to showing lowest ID (and its publisher) in the merged result. See ENG-675, but basically this will fix the bug related to images only - rest of fields are out of scope because we'd rather rework this bit of the pipeline instead of fixing each field one by one.