### PR TITLE
Use brand ref writer to write container field for series in api

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ContainerSummaryAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ContainerSummaryAnnotation.java
@@ -1,12 +1,13 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-
 import org.atlasapi.content.Content;
 import org.atlasapi.content.Item;
+import org.atlasapi.content.Series;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ContainerSummaryWriter;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -14,10 +15,16 @@ public class ContainerSummaryAnnotation extends OutputAnnotation<Content> {
 
     private final String containerField;
     private final ContainerSummaryWriter summaryWriter;
+    private final ResourceRefWriter brandRefWriter;
 
-    public ContainerSummaryAnnotation(String containerField, ContainerSummaryWriter summaryWriter) {
+    public ContainerSummaryAnnotation(
+            String containerField,
+            ContainerSummaryWriter summaryWriter,
+            ResourceRefWriter brandRefWriter
+    ) {
         this.containerField = checkNotNull(containerField);
         this.summaryWriter = checkNotNull(summaryWriter);
+        this.brandRefWriter = checkNotNull(brandRefWriter);
     }
 
     @Override
@@ -28,6 +35,13 @@ public class ContainerSummaryAnnotation extends OutputAnnotation<Content> {
                 writer.writeField(containerField, null);
             } else {
                 writer.writeObject(summaryWriter, item, ctxt);
+            }
+        } else if (entity instanceof Series) {
+            Series series = (Series) entity;
+            if (series.getBrandRef() == null) {
+                writer.writeField(containerField, null);
+            } else {
+                writer.writeObject(brandRefWriter, series.getBrandRef(), ctxt);
             }
         }
     }

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -1,7 +1,14 @@
 package org.atlasapi.query;
 
-import javax.servlet.http.HttpServletRequest;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.query.Selection.SelectionBuilder;
+import com.metabroadcast.common.time.SystemClock;
+import com.metabroadcast.representative.client.RepIdClient;
 import org.atlasapi.AtlasPersistenceModule;
 import org.atlasapi.LicenseModule;
 import org.atlasapi.annotation.Annotation;
@@ -79,6 +86,7 @@ import org.atlasapi.output.annotation.RatingsAnnotation;
 import org.atlasapi.output.annotation.RegionsAnnotation;
 import org.atlasapi.output.annotation.RelatedLinksAnnotation;
 import org.atlasapi.output.annotation.RepIdAnnotation;
+import org.atlasapi.output.annotation.ResourceRefWriter;
 import org.atlasapi.output.annotation.ReviewsAnnotation;
 import org.atlasapi.output.annotation.SegmentEventsAnnotation;
 import org.atlasapi.output.annotation.SeriesAnnotation;
@@ -169,23 +177,14 @@ import org.atlasapi.source.Sources;
 import org.atlasapi.topic.PopularTopicIndex;
 import org.atlasapi.topic.Topic;
 import org.atlasapi.topic.TopicResolver;
-
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.metabroadcast.common.query.Selection;
-import com.metabroadcast.common.query.Selection.SelectionBuilder;
-import com.metabroadcast.common.time.SystemClock;
-import com.metabroadcast.representative.client.RepIdClient;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import javax.servlet.http.HttpServletRequest;
 
 import static org.atlasapi.annotation.Annotation.ADVERTISED_CHANNELS;
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
@@ -1052,7 +1051,8 @@ public class QueryWebModule {
                                         CONTAINER_FIELD,
                                         containerSummaryResolver,
                                         CommonContainerSummaryWriter.create()
-                                )
+                                ),
+                                new ResourceRefWriter(CONTAINER_FIELD, idCodec())
                         ),
                         commonImplied,
                         ImmutableSet.of(BRAND_REFERENCE)

--- a/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/output/AnnotationRegistryTest.java
@@ -11,6 +11,7 @@ import org.atlasapi.output.annotation.ExtendedIdentificationAnnotation;
 import org.atlasapi.output.annotation.IdentificationAnnotation;
 import org.atlasapi.output.annotation.IdentificationSummaryAnnotation;
 import org.atlasapi.output.annotation.OutputAnnotation;
+import org.atlasapi.output.annotation.ResourceRefWriter;
 import org.atlasapi.output.annotation.SeriesReferenceAnnotation;
 import org.atlasapi.output.writers.ContainerSummaryWriter;
 import org.atlasapi.output.writers.IdSummaryWriter;
@@ -49,7 +50,8 @@ public class AnnotationRegistryTest {
     private final SeriesReferenceAnnotation seriesRef = new SeriesReferenceAnnotation(idCodec);
     private final ContainerSummaryAnnotation seriesSum = new ContainerSummaryAnnotation(
             "series",
-            mock(ContainerSummaryWriter.class)
+            mock(ContainerSummaryWriter.class),
+            new ResourceRefWriter("series", idCodec)
     );
 
     private final AnnotationRegistry<Content> registry = AnnotationRegistry.<Content>builder()


### PR DESCRIPTION
The container field was otherwise not being written at all for series
when using the brand_summary annotation, even if other valid annotations
for the field were used.