### PR TITLE
Sherlock split index improvement

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
+++ b/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
@@ -145,7 +145,12 @@ public class EsUnequivalentContentSearcher implements ContentSearcher, DelegateC
                                 contentMapping.getSource().getKey(),
                                 publishers)
                 )
-                .withIndex(SherlockIndex.CONTENT)
+                .withIndex(
+                        SherlockIndex.CONTENT,
+                        MoreStreams.stream(publishers)
+                                .map(Publisher::key)
+                                .collect(MoreCollectors.toImmutableSet())
+                )
                 .withOffset(selection.getOffset())
                 .withLimit(selection.getLimit() == null ? DEFAULT_LIMIT : selection.getLimit());
 

--- a/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
+++ b/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
@@ -1,6 +1,5 @@
 package org.atlasapi.elasticsearch.content;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -22,7 +21,7 @@ import org.atlasapi.content.ContentSearcher;
 import org.atlasapi.content.FuzzyQueryParams;
 import org.atlasapi.content.IndexQueryResult;
 import org.atlasapi.criteria.AttributeQuery;
-import org.atlasapi.criteria.StringAttributeQuery;
+import org.atlasapi.criteria.EnumAttributeQuery;
 import org.atlasapi.criteria.attribute.Attributes;
 import org.atlasapi.criteria.legacy.LegacyContentFieldTranslator;
 import org.atlasapi.criteria.legacy.LegacyTranslation;
@@ -152,8 +151,13 @@ public class EsUnequivalentContentSearcher implements ContentSearcher, DelegateC
 
         for (AttributeQuery<?> attributeQuery : query) {
             if (Attributes.SOURCE.equals(attributeQuery.getAttribute())) {
-                List<String> sourcesFromAttribute = ((StringAttributeQuery) attributeQuery).getValue();
-                sources = Sets.intersection(ImmutableSet.copyOf(sourcesFromAttribute), sources);
+                List<Publisher> sourcesFromAttribute = ((EnumAttributeQuery<Publisher>) attributeQuery).getValue();
+                sources = Sets.intersection(
+                        sourcesFromAttribute.stream()
+                                .map(Publisher::key)
+                                .collect(MoreCollectors.toImmutableSet()),
+                        sources
+                );
             }
         }
 

--- a/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
+++ b/atlas-api/src/main/java/org/atlasapi/elasticsearch/content/EsUnequivalentContentSearcher.java
@@ -1,5 +1,6 @@
 package org.atlasapi.elasticsearch.content;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -149,16 +150,22 @@ public class EsUnequivalentContentSearcher implements ContentSearcher, DelegateC
                 .map(Publisher::key)
                 .collect(MoreCollectors.toImmutableSet());
 
-        for (AttributeQuery<?> attributeQuery : query) {
-            if (Attributes.SOURCE.equals(attributeQuery.getAttribute())) {
-                List<Publisher> sourcesFromAttribute = ((EnumAttributeQuery<Publisher>) attributeQuery).getValue();
-                sources = Sets.intersection(
-                        sourcesFromAttribute.stream()
-                                .map(Publisher::key)
-                                .collect(MoreCollectors.toImmutableSet()),
-                        sources
-                );
-            }
+        AttributeQuery<?> sourceAttributeQuery = Iterables.getOnlyElement(
+                Iterables.filter(
+                        query,
+                        q -> Attributes.SOURCE.equals(q.getAttribute())
+                ),
+                null
+        );
+
+        if (sourceAttributeQuery != null) {
+            List<Publisher> sourcesFromAttribute = ((EnumAttributeQuery<Publisher>) sourceAttributeQuery).getValue();
+            sources = Sets.intersection(
+                    sourcesFromAttribute.stream()
+                            .map(Publisher::key)
+                            .collect(MoreCollectors.toImmutableSet()),
+                    sources
+            );
         }
 
         SearchQuery.Builder searchQueryBuilder = SearchQuery.builder()

--- a/atlas-api/src/main/java/org/atlasapi/query/v5/search/attribute/SherlockAttributes.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v5/search/attribute/SherlockAttributes.java
@@ -333,6 +333,11 @@ public class SherlockAttributes {
                         SherlockParameter.LOCATIONS_DISTRIBUTOR,
                         content.getLocations().getDistributor(),
                         StringCoercer.create()
+                ),
+                new KeywordAttribute<>(
+                        SherlockParameter.LOCATIONS_PROVIDER_NAME,
+                        content.getLocations().getProvider().getName(),
+                        StringCoercer.create()
                 )
         );
     }

--- a/atlas-api/src/main/java/org/atlasapi/query/v5/search/attribute/SherlockParameter.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v5/search/attribute/SherlockParameter.java
@@ -69,6 +69,7 @@ public enum SherlockParameter {
     LOCATIONS_SOURCE(Type.FILTER, Group.LOCATIONS, "source"),
     LOCATIONS_SOURCE_COUNTRY(Type.FILTER, Group.LOCATIONS, "source.country"),
     LOCATIONS_DISTRIBUTOR(Type.FILTER, Group.LOCATIONS, "distributor"),
+    LOCATIONS_PROVIDER_NAME(Type.FILTER, Group.LOCATIONS, "provider_name"),
 
     // Data
     DATA_BIT_RATE(Type.FILTER, Group.DATA, "bit_rate"),


### PR DESCRIPTION
Use specific split Sherlock content indices when known instead of wildcards.

Added location provider name filter to v5 Sherlock search endpoint.