### PR TITLE
Merge parent hierarchy

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -17,7 +17,6 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.stream.MoreStreams;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.Brand;
-import org.atlasapi.content.BrandRef;
 import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.Certificate;
 import org.atlasapi.content.Clip;

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -1,17 +1,23 @@
 package org.atlasapi.output;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.stream.MoreStreams;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.Brand;
+import org.atlasapi.content.BrandRef;
 import org.atlasapi.content.Broadcast;
 import org.atlasapi.content.Certificate;
 import org.atlasapi.content.Clip;
@@ -31,6 +37,7 @@ import org.atlasapi.content.LocalizedTitle;
 import org.atlasapi.content.LocationSummary;
 import org.atlasapi.content.ReleaseDate;
 import org.atlasapi.content.Series;
+import org.atlasapi.content.SeriesRef;
 import org.atlasapi.content.Subtitles;
 import org.atlasapi.content.Tag;
 import org.atlasapi.entity.Award;
@@ -40,26 +47,18 @@ import org.atlasapi.entity.Review;
 import org.atlasapi.entity.Sourceds;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.segment.SegmentEvent;
-
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.common.stream.MoreCollectors;
-import com.metabroadcast.common.stream.MoreStreams;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -389,15 +388,38 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             Set<Annotation> activeAnnotations) {
         mergeContent(application, chosen, orderedContent);
         mergeVersions(application, chosen, orderedContent, activeAnnotations);
+        mergeItemParents(chosen, orderedContent);
 
         if (chosen instanceof Film) {
             mergeFilmProperties(application, (Film) chosen, Iterables.filter(orderedContent, Film.class));
         }
-        if (chosen.getContainerRef() == null) {
-            chosen.setContainerRef(first(orderedContent, TO_CONTAINER_REF));
+    }
+
+    /**
+     * Finds the first piece item with any hierarchy. Uses the entire hierarchy (both container and series) of an
+     * episode if one is found even if not all are present (e.g. container exists but not series). This is to avoid the
+     * case where the first source lists the episode as a special of a brand and thus under no series, whilst another
+     * lists it as a series of a brand, since the merged result would not respect the hierarchy of the higher precedent
+     * source.
+     */
+    private <T extends Item> void mergeItemParents(T chosen, Iterable<T> orderedContent) {
+        if (chosen.getContainerRef() != null) {
+            return;
         }
-        if (chosen.getContainerSummary() == null) {
-            chosen.setContainerSummary(first(orderedContent, TO_CONTAINER_SUMMARY));
+        boolean chosenIsEpisode = chosen instanceof Episode;
+        for (T item : orderedContent) {
+            ContainerRef containerRef = item.getContainerRef();
+            SeriesRef seriesRef = chosenIsEpisode && item instanceof Episode
+                    ? ((Episode) item).getSeriesRef()
+                    : null;
+            if (containerRef != null || seriesRef != null) {
+                chosen.setContainerRef(containerRef);
+                chosen.setContainerSummary(item.getContainerSummary());
+                if (chosenIsEpisode) {
+                    ((Episode) chosen).setSeriesRef(seriesRef);
+                }
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
See code comments for more detail but this makes merging logic fill in hierarchy more sensibly from items (and their subclasses) along with for top-level series.

The motivation for this is to allow overrides to not ruin the underlying hierarchy of content; an override series without hierarchy is indistinguishable from a top-level series and would otherwise remove underlying hierarchy, and parentless episodes would have avoided any series parent from being merged in if it existed with the current logic.

Note for episodes we don't merge in container and series parent independently since it is nonsensical; instead we pick the first piece of content that has either value and treat them as a pair.

This change essentially changes merging logic behaviour of top-level series which are equived to non-top-level series which was an acceptable change for us since we have decided to prefer the notion that top-level series are simply series that have yet to gain a container, rather than series that should not have a container.