### PR TITLE
Fix platform annotation

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
@@ -1,7 +1,7 @@
 package org.atlasapi.output.annotation;
 
 import org.atlasapi.channel.ChannelGroup;
-import org.atlasapi.channel.Platform;
+import org.atlasapi.channel.Region;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
@@ -21,15 +21,15 @@ public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
     @Override
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        if (!(entity.getChannelGroup() instanceof Platform)) {
+        if (!(entity.getChannelGroup() instanceof Region)) {
             return;
         }
 
-        Optional<Iterable<ChannelGroup<?>>> channelGroups = entity.getRegionChannelGroups();
-        if (channelGroups.isPresent()) {
-            writer.writeList(CHANNEL_GROUP_WRITER, channelGroups.get(), ctxt);
+        Optional<ChannelGroup<?>> channelGroup = entity.getPlatformChannelGroup();
+        if (channelGroup.isPresent()) {
+            writer.writeObject(CHANNEL_GROUP_WRITER, channelGroup.get(), ctxt);
         } else {
-            throw new MissingResolvedDataException(CHANNEL_GROUP_WRITER.listName());
+            throw new MissingResolvedDataException(CHANNEL_GROUP_WRITER.fieldName(entity.getChannelGroup()));
         }
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/PlatformAnnotation.java
@@ -1,8 +1,5 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.Platform;
 import org.atlasapi.channel.ResolvedChannelGroup;
@@ -11,11 +8,14 @@ import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
 import org.atlasapi.query.common.exceptions.MissingResolvedDataException;
 
+import java.io.IOException;
+import java.util.Optional;
+
 public class PlatformAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
     private static final ChannelGroupWriter CHANNEL_GROUP_WRITER = new ChannelGroupWriter(
-            "regions",
-            "region"
+            "platforms",
+            "platform"
     );
 
     @Override

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/RegionsAnnotation.java
@@ -1,15 +1,15 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import org.atlasapi.channel.ChannelGroup;
-import org.atlasapi.channel.Region;
+import org.atlasapi.channel.Platform;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupWriter;
 import org.atlasapi.query.common.exceptions.MissingResolvedDataException;
+
+import java.io.IOException;
+import java.util.Optional;
 
 public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
 
@@ -21,15 +21,15 @@ public class RegionsAnnotation extends OutputAnnotation<ResolvedChannelGroup> {
     @Override
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
-        if (!(entity.getChannelGroup() instanceof Region)) {
+        if (!(entity.getChannelGroup() instanceof Platform)) {
             return;
         }
 
-        Optional<ChannelGroup<?>> channelGroup = entity.getPlatformChannelGroup();
-        if (channelGroup.isPresent()) {
-            writer.writeObject(CHANNEL_GROUP_WRITER, channelGroup.get(), ctxt);
+        Optional<Iterable<ChannelGroup<?>>> channelGroups = entity.getRegionChannelGroups();
+        if (channelGroups.isPresent()) {
+            writer.writeList(CHANNEL_GROUP_WRITER, channelGroups.get(), ctxt);
         } else {
-            throw new MissingResolvedDataException("missing regions for channel group");
+            throw new MissingResolvedDataException(CHANNEL_GROUP_WRITER.listName());
         }
 
     }

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -690,8 +690,8 @@ public class QueryWebModule {
                         CHANNEL_GROUP
                 )
                 .register(ID_SUMMARY, ChannelGroupIdSummaryAnnotation.create(idSummaryWriter))
-                .register(REGIONS, new PlatformAnnotation(), CHANNEL_GROUP)
-                .register(PLATFORM, new RegionsAnnotation(), CHANNEL_GROUP)
+                .register(PLATFORM, new PlatformAnnotation(), CHANNEL_GROUP)
+                .register(REGIONS, new RegionsAnnotation(), CHANNEL_GROUP)
                 .register(
                         CHANNEL_GROUPS_SUMMARY,
                         NullWriter.create(ResolvedChannelGroup.class),

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -385,7 +385,13 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
             return Optional.empty();
         }
 
-        Id platformId = ((Region) entity).getPlatform().getId();
+        Region region = (Region) entity;
+
+        if (!region.getPlatform().isPresent()) {
+            return Optional.empty();
+        }
+
+        Id platformId = region.getPlatform().get().getId();
 
         return Optional.ofNullable(Promise.wrap(channelGroupResolver.resolveIds(ImmutableSet.of(platformId)))
                 .then(Resolved::getResources)

--- a/atlas-core/src/main/java/org/atlasapi/channel/Region.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Region.java
@@ -9,6 +9,7 @@ import org.atlasapi.entity.Id;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Publisher;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -31,8 +32,8 @@ public class Region extends NumberedChannelGroup {
         this.platform = platform;
     }
 
-    public ChannelGroupRef getPlatform() {
-        return platform;
+    public Optional<ChannelGroupRef> getPlatform() {
+        return Optional.ofNullable(platform);
     }
 
     public static Builder builder(Publisher publisher) {

--- a/atlas-legacy/src/test/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformerTest.java
+++ b/atlas-legacy/src/test/java/org/atlasapi/system/legacy/LegacyChannelGroupTransformerTest.java
@@ -212,7 +212,7 @@ public class LegacyChannelGroupTransformerTest {
 
         assertThat(transformed.getId().longValue(), is(id));
         assertThat(transformed.getSource(), is(publisher));
-        assertThat(((Region) transformed).getPlatform().getId().longValue(), is(platformId));
+        assertThat(((Region) transformed).getPlatform().get().getId().longValue(), is(platformId));
 
         assertThat(
                 Iterables.any(


### PR DESCRIPTION
Allow platform field to be nullable since it can be in Owl and since YouView JSON regions do not have a platform.

Make platform and region annotation use match the class of the same name, switching class behaviour as appropriate.