### PR TITLE
Rework merging pipeline: eng-820

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/content/Brand.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Brand.java
@@ -70,7 +70,7 @@ public class Brand extends Container {
     }
 
     @Override
-    public Described createNew() {
+    public Brand createNew() {
         return new Brand();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Brand.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Brand.java
@@ -15,10 +15,11 @@ permissions and limitations under the License. */
 
 package org.atlasapi.content;
 
-import com.google.common.collect.ImmutableList;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author Robert Chatley (robert@metabroadcast.com)
@@ -79,7 +80,9 @@ public class Brand extends Container {
 
     public static Brand copyToPreferNonNull(Brand from, Brand to) {
         Container.copyToPreferNonNull(from, to);
-        to.seriesRefs = from.seriesRefs.isEmpty() ? to.seriesRefs : from.seriesRefs;
+        to.seriesRefs = from.seriesRefs == null || from.seriesRefs.isEmpty()
+                        ? to.seriesRefs
+                        : from.seriesRefs;
         return to;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Brand.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Brand.java
@@ -69,6 +69,11 @@ public class Brand extends Container {
         return Brand.copyTo(this, new Brand());
     }
 
+    @Override
+    public Described createNew() {
+        return new Brand();
+    }
+
     public <V> V accept(ContainerVisitor<V> visitor) {
         return visitor.visit(this);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Brand.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Brand.java
@@ -69,6 +69,20 @@ public class Brand extends Container {
         return Brand.copyTo(this, new Brand());
     }
 
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Brand) {
+            copyToPreferNonNull(this, (Brand) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Brand copyToPreferNonNull(Brand from, Brand to) {
+        Container.copyToPreferNonNull(from, to);
+        to.seriesRefs = from.seriesRefs.isEmpty() ? to.seriesRefs : from.seriesRefs;
+        return to;
+    }
+
     @Override
     public Brand createNew() {
         return new Brand();

--- a/atlas-core/src/main/java/org/atlasapi/content/Clip.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Clip.java
@@ -76,6 +76,11 @@ public class Clip extends Item {
     }
 
     @Override
+    public Song createNew() {
+        return new Song();
+    }
+
+    @Override
     public <V> V accept(ItemVisitor<V> visitor) {
         return visitor.visit(this);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Clip.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Clip.java
@@ -76,8 +76,8 @@ public class Clip extends Item {
     }
 
     @Override
-    public Song createNew() {
-        return new Song();
+    public Clip createNew() {
+        return new Clip();
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/content/Clip.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Clip.java
@@ -6,6 +6,8 @@ import org.atlasapi.meta.annotations.FieldName;
 
 import com.google.common.base.Function;
 
+import static java.util.Optional.ofNullable;
+
 public class Clip extends Item {
 
     private String clipOf;
@@ -69,6 +71,20 @@ public class Clip extends Item {
             return to;
         }
         return super.copyTo(to);
+    }
+
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Clip) {
+            copyToPreferNonNull(this, (Clip) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Clip copyToPreferNonNull(Clip from, Clip to) {
+        Item.copyToPreferNonNull(from, to);
+        to.clipOf = ofNullable(from.clipOf).orElse(to.clipOf);
+        return to;
     }
 
     @Override public Clip copy() {

--- a/atlas-core/src/main/java/org/atlasapi/content/Container.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Container.java
@@ -63,6 +63,23 @@ public abstract class Container extends Content {
         return super.copyTo(to);
     }
 
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Container) {
+            copyToPreferNonNull(this, (Container) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Container copyToPreferNonNull(Container from, Container to) {
+        Content.copyToPreferNonNull(from, to);
+        to.itemRefs = from.itemRefs.isEmpty() ? to.itemRefs : from.itemRefs;
+        to.upcomingContent = from.upcomingContent.isEmpty() ? to.upcomingContent : from.upcomingContent;
+        to.availableContent = from.availableContent.isEmpty() ? to.availableContent : from.availableContent;
+        to.itemSummaries = from.itemSummaries.isEmpty() ? to.itemSummaries : from.itemSummaries;
+        return to;
+    }
+
     public abstract <V> V accept(ContainerVisitor<V> visitor);
 
     public abstract ContainerRef toRef();

--- a/atlas-core/src/main/java/org/atlasapi/content/Container.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Container.java
@@ -1,17 +1,20 @@
 package org.atlasapi.content;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.metabroadcast.common.stream.MoreCollectors;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.StreamSupport;
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 public abstract class Container extends Content {
 
@@ -73,10 +76,18 @@ public abstract class Container extends Content {
 
     public static Container copyToPreferNonNull(Container from, Container to) {
         Content.copyToPreferNonNull(from, to);
-        to.itemRefs = from.itemRefs.isEmpty() ? to.itemRefs : from.itemRefs;
-        to.upcomingContent = from.upcomingContent.isEmpty() ? to.upcomingContent : from.upcomingContent;
-        to.availableContent = from.availableContent.isEmpty() ? to.availableContent : from.availableContent;
-        to.itemSummaries = from.itemSummaries.isEmpty() ? to.itemSummaries : from.itemSummaries;
+        to.itemRefs = from.itemRefs == null || from.itemRefs.isEmpty()
+                      ? to.itemRefs
+                      : from.itemRefs;
+        to.upcomingContent = from.upcomingContent == null || from.upcomingContent.isEmpty()
+                             ? to.upcomingContent
+                             : from.upcomingContent;
+        to.availableContent = from.availableContent == null || from.availableContent.isEmpty()
+                              ? to.availableContent
+                              : from.availableContent;
+        to.itemSummaries = from.itemSummaries == null || from.itemSummaries.isEmpty()
+                           ? to.itemSummaries
+                           : from.itemSummaries;
         return to;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/ContentGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/ContentGroup.java
@@ -92,7 +92,7 @@ public class ContentGroup extends Described
     }
 
     @Override
-    public Described createNew() {
+    public ContentGroup createNew() {
         return new ContentGroup();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/ContentGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/ContentGroup.java
@@ -91,6 +91,11 @@ public class ContentGroup extends Described
         return copyTo(this, new ContentGroup());
     }
 
+    @Override
+    public Described createNew() {
+        return new ContentGroup();
+    }
+
     public ContentGroupRef contentGroupRef() {
         return new ContentGroupRef(getId(), getCanonicalUri());
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Described.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Described.java
@@ -413,6 +413,9 @@ public abstract class Described extends Identified implements Sourced {
 
     public abstract Described copy();
 
+    //Allows to create a new content of the same type without having to know or figure out the type
+    public abstract Described createNew();
+
     public <T extends Described> boolean isEquivalentTo(T content) {
         return getEquivalentTo().contains(EquivalenceRef.valueOf(content))
                 || Iterables.contains(

--- a/atlas-core/src/main/java/org/atlasapi/content/Described.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Described.java
@@ -357,6 +357,9 @@ public abstract class Described extends Identified implements Sourced {
         to.reviews = from.reviews;
         to.ratings = from.ratings;
         to.awards = from.awards;
+        to.synopses = from.synopses;
+        to.priority = from.priority;
+        to.relatedLinks = from.relatedLinks;
         return to;
     }
 
@@ -391,6 +394,10 @@ public abstract class Described extends Identified implements Sourced {
         to.reviews = from.reviews.isEmpty() ? to.reviews : from.reviews;
         to.ratings = from.ratings.isEmpty() ? to.ratings : from.ratings;
         to.awards = from.awards.isEmpty() ? to.awards : from.awards;
+        //the following were added here later (they seemed to be missing)
+        to.synopses = ofNullable(from.synopses).orElse(to.synopses);
+        to.priority = ofNullable(from.priority).orElse(to.priority);
+        to.relatedLinks = from.relatedLinks.isEmpty() ? to.relatedLinks : from.relatedLinks;
         return to;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Episode.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Episode.java
@@ -21,9 +21,6 @@ import javax.annotation.Nullable;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
-import org.atlasapi.segment.SegmentEvent;
-
-import com.google.common.collect.Sets;
 
 import static java.util.Optional.ofNullable;
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Episode.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Episode.java
@@ -143,6 +143,11 @@ public class Episode extends Item {
         );
     }
 
+    @Override
+    public Episode createNew() {
+        return new Episode();
+    }
+
     public <V> V accept(ItemVisitor<V> visitor) {
         return visitor.visit(this);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Episode.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Episode.java
@@ -21,6 +21,11 @@ import javax.annotation.Nullable;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
+import org.atlasapi.segment.SegmentEvent;
+
+import com.google.common.collect.Sets;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * @author Robert Chatley (robert@metabroadcast.com)
@@ -91,10 +96,9 @@ public class Episode extends Item {
         setSeriesRef(series.toRef());
     }
 
-    @FieldName("series_ref")
-    public
     @Nullable
-    SeriesRef getSeriesRef() {
+    @FieldName("series_ref")
+    public SeriesRef getSeriesRef() {
         return seriesRef;
     }
 
@@ -124,6 +128,24 @@ public class Episode extends Item {
             return to;
         }
         return super.copyTo(to);
+    }
+
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Episode) {
+            copyToPreferNonNull(this, (Episode) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Episode copyToPreferNonNull(Episode from, Episode to) {
+        Item.copyToPreferNonNull(from, to);
+        to.seriesNumber = ofNullable(from.seriesNumber).orElse(to.seriesNumber);
+        to.episodeNumber = ofNullable(from.episodeNumber).orElse(to.episodeNumber);
+        to.partNumber = ofNullable(from.partNumber).orElse(to.partNumber);
+        to.special = ofNullable(from.special).orElse(to.special);
+        to.seriesRef = ofNullable(from.seriesRef).orElse(to.seriesRef);
+        return to;
     }
 
     @Override public Episode copy() {

--- a/atlas-core/src/main/java/org/atlasapi/content/Film.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Film.java
@@ -8,6 +8,8 @@ import org.atlasapi.meta.annotations.FieldName;
 
 import com.google.common.collect.ImmutableSet;
 
+import static java.util.Optional.ofNullable;
+
 public class Film extends Item {
 
     private String websiteUrl = null;
@@ -78,6 +80,21 @@ public class Film extends Item {
             return to;
         }
         return super.copyTo(to);
+    }
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Film) {
+            copyToPreferNonNull(this, (Film) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Film copyToPreferNonNull(Film from, Film to) {
+        Item.copyToPreferNonNull(from, to);
+        to.websiteUrl = ofNullable(from.websiteUrl).orElse(to.websiteUrl);
+        to.subtitles = from.subtitles.isEmpty() ? to.subtitles : from.subtitles;
+        to.releaseDates = from.releaseDates.isEmpty() ? to.releaseDates : from.releaseDates;
+        return to;
     }
 
     @Override public Film copy() {

--- a/atlas-core/src/main/java/org/atlasapi/content/Film.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Film.java
@@ -92,8 +92,8 @@ public class Film extends Item {
     public static Film copyToPreferNonNull(Film from, Film to) {
         Item.copyToPreferNonNull(from, to);
         to.websiteUrl = ofNullable(from.websiteUrl).orElse(to.websiteUrl);
-        to.subtitles = from.subtitles.isEmpty() ? to.subtitles : from.subtitles;
-        to.releaseDates = from.releaseDates.isEmpty() ? to.releaseDates : from.releaseDates;
+        to.subtitles = from.subtitles == null || from.subtitles.isEmpty() ? to.subtitles : from.subtitles;
+        to.releaseDates = from.releaseDates == null || from.releaseDates.isEmpty() ? to.releaseDates : from.releaseDates;
         return to;
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Film.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Film.java
@@ -85,8 +85,8 @@ public class Film extends Item {
     }
 
     @Override
-    public Song createNew() {
-        return new Song();
+    public Film createNew() {
+        return new Film();
     }
 
     public <V> V accept(ItemVisitor<V> visitor) {

--- a/atlas-core/src/main/java/org/atlasapi/content/Film.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Film.java
@@ -84,6 +84,11 @@ public class Film extends Item {
         return copyTo(this, new Film());
     }
 
+    @Override
+    public Song createNew() {
+        return new Song();
+    }
+
     public <V> V accept(ItemVisitor<V> visitor) {
         return visitor.visit(this);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Item.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Item.java
@@ -206,6 +206,10 @@ public class Item extends Content {
         return copyTo(this, new Item());
     }
 
+    public Item createNew() {
+        return new Item();
+    }
+
     public Item withSortKey(String sortKey) {
         this.sortKey = sortKey;
         return this;

--- a/atlas-core/src/main/java/org/atlasapi/content/Item.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Item.java
@@ -206,6 +206,7 @@ public class Item extends Content {
         return copyTo(this, new Item());
     }
 
+    @Override
     public Item createNew() {
         return new Item();
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Item.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Item.java
@@ -14,22 +14,22 @@
  permissions and limitations under the License. */
 package org.atlasapi.content;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import org.joda.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.metabroadcast.common.intl.Country;
+import javax.annotation.Nullable;
+
 import org.atlasapi.entity.Id;
 import org.atlasapi.hashing.ExcludeFromHash;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 import org.atlasapi.segment.SegmentEvent;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.joda.time.Duration;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Optional.ofNullable;
@@ -178,9 +178,15 @@ public class Item extends Content {
         to.containerRef = ofNullable(from.containerRef).orElse(to.containerRef);
         to.containerSummary = ofNullable(from.containerSummary).orElse(to.containerSummary);
         to.isLongForm = from.isLongForm;
-        to.broadcasts = from.broadcasts == null || from.broadcasts.isEmpty() ? to.broadcasts : Sets.newLinkedHashSet(from.broadcasts);
-        to.segmentEvents = from.segmentEvents.isEmpty() ? to.segmentEvents : SegmentEvent.ORDERING.immutableSortedCopy(from.segmentEvents);
-        to.restrictions = from.restrictions.isEmpty() ? to.restrictions : Sets.newHashSet(from.restrictions);
+        to.broadcasts = from.broadcasts == null || from.broadcasts.isEmpty()
+                        ? to.broadcasts
+                        : Sets.newLinkedHashSet(from.broadcasts);
+        to.segmentEvents = from.segmentEvents == null || from.segmentEvents.isEmpty()
+                           ? to.segmentEvents
+                           : SegmentEvent.ORDERING.immutableSortedCopy(from.segmentEvents);
+        to.restrictions = from.restrictions.isEmpty()
+                          ? to.restrictions
+                          : Sets.newHashSet(from.restrictions);
         to.blackAndWhite = ofNullable(from.blackAndWhite).orElse(to.blackAndWhite);
         to.duration = ofNullable(from.duration).orElse(to.duration);
         return to;

--- a/atlas-core/src/main/java/org/atlasapi/content/Player.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Player.java
@@ -19,4 +19,9 @@ public class Player extends Described {
         return copyTo(this, new Player());
     }
 
+    @Override
+    public Described createNew() {
+        return new Player();
+    }
+
 }

--- a/atlas-core/src/main/java/org/atlasapi/content/Series.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Series.java
@@ -7,6 +7,8 @@ import org.atlasapi.meta.annotations.FieldName;
 
 import javax.annotation.Nullable;
 
+import static java.util.Optional.ofNullable;
+
 public class Series extends Container {
 
     private Integer seriesNumber;
@@ -71,6 +73,22 @@ public class Series extends Container {
 
     @Override public Series copy() {
         return copyTo(this, new Series());
+    }
+
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Series) {
+            copyToPreferNonNull(this, (Series) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Series copyToPreferNonNull(Series from, Series to) {
+        Container.copyToPreferNonNull(from, to);
+        to.seriesNumber = ofNullable(from.seriesNumber).orElse(to.seriesNumber);
+        to.totalEpisodes = ofNullable(from.totalEpisodes).orElse(to.totalEpisodes);
+        to.brandRef = ofNullable(from.brandRef).orElse(to.brandRef);
+        return to;
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/content/Series.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Series.java
@@ -74,7 +74,7 @@ public class Series extends Container {
     }
 
     @Override
-    public Described createNew() {
+    public Series createNew() {
         return new Series();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Series.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Series.java
@@ -73,6 +73,11 @@ public class Series extends Container {
         return copyTo(this, new Series());
     }
 
+    @Override
+    public Described createNew() {
+        return new Series();
+    }
+
     public SeriesRef toRef() {
         return new SeriesRef(getId(), getSource(), Strings.nullToEmpty(this.getTitle()),
                 this.seriesNumber, getThisOrChildLastUpdated(), getYear(), getCertificates()

--- a/atlas-core/src/main/java/org/atlasapi/content/Service.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Service.java
@@ -20,7 +20,7 @@ public class Service extends Described {
     }
 
     @Override
-    public Described createNew() {
+    public Service createNew() {
         return new Service();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/content/Service.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Service.java
@@ -19,4 +19,9 @@ public class Service extends Described {
         return copyTo(this, new Service());
     }
 
+    @Override
+    public Described createNew() {
+        return new Service();
+    }
+
 }

--- a/atlas-core/src/main/java/org/atlasapi/content/Song.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Song.java
@@ -64,6 +64,11 @@ public class Song extends Item {
         return copyTo(this, new Song());
     }
 
+    @Override
+    public Song createNew() {
+        return new Song();
+    }
+
     public <V> V accept(ItemVisitor<V> visitor) {
         return visitor.visit(this);
     }

--- a/atlas-core/src/main/java/org/atlasapi/content/Song.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Song.java
@@ -6,6 +6,8 @@ import org.atlasapi.meta.annotations.FieldName;
 
 import org.joda.time.Duration;
 
+import static java.util.Optional.ofNullable;
+
 public class Song extends Item {
 
     private String isrc;
@@ -58,6 +60,20 @@ public class Song extends Item {
             return to;
         }
         return super.copyTo(to);
+    }
+
+    @Override public <T extends Described> T copyToPreferNonNull(T to) {
+        if (to instanceof Song) {
+            copyToPreferNonNull(this, (Song) to);
+            return to;
+        }
+        return super.copyToPreferNonNull(to);
+    }
+
+    public static Song copyToPreferNonNull(Song from, Song to) {
+        Item.copyToPreferNonNull(from, to);
+        to.isrc = ofNullable(from.isrc).orElse(to.isrc);
+        return to;
     }
 
     @Override public Song copy() {

--- a/atlas-core/src/main/java/org/atlasapi/entity/Person.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/Person.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.atlasapi.content.ContentGroup;
 import org.atlasapi.content.Described;
+import org.atlasapi.content.Song;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 
@@ -133,6 +134,11 @@ public class Person extends ContentGroup {
             return to;
         }
         return super.copyTo(to);
+    }
+
+    @Override
+    public Person createNew() {
+        return new Person();
     }
 
     @Override public Person copy() {

--- a/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/EquivalentsMergeStrategy.java
@@ -15,11 +15,10 @@ import org.atlasapi.equivalence.Equivalable;
 public interface EquivalentsMergeStrategy<E extends Equivalable<E>> {
 
     /**
-     * @param chosen      - resource in to which {@code equivalents} is merged.
      * @param equivalents - a set of resources equivalent to chosen.
      * @param activeAnnotations - the annotations present on the call
      * @return merged resources.
      */
-    <T extends E> T merge(T chosen, Iterable<? extends T> equivalents, Application application,
+    <T extends E> T merge(Iterable<? extends T> equivalents, Application application,
             Set<Annotation> activeAnnotations);
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -103,6 +103,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     private static final Function<Item, ContainerSummary> TO_CONTAINER_SUMMARY =
             input -> input == null ? null : input.getContainerSummary();
 
+    private static final Function<Described, String> TO_PRESENTATION_CHANNEL =
+            input -> input == null ? null : input.getPresentationChannel();
+
     private EquivalentSetContentHierarchyChooser hierarchyChooser;
 
     public OutputContentMerger(EquivalentSetContentHierarchyChooser hierarchyChooser) {
@@ -234,6 +237,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         }
         if (chosen.getShortDescription() == null) {
             chosen.setShortDescription(first(orderedContent, TO_SHORT_DESCRIPTION));
+        }
+        if (chosen.getPresentationChannel() == null) {
+            chosen.setPresentationChannel(first(orderedContent, TO_PRESENTATION_CHANNEL));
         }
 
         mergeAwards(chosen, orderedContent);

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -203,52 +203,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         return builder.build();
     }
 
-    private <T extends Described> List<T> findSame(T content, Iterable<T> contents) {
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
-        builder.add(content);
-        for (T possiblyEquivalent : contents) {
-            if (!content.equals(possiblyEquivalent) && possiblyEquivalent.isEquivalentTo(content)) {
-                builder.add(possiblyEquivalent);
-            }
-        }
-        return builder.build();
-    }
-
-    private <T extends ContentGroup> void mergeIn(Application application, T chosen,
-            Iterable<T> orderedContent) {
-        mergeDescribed(application, chosen, orderedContent);
-        for (ContentGroup contentGroup : orderedContent) {
-            for (ContentRef ref : contentGroup.getContents()) {
-                chosen.addContent(ref);
-            }
-        }
-        if (chosen instanceof Person) {
-            Person chosenPerson = (Person) chosen;
-            ImmutableSet.Builder<String> quotes = ImmutableSet.builder();
-            quotes.addAll(chosenPerson.getQuotes());
-            for (Person person : Iterables.filter(orderedContent, Person.class)) {
-                quotes.addAll(person.getQuotes());
-                chosenPerson.withName(chosenPerson.name() != null ? chosenPerson.name() : person.name());
-                chosenPerson.setGivenName(chosenPerson.getGivenName() != null
-                                    ? chosenPerson.getGivenName()
-                                    : person.getGivenName());
-                chosenPerson.setFamilyName(chosenPerson.getFamilyName() != null
-                                     ? chosenPerson.getFamilyName()
-                                     : person.getFamilyName());
-                chosenPerson.setGender(chosenPerson.getGender() != null
-                                 ? chosenPerson.getGender()
-                                 : person.getGender());
-                chosenPerson.setBirthDate(chosenPerson.getBirthDate() != null
-                                    ? chosenPerson.getBirthDate()
-                                    : person.getBirthDate());
-                chosenPerson.setBirthPlace(chosenPerson.getBirthPlace() != null
-                                     ? chosenPerson.getBirthPlace()
-                                     : person.getBirthPlace());
-            }
-            chosenPerson.setQuotes(quotes.build());
-        }
-    }
-
     private <T extends Described> void mergeDescribed(Application application, T chosen,
             Iterable<T> orderedContent) {
         mergeCustomFields(chosen, orderedContent);
@@ -306,7 +260,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Iterable<T> orderedContent,
             Function<T, Iterable<P>> projector)
     {
-
         return Iterables.concat(StreamSupport.stream(orderedContent.spliterator(), false)
                         .map(projector::apply)
                         .collect(Collectors.toList())

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -103,6 +103,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     private static final Function<Item, ContainerSummary> TO_CONTAINER_SUMMARY =
             input -> input == null ? null : input.getContainerSummary();
 
+    private static final Function<Described, String> TO_PRESENTATION_CHANNEL =
+            input -> input == null ? null : input.getPresentationChannel();
+
     private EquivalentSetContentHierarchyChooser hierarchyChooser;
 
     public OutputContentMerger(EquivalentSetContentHierarchyChooser hierarchyChooser) {
@@ -233,6 +236,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         }
         if (chosen.getShortDescription() == null) {
             chosen.setShortDescription(first(orderedContent, TO_SHORT_DESCRIPTION));
+        }
+        if (chosen.getPresentationChannel() == null) {
+            chosen.setPresentationChannel(first(orderedContent, TO_PRESENTATION_CHANNEL));
         }
 
         mergeAwards(chosen, orderedContent);

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -103,9 +103,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     private static final Function<Item, ContainerSummary> TO_CONTAINER_SUMMARY =
             input -> input == null ? null : input.getContainerSummary();
 
-    private static final Function<Described, String> TO_PRESENTATION_CHANNEL =
-            input -> input == null ? null : input.getPresentationChannel();
-
     private EquivalentSetContentHierarchyChooser hierarchyChooser;
 
     public OutputContentMerger(EquivalentSetContentHierarchyChooser hierarchyChooser) {
@@ -236,9 +233,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         }
         if (chosen.getShortDescription() == null) {
             chosen.setShortDescription(first(orderedContent, TO_SHORT_DESCRIPTION));
-        }
-        if (chosen.getPresentationChannel() == null) {
-            chosen.setPresentationChannel(first(orderedContent, TO_PRESENTATION_CHANNEL));
         }
 
         mergeAwards(chosen, orderedContent);

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -741,11 +741,12 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 .collect(Collectors.toList());
 
         if (chosen.getUpcomingContent() != null && chosen.getUpcomingContent().isEmpty()) {
-            chosen.setUpcomingContent(null);
-            Container first = contentHierarchySourceOrderedContainers.iterator().next();
-            if (first.getUpcomingContent() != null && !first.getUpcomingContent().isEmpty()) {
-                chosen.setUpcomingContent(first.getUpcomingContent());
-            }
+            java.util.Optional<Container> firstWithUpcomingContent =
+                    StreamSupport.stream(contentHierarchySourceOrderedContainers.spliterator(), false)
+                            .filter(container -> container.getUpcomingContent() != null
+                                    && !container.getUpcomingContent().isEmpty())
+                            .findFirst();
+            firstWithUpcomingContent.ifPresent(container -> chosen.setUpcomingContent(container.getUpcomingContent()));
         }
 
         Optional<Container> first =

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -142,7 +142,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         return merged;
     }
 
-    // finds the content with the lowest id, returning its id and its publisher
+    // return the content in the equiv set with the lowest id (to try and keep ID stable)
     private static <T extends Described> T findLowestIdContent(Iterable<T> orderedContent) {
         T lowestContent = orderedContent.iterator().next();
         for (T content : orderedContent) {

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -34,7 +34,6 @@ import org.atlasapi.content.LocalizedTitle;
 import org.atlasapi.content.LocationSummary;
 import org.atlasapi.content.ReleaseDate;
 import org.atlasapi.content.Series;
-import org.atlasapi.content.Song;
 import org.atlasapi.content.Subtitles;
 import org.atlasapi.content.Tag;
 import org.atlasapi.entity.Award;
@@ -43,7 +42,6 @@ import org.atlasapi.entity.Identified;
 import org.atlasapi.entity.Person;
 import org.atlasapi.entity.Rating;
 import org.atlasapi.entity.Review;
-import org.atlasapi.entity.Sourced;
 import org.atlasapi.entity.Sourceds;
 import org.atlasapi.equivalence.EquivalenceRef;
 import org.atlasapi.media.entity.Publisher;
@@ -53,7 +51,6 @@ import com.metabroadcast.applications.client.model.internal.Application;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.stream.MoreStreams;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -654,13 +651,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
         if (chosen.getBroadcasts() != null && !chosen.getBroadcasts().isEmpty()) {
             for (Broadcast chosenBroadcast : chosen.getBroadcasts()) {
-                matchAndMerge(chosenBroadcast, Lists.newArrayList(orderedContent));
+                matchAndMerge(chosenBroadcast, orderedContent);
             }
         }
-    }
-
-    private static Predicate<Item> isPublisher(Publisher publisher) {
-        return input -> publisher.equals(input.getSource());
     }
 
     private <T extends Content> void mergeEncodings(T chosen, Iterable<T> orderedContent) {
@@ -677,7 +670,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
     }
 
     private <T extends Item> void matchAndMerge(final Broadcast chosenBroadcast,
-            List<T> orderedContent) {
+            Iterable<T> orderedContent) {
         List<Broadcast> equivBroadcasts = Lists.newArrayList();
         for (T item : orderedContent) {
             Iterable<Broadcast> broadcasts = item.getBroadcasts();

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -125,6 +125,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
         // Unchecked casting is safe here because we get the most specific type from the hierarchy
         T merged = (T) mostSpecificTypeContent.createNew();
+        merged = mostSpecificTypeContent.copyToPreferNonNull(merged);
 
         // Then we need as much data as possible from the highest precedence source possible
         merged = highestPrecedenceContent.copyToPreferNonNull(merged);

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -1,7 +1,6 @@
 package org.atlasapi.output;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +19,6 @@ import org.atlasapi.content.Container;
 import org.atlasapi.content.ContainerRef;
 import org.atlasapi.content.ContainerSummary;
 import org.atlasapi.content.Content;
-import org.atlasapi.content.ContentGroup;
-import org.atlasapi.content.ContentRef;
 import org.atlasapi.content.ContentVisitorAdapter;
 import org.atlasapi.content.Described;
 import org.atlasapi.content.Encoding;
@@ -37,13 +34,10 @@ import org.atlasapi.content.Series;
 import org.atlasapi.content.Subtitles;
 import org.atlasapi.content.Tag;
 import org.atlasapi.entity.Award;
-import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identified;
-import org.atlasapi.entity.Person;
 import org.atlasapi.entity.Rating;
 import org.atlasapi.entity.Review;
 import org.atlasapi.entity.Sourceds;
-import org.atlasapi.equivalence.EquivalenceRef;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.segment.SegmentEvent;
 
@@ -57,13 +51,11 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -131,7 +123,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             }
         }
 
-        //Unchecked casting is safe here because we get the most specific type from the hierarchy
+        // Unchecked casting is safe here because we get the most specific type from the hierarchy
         T merged = (T) mostSpecificTypeContent.createNew();
 
         // Then we need as much data as possible from the highest precedence source possible
@@ -749,15 +741,11 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 .collect(Collectors.toList());
 
         if (chosen.getUpcomingContent() != null && chosen.getUpcomingContent().isEmpty()) {
-            chosen.setUpcomingContent(
-                    first(
-                            contentHierarchySourceOrderedContainers,
-                            input -> input.getUpcomingContent().isEmpty()
-                                     ? null
-                                     : input.getUpcomingContent(),
-                            ImmutableMap.of()
-                    )
-            );
+            chosen.setUpcomingContent(null);
+            Container first = contentHierarchySourceOrderedContainers.iterator().next();
+            if (first.getUpcomingContent() != null && !first.getUpcomingContent().isEmpty()) {
+                chosen.setUpcomingContent(first.getUpcomingContent());
+            }
         }
 
         Optional<Container> first =

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -294,19 +294,8 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         ));
         mergeDuration(chosen, orderedContent);
 
-        if (chosen instanceof Episode && ((Episode) chosen).getEpisodeNumber() == null) {
-            Episode chosenEpisode = (Episode) chosen;
-            MoreStreams.stream(orderedContent)
-                    .filter(Episode.class::isInstance)
-                    .map(Episode.class::cast)
-                    .filter(e -> e.getEpisodeNumber() != null)
-                    .findFirst()
-                    .ifPresent(e -> {
-                        chosenEpisode.setEpisodeNumber(e.getEpisodeNumber());
-                        if(e.getSeriesNumber() != null) {
-                            chosenEpisode.setSeriesNumber(e.getSeriesNumber());
-                        }
-                    });
+        if (chosen instanceof Episode) {
+            mergeEpisodeFields((Episode) chosen, Iterables.filter(orderedContent, Episode.class));
         }
 
         mergeEncodings(chosen, orderedContent);
@@ -318,6 +307,27 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 orderedContent,
                 Content::getCountriesOfOrigin
         ));
+    }
+
+    private <T extends Content> void mergeEpisodeFields(Episode chosen,
+            Iterable<Episode> orderedContent) {
+        for (Episode ep : orderedContent) {
+            if (chosen.getEpisodeNumber() == null && ep.getEpisodeNumber() != null) {
+                chosen.setEpisodeNumber(ep.getEpisodeNumber());
+            }
+            if (chosen.getSeriesNumber() == null && ep.getSeriesNumber() != null) {
+                chosen.setSeriesNumber(ep.getSeriesNumber());
+            }
+            if (chosen.getSeriesRef() == null && ep.getSeriesRef() != null) {
+                chosen.setSeriesRef(ep.getSeriesRef());
+            }
+            if (chosen.getPartNumber() == null && ep.getPartNumber() != null) {
+                chosen.setPartNumber(ep.getPartNumber());
+            }
+            if (chosen.getSpecial() == null && ep.getSpecial() != null) {
+                chosen.setSpecial(ep.getSpecial());
+            }
+        }
     }
 
     private <T extends Content> void mergeDuration(T chosen, Iterable<T> orderedContent) {

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -165,8 +165,10 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     private <T extends Described> T createChosen(Iterable<? extends T> orderedContent) {
 
+        T highestPrecedenceContent = orderedContent.iterator().next();
+
         // First, we need to get the most specific type in the equiv set for chosen
-        T mostSpecificTypeContent = orderedContent.iterator().next();
+        T mostSpecificTypeContent = highestPrecedenceContent;
         for (T next : ImmutableList.copyOf(orderedContent)) {
             if (!mostSpecificTypeContent.getClass().equals(next.getClass())
                     && mostSpecificTypeContent.getClass().isAssignableFrom(next.getClass())) {
@@ -175,9 +177,10 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         }
         T chosen = mostSpecificTypeContent;
 
-        //TODO to remove, probably? since merging happens later on on a field-by-field basis.
-        //TODO perhaps only leave: chosen = highestPrecedenceContent.copyToPrferNonNull(chosen);
-//        // Then we need as much data as possible from the highest precedence source possible
+        // Then we need as much data as possible from the highest precedence source possible
+        chosen = highestPrecedenceContent.copyToPreferNonNull(chosen);
+
+        //TODO following is probably unnecessary? since merging happens later on on a field-by-field basis.
 //        List<T> reverseOrderedContent = new ArrayList<>(orderedContent);
 //        Collections.reverse(reverseOrderedContent);
 //        for(T next : reverseOrderedContent) {

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -300,8 +300,19 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         ));
         mergeDuration(chosen, orderedContent);
 
-        if (chosen instanceof Episode) {
-            mergeEpisodeFields((Episode) chosen, Iterables.filter(orderedContent, Episode.class));
+        if (chosen instanceof Episode && ((Episode) chosen).getEpisodeNumber() == null) {
+            Episode chosenEpisode = (Episode) chosen;
+            MoreStreams.stream(orderedContent)
+                    .filter(Episode.class::isInstance)
+                    .map(Episode.class::cast)
+                    .filter(e -> e.getEpisodeNumber() != null)
+                    .findFirst()
+                    .ifPresent(e -> {
+                        chosenEpisode.setEpisodeNumber(e.getEpisodeNumber());
+                        if(e.getSeriesNumber() != null) {
+                            chosenEpisode.setSeriesNumber(e.getSeriesNumber());
+                        }
+                    });
         }
 
         mergeEncodings(chosen, orderedContent);
@@ -313,27 +324,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 orderedContent,
                 Content::getCountriesOfOrigin
         ));
-    }
-
-    private <T extends Content> void mergeEpisodeFields(Episode chosen,
-            Iterable<Episode> orderedContent) {
-        for (Episode ep : orderedContent) {
-            if (chosen.getEpisodeNumber() == null && ep.getEpisodeNumber() != null) {
-                chosen.setEpisodeNumber(ep.getEpisodeNumber());
-            }
-            if (chosen.getSeriesNumber() == null && ep.getSeriesNumber() != null) {
-                chosen.setSeriesNumber(ep.getSeriesNumber());
-            }
-            if (chosen.getSeriesRef() == null && ep.getSeriesRef() != null) {
-                chosen.setSeriesRef(ep.getSeriesRef());
-            }
-            if (chosen.getPartNumber() == null && ep.getPartNumber() != null) {
-                chosen.setPartNumber(ep.getPartNumber());
-            }
-            if (chosen.getSpecial() == null && ep.getSpecial() != null) {
-                chosen.setSpecial(ep.getSpecial());
-            }
-        }
     }
 
     private <T extends Content> void mergeDuration(T chosen, Iterable<T> orderedContent) {

--- a/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
@@ -48,16 +48,6 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
         if (sortedEquivalents.isEmpty()) {
             return ImmutableList.of();
         }
-        if (trivialMerge(sortedEquivalents)) {
-            return ImmutableList.of(
-                    strategy.merge(
-                            sortedEquivalents,
-                            application,
-                            activeAnnotations
-                    )
-            );
-        }
-        T chosen = sortedEquivalents.get(0);
 
         // If the query asks for a specific ID and that ID is from the highest precedence, then that
         // ID becomes the highest precedence piece of content. Relevant only if there are multiple
@@ -66,7 +56,8 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
         // but nothing built in the last 3 years relies on it. It is the view of the current team
         // this logic is wrong and should be removed as it causes the result of the merge to be
         // different for different IDs of the equiv set.
-        if (id.isPresent()) {
+        T chosen = sortedEquivalents.get(0);
+        if (id.isPresent() && sortedEquivalents.size() > 1) {
             Optional<T> requested = Iterables.tryFind(equivalents, idIs(id.get()));
 
             if (requested.isPresent()
@@ -77,10 +68,6 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
         }
 
         return ImmutableList.of(strategy.merge(sortedEquivalents, application, activeAnnotations));
-    }
-
-    private boolean trivialMerge(List<?> sortedEquivalents) {
-        return sortedEquivalents.size() == 1;
     }
 
     private Predicate<Identifiable> idIs(final Id id) {

--- a/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
@@ -1,8 +1,10 @@
 package org.atlasapi.output;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.metabroadcast.applications.client.model.internal.Application;
 
@@ -67,11 +69,8 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
             }
         }
 
-        Iterable<T> notChosen = Iterables.filter(
-                sortedEquivalents,
-                Predicates.not(idIs(chosen.getId()))
-        );
-        return ImmutableList.of(strategy.merge(chosen, notChosen, application, activeAnnotations));
+        return ImmutableList.of(strategy.merge(chosen,
+                new HashSet<>(sortedEquivalents), application, activeAnnotations));
     }
 
     private boolean trivialMerge(ImmutableList<?> sortedEquivalents) {

--- a/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/StrategyBackedEquivalentsMerger.java
@@ -3,14 +3,14 @@ package org.atlasapi.output;
 import java.util.List;
 import java.util.Set;
 
-import com.metabroadcast.applications.client.model.internal.Application;
-
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identifiable;
 import org.atlasapi.entity.Sourced;
 import org.atlasapi.equivalence.ApplicationEquivalentsMerger;
 import org.atlasapi.equivalence.Equivalable;
+
+import com.metabroadcast.applications.client.model.internal.Application;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -59,6 +59,13 @@ public class StrategyBackedEquivalentsMerger<E extends Equivalable<E>>
         }
         T chosen = sortedEquivalents.get(0);
 
+        // If the query asks for a specific ID and that ID is from the highest precedence, then that
+        // ID becomes the highest precedence piece of content. Relevant only if there are multiple
+        // IDs from the highest precedence source.
+        // Furthermore, at the time of this rework it is unclear if anything relies on this logic,
+        // but nothing built in the last 3 years relies on it. It is the view of the current team
+        // this logic is wrong and should be removed as it causes the result of the merge to be
+        // different for different IDs of the equiv set.
         if (id.isPresent()) {
             Optional<T> requested = Iterables.tryFind(equivalents, idIs(id.get()));
 

--- a/atlas-core/src/main/java/org/atlasapi/segment/Segment.java
+++ b/atlas-core/src/main/java/org/atlasapi/segment/Segment.java
@@ -55,7 +55,7 @@ public class Segment extends Described {
     }
 
     @Override
-    public Described createNew() {
+    public Segment createNew() {
         return new Segment();
     }
 

--- a/atlas-core/src/main/java/org/atlasapi/segment/Segment.java
+++ b/atlas-core/src/main/java/org/atlasapi/segment/Segment.java
@@ -54,6 +54,11 @@ public class Segment extends Described {
         return copyTo(this, new Segment());
     }
 
+    @Override
+    public Described createNew() {
+        return new Segment();
+    }
+
     public static final Function<Segment, SegmentRef> TO_REF = Segment::toRef;
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/topic/Topic.java
+++ b/atlas-core/src/main/java/org/atlasapi/topic/Topic.java
@@ -146,6 +146,11 @@ public class Topic extends Described implements Sourced, Aliased {
         return copyTo(this, new Topic());
     }
 
+    @Override
+    public Described createNew() {
+        return new Topic();
+    }
+
     @FieldName("type")
     public Type getType() {
         return this.type;

--- a/atlas-core/src/main/java/org/atlasapi/topic/Topic.java
+++ b/atlas-core/src/main/java/org/atlasapi/topic/Topic.java
@@ -147,7 +147,7 @@ public class Topic extends Described implements Sourced, Aliased {
     }
 
     @Override
-    public Described createNew() {
+    public Topic createNew() {
         return new Topic();
     }
 

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -140,7 +140,7 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
+        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application,
                 Collections.emptySet()
         );
 
@@ -229,7 +229,7 @@ public class BroadcastMergingTest {
 
         executor.merge(
                 chosenItemWithoutBroadcasts,
-                ImmutableList.of(notChosenFirstBbcItem, notChosenBbcItem, notChosenFbItem),
+                ImmutableList.of(chosenItemWithoutBroadcasts, notChosenFirstBbcItem, notChosenBbcItem, notChosenFbItem),
                 application,
                 Collections.emptySet()
         );
@@ -291,7 +291,7 @@ public class BroadcastMergingTest {
 
         //merge all broadcasts from all sources, even if different channel and start time
         activeAnnotations.add(Annotation.ALL_BROADCASTS);
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application, activeAnnotations);
+        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
         assertEquals(4, chosenItem.getBroadcasts().size());
 
     }
@@ -340,7 +340,7 @@ public class BroadcastMergingTest {
         Set<Annotation> activeAnnotations = new HashSet<>();
         //get broadcasts from all sources, merging on matching channel+start time
         activeAnnotations.add(Annotation.ALL_MERGED_BROADCASTS);
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application, activeAnnotations);
+        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
 
         assertEquals(3, chosenItem.getBroadcasts().size());
     }

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -140,7 +140,7 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application,
+        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application,
                 Collections.emptySet()
         );
 
@@ -227,7 +227,7 @@ public class BroadcastMergingTest {
         notChosenFbItem.addEquivalentTo(notChosenFirstBbcItem);
         notChosenFbItem.addEquivalentTo(notChosenBbcItem);
 
-        executor.merge(
+        chosenItemWithoutBroadcasts = executor.merge(
                 chosenItemWithoutBroadcasts,
                 ImmutableList.of(chosenItemWithoutBroadcasts, notChosenFirstBbcItem, notChosenBbcItem, notChosenFbItem),
                 application,
@@ -291,7 +291,7 @@ public class BroadcastMergingTest {
 
         //merge all broadcasts from all sources, even if different channel and start time
         activeAnnotations.add(Annotation.ALL_BROADCASTS);
-        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
+        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
         assertEquals(4, chosenItem.getBroadcasts().size());
 
     }
@@ -340,7 +340,7 @@ public class BroadcastMergingTest {
         Set<Annotation> activeAnnotations = new HashSet<>();
         //get broadcasts from all sources, merging on matching channel+start time
         activeAnnotations.add(Annotation.ALL_MERGED_BROADCASTS);
-        executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
+        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
 
         assertEquals(3, chosenItem.getBroadcasts().size());
     }

--- a/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/BroadcastMergingTest.java
@@ -37,30 +37,6 @@ public class BroadcastMergingTest {
     private final List<Publisher> defaultTestPublishers = ImmutableList.of(Publisher.BBC, Publisher.FACEBOOK);
 
     @Test
-    public void testBroadcastMergingNoBroadcasts() {
-        when(application.getConfiguration()).thenReturn(getConfigWithReads(defaultTestPublishers));
-
-        Item chosenItem = new Item();
-        chosenItem.setId(1L);
-        chosenItem.setPublisher(Publisher.BBC);
-        chosenItem.setCanonicalUri("chosenItem");
-
-        Item notChosenItem = new Item();
-        notChosenItem.setId(2L);
-        notChosenItem.setPublisher(Publisher.FACEBOOK);
-        notChosenItem.setCanonicalUri("notChosenItem");
-
-        chosenItem.addEquivalentTo(notChosenItem);
-        notChosenItem.addEquivalentTo(chosenItem);
-
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
-                Collections.emptySet()
-        );
-
-        assertTrue(notChosenItem.getBroadcasts().isEmpty());
-    }
-
-    @Test
     public void testBroadcastMergingNonMatchingBroadcasts() {
         when(application.getConfiguration()).thenReturn(getConfigWithReads(defaultTestPublishers));
 
@@ -94,11 +70,11 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        executor.merge(chosenItem, ImmutableList.of(notChosenItem), application,
+        Item merged = executor.merge(ImmutableList.of(chosenItem, notChosenItem), application,
                 Collections.emptySet()
         );
 
-        assertTrue(chosenItem.getBroadcasts().size() == 1);
+        assertTrue(merged.getBroadcasts().size() == 1);
     }
 
     @Test
@@ -140,14 +116,14 @@ public class BroadcastMergingTest {
         chosenItem.addEquivalentTo(notChosenItem);
         notChosenItem.addEquivalentTo(chosenItem);
 
-        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application,
+        Item merged = executor.merge(ImmutableList.of(chosenItem, notChosenItem), application,
                 Collections.emptySet()
         );
 
         // ensure that the broadcast matched, 
         // and the fields on the non-chosen broadcast 
         // are merged only when the original broadcast's fields are null
-        Broadcast mergedBroadcast = Iterables.getOnlyElement(chosenItem.getBroadcasts());
+        Broadcast mergedBroadcast = Iterables.getOnlyElement(merged.getBroadcasts());
         assertTrue(mergedBroadcast.getAudioDescribed());
         assertFalse(mergedBroadcast.getHighDefinition());
         assertFalse(mergedBroadcast.getSurround());
@@ -227,8 +203,7 @@ public class BroadcastMergingTest {
         notChosenFbItem.addEquivalentTo(notChosenFirstBbcItem);
         notChosenFbItem.addEquivalentTo(notChosenBbcItem);
 
-        chosenItemWithoutBroadcasts = executor.merge(
-                chosenItemWithoutBroadcasts,
+        Item merged = executor.merge(
                 ImmutableList.of(chosenItemWithoutBroadcasts, notChosenFirstBbcItem, notChosenBbcItem, notChosenFbItem),
                 application,
                 Collections.emptySet()
@@ -238,7 +213,7 @@ public class BroadcastMergingTest {
         // and the fields on the non-chosen broadcast 
         // are merged only when the original broadcast's fields are null
         // and that the most precedent broadcast's values are used
-        Broadcast mergedBroadcast = Iterables.getOnlyElement(chosenItemWithoutBroadcasts.getBroadcasts());
+        Broadcast mergedBroadcast = Iterables.getOnlyElement(merged.getBroadcasts());
         assertTrue(mergedBroadcast.getAudioDescribed());
         assertTrue(mergedBroadcast.getHighDefinition());
         assertFalse(mergedBroadcast.getSurround());
@@ -291,8 +266,8 @@ public class BroadcastMergingTest {
 
         //merge all broadcasts from all sources, even if different channel and start time
         activeAnnotations.add(Annotation.ALL_BROADCASTS);
-        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
-        assertEquals(4, chosenItem.getBroadcasts().size());
+        Item merged = executor.merge(ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
+        assertEquals(4, merged.getBroadcasts().size());
 
     }
 
@@ -340,9 +315,9 @@ public class BroadcastMergingTest {
         Set<Annotation> activeAnnotations = new HashSet<>();
         //get broadcasts from all sources, merging on matching channel+start time
         activeAnnotations.add(Annotation.ALL_MERGED_BROADCASTS);
-        chosenItem = executor.merge(chosenItem, ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
+        Item merged = executor.merge(ImmutableList.of(chosenItem, notChosenItem), application, activeAnnotations);
 
-        assertEquals(3, chosenItem.getBroadcasts().size());
+        assertEquals(3, merged.getBroadcasts().size());
     }
 
     private ApplicationConfiguration getConfigWithReads(List<Publisher> publishers) {

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -921,14 +921,17 @@ public class OutputContentMergerTest {
 
         assertThat(merged.getCanonicalUri(), is(orderedContent.iterator().next().getCanonicalUri()));
         assertThat(merged.getId(), is(one.getId()));
+        assertThat(merged.getSource(), is(one.getSource()));
         assertThat(merged.getEquivalentTo(), is(ImmutableSet.of(EquivalenceRef.valueOf(two), EquivalenceRef.valueOf(three))));
 
+        // now test without BBC
         orderedContent = sortByPublisherThenId(application, ImmutableList.of(two, three));
         setEquivalent(two, three);
         setEquivalent(three, two);
         merged = merger.merge(orderedContent, application, Collections.emptySet());
         assertThat(merged.getCanonicalUri(), is(orderedContent.iterator().next().getCanonicalUri()));
         assertThat(merged.getId(), is(two.getId()));
+        assertThat(merged.getSource(), is(two.getSource()));
         assertThat(merged.getEquivalentTo(), is(ImmutableSet.of(EquivalenceRef.valueOf(three))));
     }
 
@@ -1090,7 +1093,6 @@ public class OutputContentMergerTest {
 
     private void setEquivalent(Content receiver, Content... equivalents) {
         ImmutableList<Content> allContent = ImmutableList.<Content>builder()
-                .add(receiver)
                 .addAll(ImmutableList.copyOf(equivalents))
                 .build();
         receiver.setEquivalentTo(ImmutableSet.copyOf(

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -291,9 +291,22 @@ public class OutputContentMergerTest {
         Item item1 = item(4L, "item", Publisher.METABROADCAST);
         item1.setThisOrChildLastUpdated(DateTime.now(DateTimeZone.UTC));
 
+        Application application = getApplicationWithPrecedence(
+                true,
+                Publisher.BBC_KIWI,
+                Publisher.METABROADCAST,
+                Publisher.BBC_MUSIC
+        );
+
         setEquivalent(one, two, three);
         setEquivalent(two, one, three);
         setEquivalent(three, two, one);
+
+        Container merged = merger.merge(ImmutableList.of(one, two, three), application,
+                Collections.emptySet()
+        );
+
+        assertNull(merged.getUpcomingContent());
 
         ImmutableMap<ItemRef, Iterable<BroadcastRef>> upcomingContent = ImmutableMap.<ItemRef, Iterable<BroadcastRef>>builder()
                 .put(
@@ -314,15 +327,7 @@ public class OutputContentMergerTest {
                 upcomingContent
         );
 
-
-        Application application = getApplicationWithPrecedence(
-                true,
-                Publisher.BBC_KIWI,
-                Publisher.METABROADCAST,
-                Publisher.BBC_MUSIC
-        );
-
-        Container merged = merger.merge(ImmutableList.of(one, two, three), application,
+        merged = merger.merge(ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -57,6 +57,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -306,7 +307,7 @@ public class OutputContentMergerTest {
                 Collections.emptySet()
         );
 
-        assertNull(merged.getUpcomingContent());
+        assertThat(merged.getUpcomingContent(), is(ImmutableMap.of()));
 
         ImmutableMap<ItemRef, Iterable<BroadcastRef>> upcomingContent = ImmutableMap.<ItemRef, Iterable<BroadcastRef>>builder()
                 .put(

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -136,7 +136,7 @@ public class OutputContentMergerTest {
                 Publisher.PA
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two), application, Collections.emptySet());
+        Item merged = merger.merge(one, ImmutableList.of(one, two), application, Collections.emptySet());
         assertThat(merged.getAliases().size(), is(2));
     }
 
@@ -201,7 +201,7 @@ public class OutputContentMergerTest {
                 Publisher.PA
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two, three), application,
+        Item merged = merger.merge(one, ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 
@@ -252,7 +252,7 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Item merged = merger.merge(one, ImmutableList.of(two, three), application,
+        Item merged = merger.merge(one, ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 
@@ -304,7 +304,7 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+        Container merged = merger.merge(one, ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 
@@ -415,7 +415,7 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+        Container merged = merger.merge(one, ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 
@@ -452,7 +452,7 @@ public class OutputContentMergerTest {
                 Publisher.BBC_MUSIC
         );
 
-        Container merged = merger.merge(one, ImmutableList.of(two, three), application,
+        Container merged = merger.merge(one, ImmutableList.of(one, two, three), application,
                 Collections.emptySet()
         );
 
@@ -474,7 +474,7 @@ public class OutputContentMergerTest {
         Item item2 = item(5L, "item2", Publisher.PA);
         item2.setImages(ImmutableSet.of(new Image("http://image2.org/")));
 
-        Content merged = merger.merge(item1, ImmutableList.of(item2), application,
+        Content merged = merger.merge(item1, ImmutableList.of(item1, item2), application,
                 Collections.emptySet()
         );
         assertThat(merged.getImages().size(), is(2));
@@ -507,7 +507,7 @@ public class OutputContentMergerTest {
         item2.setImage(image2.getCanonicalUri());
         item2.setImages(ImmutableSet.of(image2));
 
-        Content merged = merger.merge(item2,  ImmutableList.of(item1), application,
+        Content merged = merger.merge(item2,  ImmutableList.of(item1, item2), application,
                 Collections.emptySet()
         );
         assertThat(merged.getImage(), is("http://image2.org/"));
@@ -625,7 +625,7 @@ public class OutputContentMergerTest {
         );
         item3.setBroadcasts(ImmutableSet.of(b3));
 
-        Item merged = merger.merge(item1, ImmutableList.of(item2, item3), application,
+        Item merged = merger.merge(item1, ImmutableList.of(item1, item2, item3), application,
                 Collections.emptySet()
         );
         assertThat(merged.getBroadcasts().size(), is(2));
@@ -660,7 +660,7 @@ public class OutputContentMergerTest {
         item2.setBroadcasts(ImmutableSet.of(b2));
         b2.addAlias(new Alias("ns2", "v2"));
 
-        Item merged = merger.merge(item1, ImmutableList.of(item2), application,
+        Item merged = merger.merge(item1, ImmutableList.of(item1, item2), application,
                 Collections.emptySet()
         );
         assertThat(Iterables.getOnlyElement(merged.getBroadcasts()).getAliases().size(), is(2));
@@ -696,7 +696,7 @@ public class OutputContentMergerTest {
         secondItem.addBroadcast(secondItemBroadcast);
 
 
-        Item merged = merger.merge(firstItem, ImmutableList.of(secondItem), application,
+        Item merged = merger.merge(firstItem, ImmutableList.of(firstItem, secondItem), application,
                 Collections.emptySet()
         );
 
@@ -736,7 +736,7 @@ public class OutputContentMergerTest {
         // chosenItem is mutated by merge, so calculate this first
         int expectedReviewsCount = expectedReviews.size();
 
-        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application,
+        Item merged = merger.merge(chosenItem, ImmutableList.of(chosenItem, firstEquivItem, secondEquivItem), application,
                 Collections.emptySet()
         );
 
@@ -779,7 +779,7 @@ public class OutputContentMergerTest {
         // chosenItem is mutated by merge, so calculate this first
         int expectedRatingsCount = expectedRatings.size();
 
-        Item merged = merger.merge(chosenItem, ImmutableList.of(firstEquivItem, secondEquivItem), application,
+        Item merged = merger.merge(chosenItem, ImmutableList.of(chosenItem, firstEquivItem, secondEquivItem), application,
                 Collections.emptySet()
         );
 
@@ -952,7 +952,7 @@ public class OutputContentMergerTest {
                 Publisher.BBC
         );
 
-        Item merged = merger.merge(chosen, ImmutableList.of(notChosen), application,
+        Item merged = merger.merge(chosen, ImmutableList.of(chosen, notChosen), application,
                 Collections.emptySet()
         );
 

--- a/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
@@ -99,9 +99,6 @@ public class StrategyBackedEquivalentsMergerTest {
         );
     }
 
-    //TODO test by going thru permutations of contents, and results will be the same regardless of order
-    //TODO add and check both URIs and IDs
-
     @Test
     @SuppressWarnings("unchecked")
     public void testMergeSortingIsStable() {
@@ -184,6 +181,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 );
     }
 
+    //
     @Test
     @SuppressWarnings("unchecked")
     public void testMergeVictimIsRequestedContentIdIfVictimMatchesMostPrecedentSource() {
@@ -213,7 +211,7 @@ public class StrategyBackedEquivalentsMergerTest {
 
         verify(strategy)
                 .merge(
-                        argThat(contains(one, two, three)),
+                        argThat(contains(two, one, three)),
                         argThat(is(mergingApplication)),
                         Matchers.anySetOf(Annotation.class)
                 );

--- a/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/StrategyBackedEquivalentsMergerTest.java
@@ -124,7 +124,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
-                                argThat(contains(two, three)),
+                                argThat(contains(one, two, three)),
                                 argThat(is(mergingApplication)),
                                 Matchers.anySetOf(Annotation.class)
                         );
@@ -132,7 +132,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
-                                argThat(contains(two, three)),
+                                argThat(contains(one, two, three)),
                                 argThat(is(mergingApplication)),
                                 Matchers.anySetOf(Annotation.class)
                         );
@@ -140,7 +140,7 @@ public class StrategyBackedEquivalentsMergerTest {
                 verify(strategy)
                         .merge(
                                 argThat(is(one)),
-                                argThat(contains(two, three)),
+                                argThat(contains(one, two, three)),
                                 argThat(is(mergingApplication)),
                                 Matchers.anySetOf(Annotation.class)
                         );
@@ -173,7 +173,7 @@ public class StrategyBackedEquivalentsMergerTest {
         verify(strategy)
                 .merge(
                         argThat(is(retrieved1)),
-                        argThat(contains(retrieved2)),
+                        argThat(contains(retrieved1, retrieved2)),
                         argThat(is(mergingApplication)),
                         Matchers.anySetOf(Annotation.class)
                 );
@@ -197,7 +197,7 @@ public class StrategyBackedEquivalentsMergerTest {
         verify(strategy)
                 .merge(
                         argThat(is(one)),
-                        argThat(contains(two, three)),
+                        argThat(contains(one, two, three)),
                         argThat(is(mergingApplication)),
                         Matchers.anySetOf(Annotation.class)
                 );
@@ -210,7 +210,7 @@ public class StrategyBackedEquivalentsMergerTest {
         verify(strategy)
                 .merge(
                         argThat(is(two)),
-                        argThat(contains(one, three)),
+                        argThat(contains(one, two, three)),
                         argThat(is(mergingApplication)),
                         Matchers.anySetOf(Annotation.class)
                 );
@@ -223,7 +223,7 @@ public class StrategyBackedEquivalentsMergerTest {
         verify(strategy)
                 .merge(
                         argThat(is(one)),
-                        argThat(contains(two, three)),
+                        argThat(contains(one, two, three)),
                         argThat(is(mergingApplication)),
                         Matchers.anySetOf(Annotation.class)
                 );


### PR DESCRIPTION
See ticket for full context, but basically merging doesn't work well for every field if lowest ID is not from highest precedence source. This is due to some hacky code which tampered with an existing piece of context from the equivset to create the merged content. 

This rework instead aims to create a new piece of content from scratch to represent the merged content, while maintaining all existing requirements and constraints.

https://metabroadcast.atlassian.net/browse/ENG-820