### PR TITLE
Eng 949

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/BroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/BroadcastsAnnotation.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.Region;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.Broadcast;
@@ -70,12 +72,14 @@ public class BroadcastsAnnotation extends OutputAnnotation<Content> {
 
         if (ctxt.getRegions().isPresent()) {
             List<Region> regions = ctxt.getRegions().get();
+            boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
 
             List<Broadcast> broadcasts = Lists.newArrayList();
             regions.forEach(region -> {
                 Iterable<Broadcast> broadcastsToAdd = channelsBroadcastFilter.sortAndFilter(
                         filteredBroadcasts,
-                        region
+                        region,
+                        lcnSharing
                 );
                 Iterables.addAll(broadcasts, broadcastsToAdd);
             });

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -66,8 +66,9 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<R
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         } else {
+            boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
             for (ChannelGroupMembership channelGroupMembership :
-                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now())) {
+                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)) {
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelIdsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelIdsAnnotation.java
@@ -2,6 +2,7 @@ package org.atlasapi.output.annotation;
 
 import java.io.IOException;
 
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.FieldWriter;
@@ -24,8 +25,9 @@ public class ChannelGroupChannelIdsAnnotation extends OutputAnnotation<ResolvedC
     @Override
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
+        boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
         ImmutableList<ChannelGroupMembership> channels = ImmutableList.copyOf(
-                entity.getChannelGroup().getChannelsAvailable(LocalDate.now())
+                entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)
         );
         writer.writeList(channelIdsWriter, channels, ctxt);
     }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -68,8 +68,9 @@ public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedCha
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         } else {
+            boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
             for (ChannelGroupMembership channelGroupMembership :
-                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now())) {
+                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)) {
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/CurrentAndFutureBroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/CurrentAndFutureBroadcastsAnnotation.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.Region;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.Broadcast;
@@ -64,12 +66,14 @@ public class CurrentAndFutureBroadcastsAnnotation extends OutputAnnotation<Conte
 
             if (ctxt.getRegions().isPresent()) {
                 List<Region> regions = ctxt.getRegions().get();
+                boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
 
                 List<Broadcast> broadcasts = Lists.newArrayList();
                 regions.forEach(region -> {
                     Iterable<Broadcast> broadcastsToAdd = channelsBroadcastFilter.sortAndFilter(
                             filteredBroadcasts,
-                            region
+                            region,
+                            lcnSharing
                     );
                     Iterables.addAll(broadcasts, broadcastsToAdd);
                 });

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingBroadcastsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingBroadcastsAnnotation.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
+
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.Region;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.content.Broadcast;
@@ -66,12 +68,14 @@ public class UpcomingBroadcastsAnnotation extends OutputAnnotation<Content> {
 
             if (ctxt.getRegions().isPresent()) {
                 List<Region> regions = ctxt.getRegions().get();
+                boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
 
                 List<Broadcast> broadcasts = Lists.newArrayList();
                 regions.forEach(region -> {
                     Iterable<Broadcast> broadcastsToAdd = channelsBroadcastFilter.sortAndFilter(
                             filteredBroadcasts,
-                            region
+                            region,
+                            lcnSharing
                     );
                     Iterables.addAll(broadcasts, broadcastsToAdd);
                 });

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingContentDetailAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/UpcomingContentDetailAnnotation.java
@@ -84,12 +84,14 @@ public class UpcomingContentDetailAnnotation extends OutputAnnotation<Content> {
                             .collect(Collectors.toSet());
                     if (ctxt.getRegions().isPresent()) {
                         List<Region> regions = ctxt.getRegions().get();
+                        boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
 
                         List<Broadcast> broadcasts = Lists.newArrayList();
                         for (Region region : regions) {
                             Iterable<Broadcast> broadcastsToAdd = channelsBroadcastFilter.sortAndFilter(
                                     upcomingBroadcasts,
-                                    region
+                                    region,
+                                    lcnSharing
                             );
                             Iterables.addAll(broadcasts, broadcastsToAdd);
                         }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -273,6 +273,10 @@ public class ChannelGroupQueryExecutorTest {
             .thenReturn(channels);
         when(testChannelGroup3.getChannelsAvailable(any(LocalDate.class)))
             .thenReturn(channels);
+        when(testChannelGroup.getChannelsAvailable(any(LocalDate.class), anyBoolean()))
+                .thenReturn(channels);
+        when(testChannelGroup3.getChannelsAvailable(any(LocalDate.class), anyBoolean()))
+                .thenReturn(channels);
 
         when(testChannelGroup.getType()).thenReturn("platform");
         when(testChannelGroup2.getType()).thenReturn("region");

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -89,7 +89,7 @@ public enum Annotation {
     CUSTOM_FIELDS,
     LOCATION_PROVIDERS,
     NO_SMART_SEARCH,
-    LCN_SHARING,
+    LCN_SHARING,    // enables fetching more than one channel per lcn (within a channel group)
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -89,6 +89,7 @@ public enum Annotation {
     CUSTOM_FIELDS,
     LOCATION_PROVIDERS,
     NO_SMART_SEARCH,
+    LCN_SHARING,
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
@@ -68,6 +68,10 @@ public class ChannelGroup<T extends ChannelGroupMembership> extends Identified i
     }
 
     public Iterable<T> getChannelsAvailable(LocalDate date) {
+        return getChannelsAvailable(date, false);
+    }
+
+    public Iterable<T> getChannelsAvailable(LocalDate date, boolean lcnSharing) {
         return channels.stream()
                 .filter(ch -> ch.isAvailable(date))
                 .collect(MoreCollectors.toImmutableSet());

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -39,6 +39,15 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
 
     @Override
     public Iterable<ChannelNumbering> getChannelsAvailable(LocalDate date) {
+        return getChannelsAvailable(date, false);
+    }
+
+    @Override
+    public Iterable<ChannelNumbering> getChannelsAvailable(LocalDate date, boolean lcnSharing) {
+        if (lcnSharing) {
+            return StreamSupport.stream(super.getChannelsAvailable(date).spliterator(), false)
+                    .sorted(CHANNEL_NUMBERING_ORDERING).collect(MoreCollectors.toImmutableList());
+        }
         return StreamSupport.stream(super.getChannelsAvailable(date).spliterator(), false)
                 //we need to use randomUUID in order to avoid deduplicating chanels which have no numbering
                 .collect(Collectors.groupingBy(cn -> cn.getChannelNumber()

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -39,6 +39,8 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
 
     @Override
     public Iterable<ChannelNumbering> getChannelsAvailable(LocalDate date, boolean lcnSharing) {
+        // normally within a channel group, we expect/want only channel per channel number AKA lcn.
+        // with lcnSharing = true (via annotation), we allow more than one to be served.
         if (lcnSharing) {
             return StreamSupport.stream(super.getChannelsAvailable(date, lcnSharing).spliterator(), false)
                     .sorted(CHANNEL_NUMBERING_ORDERING).collect(MoreCollectors.toImmutableList());

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -43,7 +43,8 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
         // with lcnSharing = true (via annotation), we allow more than one to be served.
         if (lcnSharing) {
             return StreamSupport.stream(super.getChannelsAvailable(date, lcnSharing).spliterator(), false)
-                    .sorted(CHANNEL_NUMBERING_ORDERING).collect(MoreCollectors.toImmutableList());
+                    .sorted(CHANNEL_NUMBERING_ORDERING)
+                    .collect(MoreCollectors.toImmutableList());
         }
         return StreamSupport.stream(super.getChannelsAvailable(date, lcnSharing).spliterator(), false)
                 //we need to use randomUUID in order to avoid deduplicating chanels which have no numbering

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -38,17 +38,12 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
     }
 
     @Override
-    public Iterable<ChannelNumbering> getChannelsAvailable(LocalDate date) {
-        return getChannelsAvailable(date, false);
-    }
-
-    @Override
     public Iterable<ChannelNumbering> getChannelsAvailable(LocalDate date, boolean lcnSharing) {
         if (lcnSharing) {
-            return StreamSupport.stream(super.getChannelsAvailable(date).spliterator(), false)
+            return StreamSupport.stream(super.getChannelsAvailable(date, lcnSharing).spliterator(), false)
                     .sorted(CHANNEL_NUMBERING_ORDERING).collect(MoreCollectors.toImmutableList());
         }
-        return StreamSupport.stream(super.getChannelsAvailable(date).spliterator(), false)
+        return StreamSupport.stream(super.getChannelsAvailable(date, lcnSharing).spliterator(), false)
                 //we need to use randomUUID in order to avoid deduplicating chanels which have no numbering
                 .collect(Collectors.groupingBy(cn -> cn.getChannelNumber()
                         .orElse(UUID.randomUUID().toString())))

--- a/atlas-core/src/main/java/org/atlasapi/content/ChannelsBroadcastFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/ChannelsBroadcastFilter.java
@@ -11,9 +11,7 @@ import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 public class ChannelsBroadcastFilter {
@@ -27,14 +25,15 @@ public class ChannelsBroadcastFilter {
 
     public Iterable<Broadcast> sortAndFilter(
             Iterable<Broadcast> broadcasts,
-            ChannelGroup<?> channelGroup
+            ChannelGroup<?> channelGroup,
+            boolean lcnSharing
     ) {
         if (Iterables.isEmpty(broadcasts)) {
             return ImmutableList.of();
         }
 
         ImmutableList<Id> channelIds = StreamSupport.stream(
-                channelGroup.getChannelsAvailable(LocalDate.now()).spliterator(),
+                channelGroup.getChannelsAvailable(LocalDate.now(), lcnSharing).spliterator(),
                 false
         )
                 .map(channel -> channel.getChannel().getId())

--- a/atlas-core/src/test/java/org/atlasapi/content/ChannelsBroadcastFilterTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/ChannelsBroadcastFilterTest.java
@@ -105,9 +105,10 @@ public class ChannelsBroadcastFilterTest {
 
     private ImmutableList<Broadcast> filterBroadcasts(Broadcast... broadcasts) {
         return ImmutableList.copyOf(filter.sortAndFilter(
-                    ImmutableList.copyOf(broadcasts),
-                    channelGroup
-            ));
+                ImmutableList.copyOf(broadcasts),
+                channelGroup,
+                false
+                ));
     }
 
     private ChannelGroupMembership getChannelGroupMembership(Id channelId) {


### PR DESCRIPTION
Deer channel group calls were only allowing one channel to be displayed per lcn / channel number. This was a blocker for the ingest-youview project, which has a few "legitimate" instances of channels being assigned to the same channel number (for a handful of channel group).

This PR adds the lcn_sharing annotation which, when used together with `channels` on a channel group call, will return all currently available channels within a channelGroup including those cases of channels sharing an LCN.