### PR TITLE
Fix merging logic for languages & certificates

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -612,7 +612,6 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         chosen.setCertificates(combinedCertificates);
     }
 
-    // find first non-null, non-empty set of languages
     private <T extends Content> void mergeLanguages(T chosen, Iterable<T> orderedContent) {
         Set<String> combinedLanguages = MoreStreams.stream(orderedContent)
                 .map(Content::getLanguages)

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -612,14 +612,12 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
         chosen.setCertificates(combinedCertificates);
     }
 
-
+    // find first non-null, non-empty set of languages
     private <T extends Content> void mergeLanguages(T chosen, Iterable<T> orderedContent) {
-        Set<String> combinedLanguages = MoreStreams.stream(orderedContent)
-                .map(Content::getLanguages)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-
-        chosen.setLanguages(combinedLanguages);
+        MoreStreams.stream(orderedContent)
+                .filter(input -> input.getLanguages() != null && !input.getLanguages().isEmpty())
+                .findFirst()
+                .ifPresent(input -> chosen.setLanguages(input.getLanguages()));
     }
 
     private <T extends Item> void matchAndMerge(final Broadcast chosenBroadcast,

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -325,6 +325,9 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
                 orderedContent,
                 Content::getCountriesOfOrigin
         ));
+
+        mergeLanguages(chosen, orderedContent);
+        mergeCertificates(chosen, orderedContent);
     }
 
     private <T extends Content> void mergeDuration(T chosen, Iterable<T> orderedContent) {
@@ -416,20 +419,14 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Iterable<Film> orderedContent) {
 
         Builder<Subtitles> subtitles = ImmutableSet.<Subtitles>builder().addAll(chosen.getSubtitles());
-        Builder<String> languages = ImmutableSet.<String>builder().addAll(chosen.getLanguages());
-        Builder<Certificate> certs = ImmutableSet.<Certificate>builder().addAll(chosen.getCertificates());
         Builder<ReleaseDate> releases = ImmutableSet.<ReleaseDate>builder().addAll(chosen.getReleaseDates());
 
         for (Film film : orderedContent) {
             subtitles.addAll(film.getSubtitles());
-            languages.addAll(film.getLanguages());
-            certs.addAll(film.getCertificates());
             releases.addAll(film.getReleaseDates());
         }
 
         chosen.setSubtitles(subtitles.build());
-        chosen.setLanguages(languages.build());
-        chosen.setCertificates(certs.build());
         chosen.setReleaseDates(releases.build());
 
         if (application.getConfiguration().isPeoplePrecedenceEnabled()) {
@@ -604,6 +601,25 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             }
         }
         chosen.setManifestedAs(encodings);
+    }
+
+    private <T extends Content> void mergeCertificates(T chosen, Iterable<T> orderedContent) {
+        Set<Certificate> combinedCertificates = MoreStreams.stream(orderedContent)
+                .map(Content::getCertificates)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        chosen.setCertificates(combinedCertificates);
+    }
+
+
+    private <T extends Content> void mergeLanguages(T chosen, Iterable<T> orderedContent) {
+        Set<String> combinedLanguages = MoreStreams.stream(orderedContent)
+                .map(Content::getLanguages)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        chosen.setLanguages(combinedLanguages);
     }
 
     private <T extends Item> void matchAndMerge(final Broadcast chosenBroadcast,

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -614,10 +614,12 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
     // find first non-null, non-empty set of languages
     private <T extends Content> void mergeLanguages(T chosen, Iterable<T> orderedContent) {
-        MoreStreams.stream(orderedContent)
-                .filter(input -> input.getLanguages() != null && !input.getLanguages().isEmpty())
-                .findFirst()
-                .ifPresent(input -> chosen.setLanguages(input.getLanguages()));
+        Set<String> combinedLanguages = MoreStreams.stream(orderedContent)
+                .map(Content::getLanguages)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        chosen.setLanguages(combinedLanguages);
     }
 
     private <T extends Item> void matchAndMerge(final Broadcast chosenBroadcast,

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -1031,7 +1031,7 @@ public class OutputContentMergerTest {
         List<Brand> orderedContent = sortByPublisherThenId(application, ImmutableList.of(highestPrecedence, lowerPrecedence));
         Brand merged = merger.merge(orderedContent, application, Collections.emptySet());
 
-        assertThat(merged.getLanguages(), is(ImmutableSet.of("en_GB")));
+        assertThat(merged.getLanguages(), is(ImmutableSet.of("en_GB", "fr_FR")));
 
         Brand anotherHighestPrecedence = brand(3, "again not relevant", Publisher.PA);    // no language
         orderedContent = sortByPublisherThenId(application, ImmutableList.of(anotherHighestPrecedence, lowerPrecedence));

--- a/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/output/OutputContentMergerTest.java
@@ -1023,23 +1023,21 @@ public class OutputContentMergerTest {
                 Publisher.PA,
                 Publisher.YOUVIEW
         );
-        Item highestPrecedence = item(2, "not relevant", Publisher.PA);
+        Brand highestPrecedence = brand(2, "not relevant", Publisher.PA);
         highestPrecedence.setLanguages(ImmutableSet.of("en_GB"));
-        Item lowerPrecedence = item(1, "also not relevant", Publisher.YOUVIEW);
+        Brand lowerPrecedence = brand(1, "also not relevant", Publisher.YOUVIEW);
         lowerPrecedence.setLanguages(ImmutableSet.of("fr_FR"));
 
-        List<Item> orderedContent = sortByPublisherThenId(application, ImmutableList.of(highestPrecedence, lowerPrecedence));
-        Item merged = merger.merge(orderedContent, application, Collections.emptySet());
+        List<Brand> orderedContent = sortByPublisherThenId(application, ImmutableList.of(highestPrecedence, lowerPrecedence));
+        Brand merged = merger.merge(orderedContent, application, Collections.emptySet());
 
         assertThat(merged.getLanguages(), is(ImmutableSet.of("en_GB")));
 
-/*        TODO add these language merging is fixed (move it out of mergeFilm into mergeContent)
-        Item anotherHighestPrecedence = item(3, "again not relevant", Publisher.PA);    // no language
+        Brand anotherHighestPrecedence = brand(3, "again not relevant", Publisher.PA);    // no language
         orderedContent = sortByPublisherThenId(application, ImmutableList.of(anotherHighestPrecedence, lowerPrecedence));
         merged = merger.merge(orderedContent, application, Collections.emptySet());
 
         assertThat(merged.getLanguages(), is(ImmutableSet.of("fr_FR")));
-*/
     }
 
     @Test


### PR DESCRIPTION
This adds merging logic for languages & certificates
to all content types (previously, it was just films). 
This fixes cases such as editors renaming a brand, 
which adds a higher precedence source content
with no language the equiv set, resulting in no
language being visible in Shaman. See ENG-813.