### PR TITLE
Support dynamic channel numbers for certain channel groups

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/AtlasPersistenceModule.java
@@ -80,6 +80,7 @@ import org.atlasapi.persistence.player.CachingPlayerResolver;
 import org.atlasapi.persistence.player.PlayerResolver;
 import org.atlasapi.persistence.service.CachingServiceResolver;
 import org.atlasapi.persistence.service.ServiceResolver;
+import org.atlasapi.query.v4.schedule.OutputChannelGroupResolver;
 import org.atlasapi.query.v4.search.PseudoEsEquivalentContentSearcher;
 import org.atlasapi.schedule.EquivalentScheduleStore;
 import org.atlasapi.schedule.ScheduleResolver;
@@ -345,7 +346,7 @@ public class AtlasPersistenceModule {
         return new SherlockSearchModule(
                 sherlockElasticSearchConfig(),
                 metricsModule.metrics(),
-                channelGroupResolver(),
+                outputChannelGroupResolver(),
                 new CassandraSecondaryIndex(
                         persistenceModule().getSession(),
                         CassandraEquivalentContentStore.EQUIVALENT_CONTENT_INDEX,
@@ -461,6 +462,11 @@ public class AtlasPersistenceModule {
                 channelGroupStore(),
                 new LegacyChannelGroupTransformer()
         );
+    }
+
+    @Bean
+    public OutputChannelGroupResolver outputChannelGroupResolver() {
+        return new OutputChannelGroupResolver(channelGroupResolver());
     }
 
     @Bean

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/BaseChannelGroupsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/BaseChannelGroupsAnnotation.java
@@ -1,0 +1,30 @@
+package org.atlasapi.output.annotation;
+
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.NumberedChannelGroup;
+import org.atlasapi.channel.ResolvedChannelGroup;
+import org.atlasapi.output.FieldWriter;
+import org.atlasapi.output.OutputContext;
+import org.atlasapi.output.writers.ChannelGroupWriter;
+import org.atlasapi.query.common.exceptions.MissingResolvedDataException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class BaseChannelGroupsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
+
+    private static final ChannelGroupWriter CHANNEL_GROUP_WRITER = new ChannelGroupWriter(
+            "channel_numbers_from",
+            "channel_numbers_from"
+    );
+
+    @Override
+    public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
+            throws IOException {
+        if (!(entity.getChannelGroup() instanceof NumberedChannelGroup)) {
+            return;
+        }
+        Optional<ChannelGroup<?>> channelGroup = entity.getChannelNumbersFromGroup();
+        writer.writeObject(CHANNEL_GROUP_WRITER, channelGroup.orElse(null), ctxt);
+    }
+}

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryModule.java
@@ -99,7 +99,7 @@ public class QueryModule {
     @Bean
     public QueryExecutor<ResolvedChannelGroup> channelGroupQueryExecutor() {
         return new ChannelGroupQueryExecutor(
-                persistenceModule.channelGroupResolver(),
+                persistenceModule.outputChannelGroupResolver(),
                 persistenceModule.channelResolver());
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -45,6 +45,7 @@ import org.atlasapi.output.annotation.AvailableContentAnnotation;
 import org.atlasapi.output.annotation.AvailableContentDetailAnnotation;
 import org.atlasapi.output.annotation.AvailableLocationsAnnotation;
 import org.atlasapi.output.annotation.AwardsAnnotation;
+import org.atlasapi.output.annotation.BaseChannelGroupsAnnotation;
 import org.atlasapi.output.annotation.BrandReferenceAnnotation;
 import org.atlasapi.output.annotation.BroadcastsAnnotation;
 import org.atlasapi.output.annotation.ChannelAnnotation;
@@ -197,6 +198,7 @@ import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_CONTENT_DETAIL;
 import static org.atlasapi.annotation.Annotation.AVAILABLE_LOCATIONS;
 import static org.atlasapi.annotation.Annotation.AWARDS;
+import static org.atlasapi.annotation.Annotation.BASE_CHANNEL_GROUPS;
 import static org.atlasapi.annotation.Annotation.BRAND_REFERENCE;
 import static org.atlasapi.annotation.Annotation.BRAND_SUMMARY;
 import static org.atlasapi.annotation.Annotation.BROADCASTS;
@@ -716,6 +718,7 @@ public class QueryWebModule {
                                 )
                         )
                 )
+                .register(BASE_CHANNEL_GROUPS, new BaseChannelGroupsAnnotation(), CHANNEL_GROUP)
                 .build());
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
@@ -84,22 +84,21 @@ public class OutputChannelGroupResolver implements ChannelGroupResolver {
                     .filter(id -> !channelGroupById.containsKey(id))
                     .collect(MoreCollectors.toImmutableSet());
 
-            if (additionalChannelGroupsToResolve.isEmpty()) {
-                return Futures.immediateFuture(Resolved.valueOf(channelGroups));
-            }
-            ListenableFuture<Resolved<ChannelGroup<?>>> additionalChannelGroupsFuture
-                    = delegate.resolveIds(additionalChannelGroupsToResolve, refreshCache);
+            ListenableFuture<Resolved<ChannelGroup<?>>> additionalChannelGroupsFuture =
+                    additionalChannelGroupsToResolve.isEmpty()
+                            ? Futures.immediateFuture(Resolved.empty())
+                            : delegate.resolveIds(additionalChannelGroupsToResolve, refreshCache);
 
             return Futures.transform(additionalChannelGroupsFuture,
                     (Function<Resolved<ChannelGroup<?>>, Resolved<ChannelGroup<?>>>) additionalChannelGroups -> {
-                        ImmutableMap.Builder<Id, ChannelGroup<?>> additionalChannelGroupByIdMapBuilder
-                                = ImmutableMap.builder();
+                        ImmutableMap.Builder<Id, ChannelGroup<?>> additionalChannelGroupByIdMapBuilder =
+                                ImmutableMap.builder();
                         additionalChannelGroupByIdMapBuilder.putAll(channelGroupById);
                         for (ChannelGroup<?> channelGroup : additionalChannelGroups.getResources()) {
                             additionalChannelGroupByIdMapBuilder.put(channelGroup.getId(), channelGroup);
                         }
-                        ImmutableMap<Id, ChannelGroup<?>> additionalChannelGroupByIdMap
-                                = additionalChannelGroupByIdMapBuilder.build();
+                        ImmutableMap<Id, ChannelGroup<?>> additionalChannelGroupByIdMap =
+                                additionalChannelGroupByIdMapBuilder.build();
 
                         LocalDate now = LocalDate.now();
                         for (NumberedChannelGroup channelGroupToFillChannelNumbers : channelGroupsToFillChannelNumbers) {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
@@ -83,6 +83,10 @@ public class OutputChannelGroupResolver implements ChannelGroupResolver {
                     .map(ChannelGroupRef::getId)
                     .filter(id -> !channelGroupById.containsKey(id))
                     .collect(MoreCollectors.toImmutableSet());
+
+            if (additionalChannelGroupsToResolve.isEmpty()) {
+                return Futures.immediateFuture(Resolved.valueOf(channelGroups));
+            }
             ListenableFuture<Resolved<ChannelGroup<?>>> additionalChannelGroupsFuture
                     = delegate.resolveIds(additionalChannelGroupsToResolve, refreshCache);
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
@@ -10,6 +10,7 @@ import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.stream.MoreStreams;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.channel.ChannelNumbering;
 import org.atlasapi.channel.NumberedChannelGroup;
@@ -18,6 +19,7 @@ import org.atlasapi.entity.util.Resolved;
 import org.joda.time.LocalDate;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -73,7 +75,10 @@ public class OutputChannelGroupResolver implements ChannelGroupResolver {
                     channelGroupsToFillChannelNumbersBuilder.build();
 
             ImmutableSet<Id> additionalChannelGroupsToResolve = channelGroupsToFillChannelNumbers.stream()
-                    .map(ChannelGroup::getId)
+                    .map(NumberedChannelGroup::getChannelNumbersFrom)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(ChannelGroupRef::getId)
                     .filter(id -> !channelGroupById.containsKey(id))
                     .collect(MoreCollectors.toImmutableSet());
             ListenableFuture<Resolved<ChannelGroup<?>>> additionalChannelGroupsFuture

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolver.java
@@ -1,0 +1,160 @@
+package org.atlasapi.query.v4.schedule;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.stream.MoreStreams;
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelNumbering;
+import org.atlasapi.channel.NumberedChannelGroup;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.util.Resolved;
+import org.joda.time.LocalDate;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A ChannelGroupResolver which performs additional operations on a channel group after resolving when used in API
+ * output. For example to add channel numbers to channel groups with the "channelNumbersFrom" field set.
+ */
+public class OutputChannelGroupResolver implements ChannelGroupResolver {
+
+    private final ChannelGroupResolver delegate;
+
+    public OutputChannelGroupResolver(ChannelGroupResolver delegate) {
+        this.delegate = checkNotNull(delegate);
+    }
+
+    @Override
+    public ListenableFuture<Resolved<ChannelGroup<?>>> allChannels() {
+        return handleResult(delegate.allChannels(), false);
+    }
+
+    @Override
+    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveIds(Iterable<Id> ids) {
+        return handleResult(delegate.resolveIds(ids), false);
+    }
+
+    @Override
+    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveIds(Iterable<Id> ids, Boolean refreshCache) {
+        return handleResult(delegate.resolveIds(ids, refreshCache), refreshCache);
+    }
+
+    private ListenableFuture<Resolved<ChannelGroup<?>>> handleResult(
+            ListenableFuture<Resolved<ChannelGroup<?>>> delegateResult,
+            Boolean refreshCache
+    ) {
+        return Futures.transformAsync(delegateResult, result -> {
+            ImmutableMap.Builder<Id, ChannelGroup<?>> channelGroupByIdBuilder = ImmutableMap.builder();
+            ImmutableList.Builder<ChannelGroup<?>> channelGroupsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<NumberedChannelGroup> channelGroupsToFillChannelNumbersBuilder =
+                    ImmutableList.builder();
+            for (ChannelGroup<?> channelGroup : result.getResources()) {
+                channelGroupByIdBuilder.put(channelGroup.getId(), channelGroup);
+                channelGroupsBuilder.add(channelGroup);
+                if (channelGroup instanceof NumberedChannelGroup) {
+                    NumberedChannelGroup numberedChannelGroup = (NumberedChannelGroup) channelGroup;
+                    if (numberedChannelGroup.getChannelNumbersFrom().isPresent()) {
+                        channelGroupsToFillChannelNumbersBuilder.add(numberedChannelGroup);
+                    }
+                }
+            }
+            final ImmutableMap<Id, ChannelGroup<?>> channelGroupById = channelGroupByIdBuilder.build();
+            final ImmutableList<ChannelGroup<?>> channelGroups = channelGroupsBuilder.build();
+            final ImmutableList<NumberedChannelGroup> channelGroupsToFillChannelNumbers =
+                    channelGroupsToFillChannelNumbersBuilder.build();
+
+            ImmutableSet<Id> additionalChannelGroupsToResolve = channelGroupsToFillChannelNumbers.stream()
+                    .map(ChannelGroup::getId)
+                    .filter(id -> !channelGroupById.containsKey(id))
+                    .collect(MoreCollectors.toImmutableSet());
+            ListenableFuture<Resolved<ChannelGroup<?>>> additionalChannelGroupsFuture
+                    = delegate.resolveIds(additionalChannelGroupsToResolve, refreshCache);
+
+            return Futures.transform(additionalChannelGroupsFuture,
+                    (Function<Resolved<ChannelGroup<?>>, Resolved<ChannelGroup<?>>>) additionalChannelGroups -> {
+                        ImmutableMap.Builder<Id, ChannelGroup<?>> additionalChannelGroupByIdMapBuilder
+                                = ImmutableMap.builder();
+                        additionalChannelGroupByIdMapBuilder.putAll(channelGroupById);
+                        for (ChannelGroup<?> channelGroup : additionalChannelGroups.getResources()) {
+                            additionalChannelGroupByIdMapBuilder.put(channelGroup.getId(), channelGroup);
+                        }
+                        ImmutableMap<Id, ChannelGroup<?>> additionalChannelGroupByIdMap
+                                = additionalChannelGroupByIdMapBuilder.build();
+
+                        LocalDate now = LocalDate.now();
+                        for (NumberedChannelGroup channelGroupToFillChannelNumbers : channelGroupsToFillChannelNumbers) {
+                            addChannelNumbersToChannelGroup(
+                                    channelGroupToFillChannelNumbers,
+                                    additionalChannelGroupByIdMap,
+                                    now
+                            );
+                        }
+                        return Resolved.valueOf(channelGroups);
+
+                    });
+        });
+    }
+
+    private void addChannelNumbersToChannelGroup(
+            NumberedChannelGroup channelGroup,
+            Map<Id, ChannelGroup<?>> resolvedChannelGroups,
+            LocalDate now
+    ) {
+        if (!channelGroup.getChannelNumbersFrom().isPresent()) {
+            return;
+        }
+        ChannelGroup<?> baseChannelGroup = resolvedChannelGroups.get(
+                channelGroup.getChannelNumbersFrom().get().getId()
+        );
+        if (!(baseChannelGroup instanceof NumberedChannelGroup)) {
+            return;
+        }
+        NumberedChannelGroup baseNumberedChannelGroup = (NumberedChannelGroup) baseChannelGroup;
+        ImmutableSet.Builder<ChannelNumbering> newChannelNumberings = ImmutableSet.builder();
+        ImmutableMap<Id, ChannelNumbering> baseChannelNumberingsById =
+                MoreStreams.stream(baseNumberedChannelGroup.getChannels())
+                        .filter(channelGroupMembership -> channelGroupMembership.isAvailable(now))
+                        .collect(
+                                MoreCollectors.toImmutableMap(
+                                        channelGroupMembership -> channelGroupMembership.getChannel().getId(),
+                                        channelGroupMembership -> channelGroupMembership
+                                )
+                        );
+        for (ChannelNumbering channelNumbering : channelGroup.getChannels()) {
+            ChannelNumbering baseChannelNumbering =
+                    baseChannelNumberingsById.get(channelNumbering.getChannel().getId());
+            if (baseChannelNumbering == null) {
+                newChannelNumberings.add(channelNumbering);
+            } else {
+                ChannelGroupMembership.Builder newChannelNumbering = ChannelGroupMembership.builder(
+                        channelNumbering.getChannelGroup().getSource()
+                )
+                        .withChannelGroupId(channelNumbering.getChannelGroup().getId().longValue())
+                        .withChannelId(channelNumbering.getChannel().getId().longValue());
+
+                if (baseChannelNumbering.getChannelNumber().isPresent()) {
+                    newChannelNumbering.withChannelNumber(baseChannelNumbering.getChannelNumber().get());
+                }
+                if (baseChannelNumbering.getStartDate().isPresent()) {
+                    newChannelNumbering.withStartDate(baseChannelNumbering.getStartDate().get());
+                }
+                if (baseChannelNumbering.getEndDate().isPresent()) {
+                    newChannelNumbering.withEndDate(baseChannelNumbering.getEndDate().get());
+                }
+                newChannelNumberings.add(newChannelNumbering.buildChannelNumbering());
+            }
+        }
+        channelGroup.setChannels(newChannelNumberings.build());
+    }
+
+
+}

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolverTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolverTest.java
@@ -1,0 +1,445 @@
+package org.atlasapi.query.v4.schedule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ChannelGroupResolver;
+import org.atlasapi.channel.ChannelNumbering;
+import org.atlasapi.channel.Platform;
+import org.atlasapi.channel.Region;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.media.entity.Publisher;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OutputChannelGroupResolverTest {
+
+    private OutputChannelGroupResolver resolver;
+    private final ChannelGroupResolver delegateResolver = mock(ChannelGroupResolver.class);
+
+    @Before
+    public void setUp() throws Exception {
+        resolver = new OutputChannelGroupResolver(delegateResolver);
+    }
+
+    private ChannelNumbering channelNumbering(
+            long id,
+            long channelGroupId,
+            @Nullable String channelNumber
+    ) {
+        return channelNumbering(id, channelGroupId, channelNumber, null, null);
+    }
+
+    private ChannelNumbering channelNumberingWithExpiredAvailability(
+            long id,
+            long channelGroupId,
+            @Nullable String channelNumber
+    ) {
+        return channelNumbering(
+                id,
+                channelGroupId,
+                channelNumber,
+                LocalDate.now().minusDays(10),
+                LocalDate.now().minusDays(5)
+        );
+    }
+
+    private ChannelNumbering channelNumberingWithCurrentAvailability(
+            long id,
+            long channelGroupId,
+            @Nullable String channelNumber
+    ) {
+        return channelNumbering(
+                id,
+                channelGroupId,
+                channelNumber,
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(1)
+        );
+    }
+
+    private ChannelNumbering channelNumbering(
+            long id,
+            long channelGroupId,
+            @Nullable String channelNumber,
+            @Nullable LocalDate start,
+            @Nullable LocalDate end
+    ) {
+        ChannelNumbering.Builder channelNumbering = ChannelNumbering.builder(Publisher.METABROADCAST)
+                .withChannelId(id)
+                .withChannelGroupId(channelGroupId);
+        if (channelNumber != null) {
+            channelNumbering.withChannelNumber(channelNumber);
+        }
+        if (start != null) {
+            channelNumbering.withStartDate(start);
+        }
+        if (end != null) {
+            channelNumbering.withEndDate(end);
+        }
+        return channelNumbering.buildChannelNumbering();
+    }
+
+    private Platform platform(long id, Iterable<ChannelNumbering> channelNumberings, @Nullable Long channelNumbersFrom) {
+        Platform.Builder platform = Platform.builder(Publisher.METABROADCAST)
+                .withId(id)
+                .withChannels(channelNumberings);
+        if (channelNumbersFrom != null) {
+            platform.withChannelNumbersFromId(channelNumbersFrom);
+        }
+        return platform.build();
+    }
+
+    private Region region(long id, Iterable<ChannelNumbering> channelNumberings, @Nullable Long channelNumbersFrom) {
+        Region.Builder region = Region.builder(Publisher.METABROADCAST)
+                .withId(id)
+                .withChannels(channelNumberings);
+        if (channelNumbersFrom != null) {
+            region.withChannelNumbersFromId(channelNumbersFrom);
+        }
+        return region.build();
+    }
+
+    private void setUpResolving(ChannelGroup<?>... channelGroups) {
+        List<ChannelGroup<?>> channelGroupList = ImmutableList.copyOf(channelGroups);
+        Set<Id> ids = channelGroupList.stream()
+                .map(ChannelGroup::getId)
+                .collect(MoreCollectors.toImmutableSet());
+        when(delegateResolver.resolveIds(ids))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
+        when(delegateResolver.resolveIds(ids, false))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
+        when(delegateResolver.resolveIds(ids, true))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
+        when(delegateResolver.resolveIds(ids, null))
+                .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
+    }
+
+    private void assertChannelGroupEquals(ChannelGroup<?> expected, ChannelGroup<?> actual) {
+        assertEquals(expected.getClass(), actual.getClass());
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getType(), actual.getType());
+        assertEquals(expected.getSource(), actual.getSource());
+        assertChannelNumberingsEqual(expected.getChannels(), actual.getChannels());
+    }
+
+    private void assertChannelNumberingsEqual(
+            Iterable<? extends ChannelGroupMembership> expected,
+            Iterable<? extends ChannelGroupMembership> actual
+    ) {
+        assertEquals(Iterables.size(expected), Iterables.size(actual));
+        Iterator<? extends ChannelGroupMembership> expectedIt = expected.iterator();
+        Iterator<? extends ChannelGroupMembership> actualIt = actual.iterator();
+        while (expectedIt.hasNext() && actualIt.hasNext()) {
+            ChannelGroupMembership expectedMembership = expectedIt.next();
+            ChannelGroupMembership actualMembership = actualIt.next();
+            assertEquals(expectedMembership.getClass(), actualMembership.getClass());
+            assertEquals(expectedMembership.getChannel().getId(), actualMembership.getChannel().getId());
+            assertEquals(expectedMembership.getChannelGroup().getId(), actualMembership.getChannelGroup().getId());
+            assertEquals(expectedMembership.getStartDate(), actualMembership.getStartDate());
+            assertEquals(expectedMembership.getEndDate(), actualMembership.getEndDate());
+            if (expectedMembership instanceof ChannelNumbering && actualMembership instanceof ChannelNumbering) {
+                assertEquals(
+                        ((ChannelNumbering) expectedMembership).getChannelNumber(),
+                        ((ChannelNumbering) actualMembership).getChannelNumber()
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testNoChangeForRegularChannelGroup() {
+        long groupId = 1;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+
+        List<ChannelNumbering> numberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, channel1Number),
+                channelNumberingWithExpiredAvailability(channel2Id, groupId, channel3Number),
+                channelNumberingWithCurrentAvailability(channel2Id, groupId, channel2Number),
+                channelNumbering(channel3Id, groupId, null)
+        );
+
+        Platform platform = platform(groupId, numberings, null);
+
+        setUpResolving(platform);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        assertChannelGroupEquals(platform, resolvedGroup);
+    }
+
+    @Test
+    public void testChannelNumbersAreAddedForPlatforms() {
+        long groupId = 1;
+        long baseGroupId = 2;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        long channel4Id = 14;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+
+        List<ChannelNumbering> groupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, null),
+                channelNumbering(channel2Id, groupId, null),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        List<ChannelNumbering> baseGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, baseGroupId, channel1Number),
+                channelNumbering(channel2Id, baseGroupId, channel2Number),
+                channelNumbering(channel3Id, baseGroupId, channel3Number)
+        );
+
+        Platform platform = platform(groupId, groupNumberings, baseGroupId);
+        Platform basePlatform = platform(baseGroupId, baseGroupNumberings, null);
+
+        setUpResolving(platform);
+        setUpResolving(basePlatform);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        List<ChannelNumbering> expectedGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, channel1Number),
+                channelNumbering(channel2Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        Platform expected = platform(groupId, expectedGroupNumberings, baseGroupId);
+
+        assertChannelGroupEquals(expected, resolvedGroup);
+    }
+
+    @Test
+    public void testChannelNumbersAreAddedForRegions() {
+        long groupId = 1;
+        long baseGroupId = 2;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        long channel4Id = 14;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+
+        List<ChannelNumbering> groupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, null),
+                channelNumbering(channel2Id, groupId, null),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        List<ChannelNumbering> baseGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, baseGroupId, channel1Number),
+                channelNumbering(channel2Id, baseGroupId, channel2Number),
+                channelNumbering(channel3Id, baseGroupId, channel3Number)
+        );
+
+        Region region = region(groupId, groupNumberings, baseGroupId);
+        Region baseRegion = region(baseGroupId, baseGroupNumberings, null);
+
+        setUpResolving(region);
+        setUpResolving(baseRegion);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        List<ChannelNumbering> expectedGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, channel1Number),
+                channelNumbering(channel2Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        Region expected = region(groupId, expectedGroupNumberings, baseGroupId);
+
+        assertChannelGroupEquals(expected, resolvedGroup);
+    }
+
+    @Test
+    public void testChannelNumbersAreAddedForPlatformAndRegion() {
+        long groupId = 1;
+        long baseGroupId = 2;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        long channel4Id = 14;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+
+        List<ChannelNumbering> groupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, null),
+                channelNumbering(channel2Id, groupId, null),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        List<ChannelNumbering> baseGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, baseGroupId, channel1Number),
+                channelNumbering(channel2Id, baseGroupId, channel2Number),
+                channelNumbering(channel3Id, baseGroupId, channel3Number)
+        );
+
+        Platform platform = platform(groupId, groupNumberings, baseGroupId);
+        Region baseRegion = region(baseGroupId, baseGroupNumberings, null);
+
+        setUpResolving(platform);
+        setUpResolving(baseRegion);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        List<ChannelNumbering> expectedGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, channel1Number),
+                channelNumbering(channel2Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        Platform expected = platform(groupId, expectedGroupNumberings, baseGroupId);
+
+        assertChannelGroupEquals(expected, resolvedGroup);
+    }
+
+    @Test
+    public void testChannelNumbersAreAddedForRegionAndPlatform() {
+        long groupId = 1;
+        long baseGroupId = 2;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        long channel4Id = 14;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+
+        List<ChannelNumbering> groupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, null),
+                channelNumbering(channel2Id, groupId, null),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        List<ChannelNumbering> baseGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, baseGroupId, channel1Number),
+                channelNumbering(channel2Id, baseGroupId, channel2Number),
+                channelNumbering(channel3Id, baseGroupId, channel3Number)
+        );
+
+        Region region = region(groupId, groupNumberings, baseGroupId);
+        Platform basePlatform = platform(baseGroupId, baseGroupNumberings, null);
+
+        setUpResolving(region);
+        setUpResolving(basePlatform);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        List<ChannelNumbering> expectedGroupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, channel1Number),
+                channelNumbering(channel2Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        Region expected = region(groupId, expectedGroupNumberings, baseGroupId);
+
+        assertChannelGroupEquals(expected, resolvedGroup);
+    }
+
+    @Test
+    public void testExistingMembershipIsReplacedWhenChannelNumbersFromAnotherGroup() {
+        long groupId = 1;
+        long baseGroupId = 2;
+        long channel1Id = 11;
+        long channel2Id = 12;
+        long channel3Id = 13;
+        long channel4Id = 14;
+        String channel1Number = "1";
+        String channel2Number = "2";
+        String channel3Number = "3";
+        String channel4Number = "4";
+
+        List<ChannelNumbering> groupNumberings = ImmutableList.of(
+                channelNumbering(channel1Id, groupId, null),
+                channelNumberingWithExpiredAvailability(channel1Id, groupId, channel3Number),
+                channelNumbering(channel2Id, groupId, null),
+                channelNumberingWithExpiredAvailability(channel2Id, groupId, null),
+                channelNumberingWithExpiredAvailability(channel4Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, channel4Number)
+        );
+
+        List<ChannelNumbering> baseGroupNumberings = ImmutableList.of(
+                channelNumberingWithCurrentAvailability(channel1Id, baseGroupId, channel1Number),
+                channelNumbering(channel2Id, baseGroupId, channel2Number),
+                channelNumbering(channel3Id, baseGroupId, channel3Number)
+        );
+
+        Platform platform = platform(groupId, groupNumberings, baseGroupId);
+        Platform basePlatform = platform(baseGroupId, baseGroupNumberings, null);
+
+        setUpResolving(platform);
+        setUpResolving(basePlatform);
+
+        Resolved<ChannelGroup<?>> resolved = Futures.getUnchecked(
+                resolver.resolveIds(ImmutableSet.of(Id.valueOf(groupId)))
+        );
+
+        assertEquals(1, Iterables.size(resolved.getResources()));
+
+        ChannelGroup<?> resolvedGroup = Iterables.getOnlyElement(resolved.getResources());
+
+        List<ChannelNumbering> expectedGroupNumberings = ImmutableList.of(
+                channelNumberingWithCurrentAvailability(channel1Id, groupId, channel1Number),
+                channelNumbering(channel2Id, groupId, channel2Number),
+                channelNumbering(channel4Id, groupId, null)
+        );
+
+        Platform expected = platform(groupId, expectedGroupNumberings, baseGroupId);
+
+        assertChannelGroupEquals(expected, resolvedGroup);
+    }
+}

