### PR TITLE
Set UTF-8 character encoding header for json responses 

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/JsonResponseWriter.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/JsonResponseWriter.java
@@ -89,6 +89,7 @@ public final class JsonResponseWriter implements ResponseWriter {
     public void startResponse() throws IOException {
         printMemberSeparator = false;
         response.setContentType(MimeType.APPLICATION_JSON.toString());
+        response.setCharacterEncoding("UTF-8");
         writer = writer();
         callback = callback(request);
         if (callback != null) {


### PR DESCRIPTION
since it was being deserialized as something else (some ISO- standard).