### PR TITLE
Add retries to select queries in CassandraEquivalentContentStore...

### DIFF
--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -800,9 +800,14 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                 List<Row> graphResults = getGraphResults(combinedResults);
                 List<Row> dataResults = getDataResults(combinedResults);
                 boolean resultsMatch = resultsMatch(graphResults, dataResults);
-                if (resultsMatch || attempt.incrementAndGet() > NUMBER_OF_CASSANDRA_SELECT_RETRIES) {
+                int attemptNumber = attempt.incrementAndGet();
+                if (resultsMatch || attemptNumber > NUMBER_OF_CASSANDRA_SELECT_RETRIES) {
                     if (!resultsMatch) {
                         log.warn("Exceeded retry count for combined data and graph future");
+                    } else {
+                        if (attemptNumber > 1) {
+                            log.info("Succeeded to fetch combined data and graph future after {} attempts", attemptNumber);
+                        }
                     }
                     return Futures.immediateFuture(new GraphAndDataResults(graphResults, dataResults));
                 } else {

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -796,11 +796,7 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                 boolean resultsMatch = resultsMatch(combinedResults);
                 if (resultsMatch || attempt.incrementAndGet() > NUMBER_OF_CASSANDRA_SELECT_RETRIES) {
                     if (!resultsMatch) {
-                        log.warn(
-                                "Exceeded retry count for dataStatement: {}, graphStatement: {}",
-                                dataStatement,
-                                graphStatement
-                        );
+                        log.warn("Exceeded retry count for combined data and graph future");
                     } else {
                         log.info("Succeeded after {} attempt(s)", attempt.get());
                     }

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -844,11 +844,6 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
             return resultsFuture.isDone();
         }
 
-        private GraphAndDataResults toGraphAndDataResults(List<ResultSet> resultSets) {
-            assert(resultSets.size() == 2);
-            return new GraphAndDataResults(getGraphResults(resultSets), getDataResults(resultSets));
-        }
-
         @Override
         public GraphAndDataResults get() throws InterruptedException, ExecutionException {
             return resultsFuture.get();

--- a/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
+++ b/atlas-cassandra/src/main/java/org/atlasapi/content/CassandraEquivalentContentStore.java
@@ -803,8 +803,6 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
                 if (resultsMatch || attempt.incrementAndGet() > NUMBER_OF_CASSANDRA_SELECT_RETRIES) {
                     if (!resultsMatch) {
                         log.warn("Exceeded retry count for combined data and graph future");
-                    } else {
-                        log.info("Succeeded after {} attempt(s)", attempt.get());
                     }
                     return Futures.immediateFuture(new GraphAndDataResults(graphResults, dataResults));
                 } else {
@@ -814,10 +812,6 @@ public class CassandraEquivalentContentStore extends AbstractEquivalentContentSt
         }
 
         private boolean resultsMatch(List<Row> graphResults, List<Row> dataResults) {
-            //For testing
-            if (Math.random() < 0.3) {
-                return false;
-            }
             Set<Long> graphSetIds = graphResults.stream()
                     .map(row -> row.getLong(SET_ID_KEY))
                     .collect(MoreCollectors.toImmutableSet());


### PR DESCRIPTION
...if the set of setIds from the graph and data queries do not match
to try and work around an unavoidable race condition which otherwise
led to an error.