### PR TITLE
Image merging rework (ENG-1023)

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
@@ -31,10 +31,10 @@ public class DescriptionAnnotation<T extends Described> extends
         writer.writeField("title", entity.getTitle());
         writer.writeField("description", entity.getDescription());
         boolean shouldWriteImage = contextHasAnnotation(ctxt, Annotation.UNAVAILABLE_IMAGES) ||
-                Image.isAvailableAndNotGenericImageContentPlayer(
+                (entity.getImage() != null && Image.isAvailableAndNotGenericImageContentPlayer(
                         entity.getImage(),
                         entity.getImages()
-                );
+                ));
         writer.writeField("image", shouldWriteImage ? entity.getImage() : null);
         writer.writeField("thumbnail", shouldWriteImage ? entity.getThumbnail() : null);
         if (entity instanceof Item) {

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
@@ -1,7 +1,9 @@
 package org.atlasapi.output.annotation;
 
 import com.google.common.primitives.Ints;
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.Described;
+import org.atlasapi.content.Image;
 import org.atlasapi.content.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.EntityWriter;
@@ -11,6 +13,8 @@ import org.atlasapi.output.writers.SourceWriter;
 import org.atlasapi.topic.Topic;
 
 import java.io.IOException;
+
+import static org.atlasapi.util.QueryUtils.contextHasAnnotation;
 
 public class DescriptionAnnotation<T extends Described> extends
         OutputAnnotation<T> {
@@ -26,8 +30,13 @@ public class DescriptionAnnotation<T extends Described> extends
         }
         writer.writeField("title", entity.getTitle());
         writer.writeField("description", entity.getDescription());
-        writer.writeField("image", entity.getImage());
-        writer.writeField("thumbnail", entity.getThumbnail());
+        boolean shouldWriteImage = contextHasAnnotation(ctxt, Annotation.UNAVAILABLE_IMAGES) ||
+                Image.isAvailableAndNotGenericImageContentPlayer(
+                        entity.getImage(),
+                        entity.getImages()
+                );
+        writer.writeField("image", shouldWriteImage ? entity.getImage() : null);
+        writer.writeField("thumbnail", shouldWriteImage ? entity.getThumbnail() : null);
         if (entity instanceof Item) {
             Item item = (Item) entity;
             writer.writeField(

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/DescriptionAnnotation.java
@@ -30,7 +30,7 @@ public class DescriptionAnnotation<T extends Described> extends
         }
         writer.writeField("title", entity.getTitle());
         writer.writeField("description", entity.getDescription());
-        boolean shouldWriteImage = contextHasAnnotation(ctxt, Annotation.UNAVAILABLE_IMAGES) ||
+        boolean shouldWriteImage = contextHasAnnotation(ctxt, Annotation.ALL_IMAGES) ||
                 (entity.getImage() != null && Image.isAvailableAndNotGenericImageContentPlayer(
                         entity.getImage(),
                         entity.getImages()

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -191,6 +191,7 @@ import static org.atlasapi.annotation.Annotation.ADVERTISED_CHANNELS;
 import static org.atlasapi.annotation.Annotation.AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_AGGREGATED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.ALL_BROADCASTS;
+import static org.atlasapi.annotation.Annotation.ALL_IMAGES;
 import static org.atlasapi.annotation.Annotation.ALL_MERGED_BROADCASTS;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT_DETAIL;
@@ -1149,6 +1150,7 @@ public class QueryWebModule {
                         commonImplied
                 )
                 .register(IMAGES, new ImagesAnnotation(), commonImplied)
+                .register(ALL_IMAGES, NullWriter.create(Content.class), ImmutableSet.of(IMAGES))
                 .register(CHANNELS, new ChannelsAnnotation(), commonImplied)
                 .register(
                         CONTENT_SUMMARY,

--- a/atlas-api/src/main/java/org/atlasapi/query/annotation/ImagesAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/annotation/ImagesAnnotation.java
@@ -1,7 +1,7 @@
 package org.atlasapi.query.annotation;
 
-import java.io.IOException;
-
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.annotation.Annotation;
 import org.atlasapi.content.Described;
 import org.atlasapi.content.Image;
 import org.atlasapi.output.EntityListWriter;
@@ -10,13 +10,23 @@ import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.annotation.OutputAnnotation;
 import org.atlasapi.output.writers.ImageListWriter;
 
+import java.io.IOException;
+import java.util.Set;
+
+import static org.atlasapi.util.QueryUtils.contextHasAnnotation;
+
 public class ImagesAnnotation extends OutputAnnotation<Described> {
 
     private final EntityListWriter<Image> imageWriter = new ImageListWriter();
 
     @Override
     public void write(Described entity, FieldWriter writer, OutputContext ctxt) throws IOException {
-        writer.writeList(imageWriter, entity.getImages(), ctxt);
+        Set<Image> images = contextHasAnnotation(ctxt, Annotation.UNAVAILABLE_IMAGES) ?
+                entity.getImages() :
+                entity.getImages().stream()
+                        .filter(Image.IS_AVAILABLE::apply)
+                        .collect(MoreCollectors.toImmutableSet());
+        writer.writeList(imageWriter, images, ctxt);
     }
 
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/annotation/ImagesAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/annotation/ImagesAnnotation.java
@@ -21,7 +21,7 @@ public class ImagesAnnotation extends OutputAnnotation<Described> {
 
     @Override
     public void write(Described entity, FieldWriter writer, OutputContext ctxt) throws IOException {
-        Set<Image> images = contextHasAnnotation(ctxt, Annotation.UNAVAILABLE_IMAGES) ?
+        Set<Image> images = contextHasAnnotation(ctxt, Annotation.ALL_IMAGES) ?
                 entity.getImages() :
                 entity.getImages().stream()
                         .filter(Image.IS_AVAILABLE::apply)

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -89,7 +89,7 @@ public enum Annotation {
     CUSTOM_FIELDS,
     LOCATION_PROVIDERS,
     LCN_SHARING,    // enables fetching more than one channel per lcn (within a channel group)
-    UNAVAILABLE_IMAGES,
+    ALL_IMAGES,
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -89,6 +89,7 @@ public enum Annotation {
     CUSTOM_FIELDS,
     LOCATION_PROVIDERS,
     LCN_SHARING,    // enables fetching more than one channel per lcn (within a channel group)
+    UNAVAILABLE_IMAGES,
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/content/Image.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Image.java
@@ -412,20 +412,20 @@ public class Image implements Sourced, Hashable {
                 "http://images.atlas.metabroadcast.com/pressassociation.com/"
         );
 
-        boolean knownToBeAvailableAndNotGeneric = false;
         boolean found = false;
 
         // If there is a corresponding Image object for this URI, we check its availability and
         // whether it is generic.
         for (Image image : images) {
             if (image.getCanonicalUri().equals(rewrittenUri)) {
+                if (IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER.apply(image)) {
+                    return true;
+                }
                 found = true;
-                knownToBeAvailableAndNotGeneric = knownToBeAvailableAndNotGeneric
-                        || IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER.apply(image);
             }
         }
-        // Otherwise, we can only assume the image is available as we know no better
-        return knownToBeAvailableAndNotGeneric || !found;
+        // If not found we can only assume the image is available as we know no better
+        return !found;
     }
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/content/Image.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Image.java
@@ -406,7 +406,7 @@ public class Image implements Sourced, Hashable {
             @Nullable String imageUri,
             Set<Image> images
     ) {
-        // Image URIs differ between the image attribute and the canonical URI on Images.
+        // Image URIs can differ between the image attribute and the canonical URI on Images.
         // See PaProgrammeProcessor for why.
         String rewrittenUri = imageUri.replace(
                 "http://images.atlasapi.org/pa/",

--- a/atlas-core/src/main/java/org/atlasapi/content/Image.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Image.java
@@ -12,6 +12,9 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
+import java.util.Set;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Image implements Sourced, Hashable {
@@ -388,15 +391,37 @@ public class Image implements Sourced, Hashable {
         return uri.hashCode();
     }
 
-    public static final Predicate<Image> IS_AVAILABLE = new Predicate<Image>() {
+    public static final Predicate<Image> IS_AVAILABLE = image ->
+            (image.getAvailabilityStart() == null
+                    || !(new DateTime(image.getAvailabilityStart()).isAfterNow()))
+                    && (image.getAvailabilityEnd() == null
+                    || new DateTime(image.getAvailabilityEnd()).isAfterNow());
 
-        @Override
-        public boolean apply(Image input) {
-            return (input.getAvailabilityStart() == null
-                    || !(new DateTime(input.getAvailabilityStart()).isAfterNow()))
-                    && (input.getAvailabilityEnd() == null
-                    || new DateTime(input.getAvailabilityEnd()).isAfterNow());
+    public static final Predicate<Image> IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER = image ->
+            IS_AVAILABLE.apply(image)
+                    && !Type.GENERIC_IMAGE_CONTENT_PLAYER.equals(image.getType());
+
+    // N.B. an adapted version of this is also used in OutputContentMerger
+    public static boolean isAvailableAndNotGenericImageContentPlayer(
+            @Nullable String imageUri,
+            Set<Image> images
+    ) {
+        // Image URIs differ between the image attribute and the canonical URI on Images.
+        // See PaProgrammeProcessor for why.
+        String rewrittenUri = imageUri.replace(
+                "http://images.atlasapi.org/pa/",
+                "http://images.atlas.metabroadcast.com/pressassociation.com/"
+        );
+
+        // If there is a corresponding Image object for this URI, we check its availability and
+        // whether it is generic.
+        for (Image image : images) {
+            if (image.getCanonicalUri().equals(rewrittenUri)) {
+                return IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER.apply(image);
+            }
         }
-    };
+        // Otherwise, we can only assume the image is available as we know no better
+        return true;
+    }
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/content/Image.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/Image.java
@@ -12,7 +12,6 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -403,7 +402,7 @@ public class Image implements Sourced, Hashable {
 
     // N.B. an adapted version of this is also used in OutputContentMerger
     public static boolean isAvailableAndNotGenericImageContentPlayer(
-            @Nullable String imageUri,
+            String imageUri,
             Set<Image> images
     ) {
         // Image URIs can differ between the image attribute and the canonical URI on Images.
@@ -413,15 +412,20 @@ public class Image implements Sourced, Hashable {
                 "http://images.atlas.metabroadcast.com/pressassociation.com/"
         );
 
+        boolean knownToBeAvailableAndNotGeneric = false;
+        boolean found = false;
+
         // If there is a corresponding Image object for this URI, we check its availability and
         // whether it is generic.
         for (Image image : images) {
             if (image.getCanonicalUri().equals(rewrittenUri)) {
-                return IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER.apply(image);
+                found = true;
+                knownToBeAvailableAndNotGeneric = knownToBeAvailableAndNotGeneric
+                        || IS_AVAILABLE_AND_NOT_GENERIC_IMAGE_CONTENT_PLAYER.apply(image);
             }
         }
         // Otherwise, we can only assume the image is available as we know no better
-        return true;
+        return knownToBeAvailableAndNotGeneric || !found;
     }
 
 }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -548,7 +548,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
             }
         }
 
-        if (chosenImage == null && activeAnnotations.contains(Annotation.UNAVAILABLE_IMAGES)) {
+        if (chosenImage == null && activeAnnotations.contains(Annotation.ALL_IMAGES)) {
             chosenImage = fallbackImageIfAllUnavailable;
             chosenThumbnail = fallbackThumbnailIfAllUnavailable;
         }

--- a/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
+++ b/atlas-core/src/main/java/org/atlasapi/output/OutputContentMerger.java
@@ -538,7 +538,7 @@ public class OutputContentMerger implements EquivalentsMergeStrategy<Content> {
 
             if (chosenImage == null) {
                 // assume image can be used if we do not have its availability
-                if (canUseMainImage || !foundMainImageInSet) {
+                if (content.getImage() != null && (canUseMainImage || !foundMainImageInSet)) {
                     chosenImage = content.getImage();
                     chosenThumbnail = content.getThumbnail();
                 } else if (firstAvailableImageFromSet != null) {


### PR DESCRIPTION
The images set now includes all images from all equivs since it was a promised feature and to make it more consistent with merging of other collection fields.

If the content's image field is not set or is an unavailable image, an available image can now be chosen for it from the images set. In particular this allows another image from the same source to take the place of the expired image, instead of a lower precedent source image being chosen.

Unavailable images are now excluded from the images set as well unless a new all_images annotation is used.