--- a/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
+++ b/atlas-core/src/main/java/org/atlasapi/annotation/Annotation.java
@@ -90,6 +90,7 @@ public enum Annotation {
     LOCATION_PROVIDERS,
     LCN_SHARING,    // enables fetching more than one channel per lcn (within a channel group)
     ALL_IMAGES,
+    BASE_CHANNEL_GROUPS,
     ;
 
     private static final ImmutableSet<Annotation> ALL = ImmutableSet.copyOf(values());

--- a/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
@@ -1,19 +1,17 @@
 package org.atlasapi.channel;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.intl.Country;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.Identified;
 import org.atlasapi.entity.Sourced;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.meta.annotations.FieldName;
-
-import com.metabroadcast.common.intl.Country;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.LocalDate;
+
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -1,18 +1,18 @@
 package org.atlasapi.channel;
 
+import com.metabroadcast.common.intl.Country;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.entity.Id;
+import org.atlasapi.media.channel.TemporalField;
+import org.atlasapi.media.entity.Publisher;
+import org.joda.time.LocalDate;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import org.atlasapi.entity.Id;
-import org.atlasapi.media.channel.TemporalField;
-import org.atlasapi.media.entity.Publisher;
-
-import com.metabroadcast.common.intl.Country;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import org.joda.time.LocalDate;
 
 public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering> {
 
@@ -20,14 +20,35 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
 
     private static final LocalDate EARLIEST_POSSIBLE_DATE = new LocalDate(0, 1, 1);
 
-    protected NumberedChannelGroup(Id id, Publisher publisher, Set<ChannelNumbering> channels,
-            Set<Country> availableCountries, Set<TemporalField<String>> titles) {
+    private final ChannelGroupRef channelNumbersFrom;
+
+    protected NumberedChannelGroup(
+            Id id,
+            Publisher publisher,
+            Set<ChannelNumbering> channels,
+            Set<Country> availableCountries,
+            Set<TemporalField<String>> titles,
+            @Nullable ChannelGroupRef channelNumbersFrom
+    ) {
         super(id, publisher, channels, availableCountries, titles);
+        this.channelNumbersFrom = channelNumbersFrom;
     }
 
-    protected NumberedChannelGroup(Id id, String canonicalUri, Publisher publisher, Set<ChannelNumbering> channels,
-            Set<Country> availableCountries, Set<TemporalField<String>> titles) {
+    protected NumberedChannelGroup(
+            Id id,
+            String canonicalUri,
+            Publisher publisher,
+            Set<ChannelNumbering> channels,
+            Set<Country> availableCountries,
+            Set<TemporalField<String>> titles,
+            @Nullable ChannelGroupRef channelNumbersFrom
+    ) {
         super(id, canonicalUri, publisher, channels, availableCountries, titles);
+        this.channelNumbersFrom = channelNumbersFrom;
+    }
+
+    public Optional<ChannelGroupRef> getChannelNumbersFrom() {
+        return Optional.ofNullable(channelNumbersFrom);
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
@@ -1,20 +1,17 @@
 package org.atlasapi.channel;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.intl.Country;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Publisher;
 
-import com.metabroadcast.common.intl.Country;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,9 +25,10 @@ public class Platform extends NumberedChannelGroup {
             Set<ChannelNumbering> channels,
             Set<Country> availableCountries,
             Set<TemporalField<String>> titles,
-            Set<ChannelGroupRef> regions
+            Set<ChannelGroupRef> regions,
+            ChannelGroupRef channelNumbersFrom
     ) {
-        super(id, publisher, channels, availableCountries, titles);
+        super(id, publisher, channels, availableCountries, titles, channelNumbersFrom);
         this.regions = ImmutableSet.copyOf(regions);
     }
 
@@ -41,9 +39,10 @@ public class Platform extends NumberedChannelGroup {
             Set<ChannelNumbering> channels,
             Set<Country> availableCountries,
             Set<TemporalField<String>> titles,
-            Set<ChannelGroupRef> regions
+            Set<ChannelGroupRef> regions,
+            ChannelGroupRef channelNumbersFrom
     ) {
-        super(id, canonicalUri, publisher, channels, availableCountries, titles);
+        super(id, canonicalUri, publisher, channels, availableCountries, titles, channelNumbersFrom);
         this.regions = ImmutableSet.copyOf(regions);
     }
 
@@ -70,6 +69,7 @@ public class Platform extends NumberedChannelGroup {
         private Set<TemporalField<String>> titles = Sets.newHashSet();
         private Set<Long> regionIds = Sets.newHashSet();
         private Set<Alias> aliases = Sets.newHashSet();
+        private ChannelGroupRef channelNumbersFromRef;
 
         public Builder(Publisher publisher) {
             this.publisher = checkNotNull(publisher);
@@ -110,6 +110,16 @@ public class Platform extends NumberedChannelGroup {
             return this;
         }
 
+        public Builder withChannelNumbersFromId(Long channelNumbersFromId) {
+            if (channelNumbersFromId != null) {
+                this.channelNumbersFromRef = new ChannelGroupRef(
+                        Id.valueOf(channelNumbersFromId),
+                        publisher
+                );
+            }
+            return this;
+        }
+
         public Platform build() {
             HashSet<ChannelGroupRef> regions = Sets.newHashSet(
                     Collections2.transform(
@@ -127,7 +137,8 @@ public class Platform extends NumberedChannelGroup {
                     channels,
                     availableCountries,
                     titles,
-                    regions
+                    regions,
+                    channelNumbersFromRef
             );
             platform.setAliases(ImmutableSet.copyOf(aliases));
 

--- a/atlas-core/src/main/java/org/atlasapi/channel/Region.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Region.java
@@ -1,17 +1,15 @@
 package org.atlasapi.channel;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.intl.Country;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Publisher;
 
-import com.metabroadcast.common.intl.Country;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,9 +24,10 @@ public class Region extends NumberedChannelGroup {
             Set<ChannelNumbering> channels,
             Set<Country> availableCountries,
             Set<TemporalField<String>> titles,
-            ChannelGroupRef platform
+            ChannelGroupRef platform,
+            ChannelGroupRef channelNumbersFrom
     ) {
-        super(id, canonicalUri, publisher, channels, availableCountries, titles);
+        super(id, canonicalUri, publisher, channels, availableCountries, titles, channelNumbersFrom);
         this.platform = platform;
     }
 
@@ -55,6 +54,7 @@ public class Region extends NumberedChannelGroup {
         private Set<TemporalField<String>> titles = Sets.newHashSet();
         private ChannelGroupRef platformRef;
         private Set<Alias> aliases = Sets.newHashSet();
+        private ChannelGroupRef channelNumbersFromRef;
 
         public Builder(Publisher publisher) {
             this.publisher = checkNotNull(publisher);
@@ -100,6 +100,16 @@ public class Region extends NumberedChannelGroup {
             return this;
         }
 
+        public Builder withChannelNumbersFromId(Long channelNumbersFromId) {
+            if (channelNumbersFromId != null) {
+                this.channelNumbersFromRef = new ChannelGroupRef(
+                        Id.valueOf(channelNumbersFromId),
+                        publisher
+                );
+            }
+            return this;
+        }
+
         public Region build() {
             Region region = new Region(
                     id,
@@ -108,7 +118,8 @@ public class Region extends NumberedChannelGroup {
                     channels,
                     availableCountries,
                     titles,
-                    platformRef
+                    platformRef,
+                    channelNumbersFromRef
             );
             region.setAliases(ImmutableSet.copyOf(aliases));
             return region;

--- a/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ResolvedChannelGroup.java
@@ -9,17 +9,20 @@ public class ResolvedChannelGroup {
     private final ChannelGroup<?> channelGroup;
     private final Optional<Iterable<ChannelGroup<?>>> regionChannelGroups;
     private final Optional<ChannelGroup<?>> platformChannelGroup;
+    private final Optional<ChannelGroup<?>> channelNumbersFromGroup;
     private final Optional<Iterable<ResolvedChannel>> channels;
 
     private ResolvedChannelGroup(
             ChannelGroup channelGroup,
             Optional<Iterable<ChannelGroup<?>>> regionChannelGroups,
             Optional<ChannelGroup<?>> platformChannelGroup,
+            Optional<ChannelGroup<?>> channelNumbersFromGroup,
             Optional<Iterable<ResolvedChannel>> channels
-            ) {
+    ) {
         this.channelGroup = checkNotNull(channelGroup);
         this.regionChannelGroups = checkNotNull(regionChannelGroups);
         this.platformChannelGroup = checkNotNull(platformChannelGroup);
+        this.channelNumbersFromGroup = checkNotNull(channelNumbersFromGroup);
         this.channels = checkNotNull(channels);
     }
 
@@ -39,6 +42,10 @@ public class ResolvedChannelGroup {
         return platformChannelGroup;
     }
 
+    public Optional<ChannelGroup<?>> getChannelNumbersFromGroup() {
+        return channelNumbersFromGroup;
+    }
+
     public Optional<Iterable<ResolvedChannel>> getChannels() {
         return channels;
     }
@@ -48,6 +55,7 @@ public class ResolvedChannelGroup {
         private final ChannelGroup<?> channelGroup;
         private Optional<Iterable<ChannelGroup<?>>> regionChannelGroups = Optional.empty();
         private Optional<ChannelGroup<?>> platformChannelGroup = Optional.empty();
+        private Optional<ChannelGroup<?>> channelNumbersFromGroup = Optional.empty();
         private Optional<Iterable<ResolvedChannel>> channels = Optional.empty();
 
         public Builder(ChannelGroup<?> channelGroup) {
@@ -64,6 +72,11 @@ public class ResolvedChannelGroup {
             return this;
         }
 
+        public Builder withChannelNumbersFromGroup(Optional<ChannelGroup<?>> channelNumbersFromGroup) {
+            this.channelNumbersFromGroup = channelNumbersFromGroup;
+            return this;
+        }
+
         public Builder withAdvertisedChannels(Optional<Iterable<ResolvedChannel>> channels) {
             this.channels = channels;
             return this;
@@ -74,6 +87,7 @@ public class ResolvedChannelGroup {
                     channelGroup,
                     regionChannelGroups,
                     platformChannelGroup,
+                    channelNumbersFromGroup,
                     channels
             );
         }

--- a/atlas-core/src/test/java/org/atlasapi/channel/NumberedChannelGroupTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/channel/NumberedChannelGroupTest.java
@@ -1,17 +1,15 @@
 package org.atlasapi.channel;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.intl.Country;
 import org.atlasapi.entity.Id;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Publisher;
-
-import com.metabroadcast.common.intl.Country;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.LocalDate;
 import org.junit.Test;
+
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
@@ -24,7 +22,7 @@ public class NumberedChannelGroupTest {
         protected TestNumberedChannelGroup(Id id, Publisher publisher,
                 Set<ChannelNumbering> channels, Set<Country> availableCountries,
                 Set<TemporalField<String>> titles) {
-            super(id, publisher, channels, availableCountries, titles);
+            super(id, publisher, channels, availableCountries, titles, null);
         }
     }
 

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.channel.Channel;
@@ -36,7 +35,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.longThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -286,7 +284,8 @@ public class BroadcastAggregatorTest {
                 ),
                 ImmutableSet.of(),
                 ImmutableSet.of(),
-                ImmutableSet.of()
+                ImmutableSet.of(),
+                null
         );
 
         Set<Broadcast> filteredBroadcasts = broadcastAggregator.removeBroadcastsNotOnPlatform(

--- a/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformer.java
+++ b/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformer.java
@@ -1,7 +1,6 @@
 package org.atlasapi.system.legacy;
 
-import java.util.Set;
-
+import com.google.common.collect.Iterables;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupMembership;
 import org.atlasapi.channel.ChannelNumbering;
@@ -9,7 +8,7 @@ import org.atlasapi.channel.Platform;
 import org.atlasapi.channel.Region;
 import org.atlasapi.media.entity.Publisher;
 
-import com.google.common.collect.Iterables;
+import java.util.Set;
 
 public class LegacyChannelGroupTransformer extends
         BaseLegacyResourceTransformer<org.atlasapi.media.channel.ChannelGroup, ChannelGroup<?>> {
@@ -33,13 +32,13 @@ public class LegacyChannelGroupTransformer extends
     @Override
     public ChannelGroup apply(org.atlasapi.media.channel.ChannelGroup input) {
         if (input instanceof org.atlasapi.media.channel.Platform) {
-            return transformService((org.atlasapi.media.channel.Platform) input);
+            return transformPlatform((org.atlasapi.media.channel.Platform) input);
         } else {
             return transformRegion((org.atlasapi.media.channel.Region) input);
         }
     }
 
-    private Platform transformService(org.atlasapi.media.channel.Platform input) {
+    private Platform transformPlatform(org.atlasapi.media.channel.Platform input) {
         return Platform.builder(input.getPublisher())
                 .withId(input.getId())
                 .withCanonicalUri(input.getCanonicalUri())
@@ -51,6 +50,7 @@ public class LegacyChannelGroupTransformer extends
                         input.getPublisher()
                 ))
                 .withAliases(transformAliases(input))
+                .withChannelNumbersFromId(input.getChannelNumbersFrom())
                 .build();
     }
 
@@ -66,6 +66,7 @@ public class LegacyChannelGroupTransformer extends
                         input.getPublisher()
                 ))
                 .withAliases(transformAliases(input))
+                .withChannelNumbersFromId(input.getChannelNumbersFrom())
                 .build();
     }
 }

--- a/atlas-legacy/src/test/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformerTest.java
+++ b/atlas-legacy/src/test/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformerTest.java
@@ -1,7 +1,9 @@
 package org.atlasapi.system.legacy;
 
-import java.util.Set;
-
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.intl.Country;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupRef;
 import org.atlasapi.channel.ChannelNumbering;
@@ -9,15 +11,11 @@ import org.atlasapi.channel.Platform;
 import org.atlasapi.channel.Region;
 import org.atlasapi.entity.Alias;
 import org.atlasapi.media.entity.Publisher;
-
-import com.metabroadcast.common.intl.Country;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import org.hamcrest.core.Is;
 import org.joda.time.LocalDate;
 import org.junit.Test;
+
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -43,6 +41,8 @@ public class LegacyChannelGroupTransformerTest {
         final Long channel2Id = 2L;
         final LocalDate startDate2 = new LocalDate("2014-01-03");
         final LocalDate endDate2 = new LocalDate("2014-01-04");
+
+        final Long channelNumbersFromId = 4L;
 
         Set<org.atlasapi.media.channel.ChannelNumbering> channelNumberings = ImmutableSet.of(
                 org.atlasapi.media.channel.ChannelNumbering.builder()
@@ -76,6 +76,7 @@ public class LegacyChannelGroupTransformerTest {
                         new org.atlasapi.media.entity.Alias("namespace2", "value2")
                 )
         );
+        legacyPlatform.setChannelNumbersFrom(channelNumbersFromId);
         ChannelGroup transformed = this.objectUnderTest.apply(legacyPlatform);
 
         assertThat(transformed.getId().longValue(), is(id));
@@ -151,6 +152,10 @@ public class LegacyChannelGroupTransformerTest {
                         )
                 )
         );
+        assertThat(
+                ((Platform) transformed).getChannelNumbersFrom().get().getId().longValue(),
+                is(channelNumbersFromId)
+        );
     }
 
     @Test
@@ -168,6 +173,8 @@ public class LegacyChannelGroupTransformerTest {
         final Long channel2Id = 2L;
         final LocalDate startDate2 = new LocalDate("2014-01-03");
         final LocalDate endDate2 = new LocalDate("2014-01-04");
+
+        final Long channelNumbersFromId = 4L;
 
         Set<org.atlasapi.media.channel.ChannelNumbering> channelNumberings = ImmutableSet.of(
                 org.atlasapi.media.channel.ChannelNumbering.builder()
@@ -200,6 +207,7 @@ public class LegacyChannelGroupTransformerTest {
                         new org.atlasapi.media.entity.Alias("namespace2", "value2")
                 )
         );
+        legacyRegion.setChannelNumbersFrom(channelNumbersFromId);
         ChannelGroup transformed = this.objectUnderTest.apply(legacyRegion);
 
         assertThat(transformed.getId().longValue(), is(id));
@@ -253,6 +261,10 @@ public class LegacyChannelGroupTransformerTest {
                                 new Alias("namespace2", "value2")
                         )
                 )
+        );
+        assertThat(
+                ((Region) transformed).getChannelNumbersFrom().get().getId().longValue(),
+                is(channelNumbersFromId)
         );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
       <dependency>
         <groupId>org.atlasapi</groupId>
         <artifactId>atlas-model</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -289,7 +289,7 @@
       <dependency>
         <groupId>org.atlasapi</groupId>
         <artifactId>atlas-persistence</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>${atlas.legacy.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
       <dependency>
         <groupId>org.atlasapi</groupId>
         <artifactId>atlas-model</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.1-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -289,7 +289,7 @@
       <dependency>
         <groupId>org.atlasapi</groupId>
         <artifactId>atlas-persistence</artifactId>
-        <version>${atlas.legacy.version}</version>
+        <version>5.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
* Added channelNumbersFrom field to NumberedChannelGroup

* Added a new ChannelGroupResolver used for API output which dynamically populates the channel numbers from the specified group when this field is set.

* Added a base_channel_groups annotation to expose this field in the API for use in the channel grouping frontend tool.