### PR TITLE
Channel and channel group endpoint improvements

### DIFF
--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupAdvertisedChannelsAnnotation.java
@@ -1,12 +1,14 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.NumberedChannelGroup;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.attribute.Attributes;
@@ -16,14 +18,13 @@ import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.ResolvedChannelWithChannelGroupMembership;
 import org.atlasapi.query.common.exceptions.MissingResolvedDataException;
 import org.atlasapi.query.v4.channelgroup.ChannelGroupChannelWriter;
-
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import org.joda.time.LocalDate;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -67,8 +68,12 @@ public class ChannelGroupAdvertisedChannelsAnnotation extends OutputAnnotation<R
             }
         } else {
             boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
-            for (ChannelGroupMembership channelGroupMembership :
-                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)) {
+            Set<? extends ChannelGroupMembership> availableChannels =
+                    entity.getChannelGroup() instanceof NumberedChannelGroup ?
+                            ((NumberedChannelGroup) entity.getChannelGroup())
+                                    .getChannelsAvailable(LocalDate.now(), lcnSharing) :
+                            entity.getChannelGroup().getChannelsAvailable(LocalDate.now());
+            for (ChannelGroupMembership channelGroupMembership : availableChannels) {
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelIdsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelIdsAnnotation.java
@@ -1,16 +1,16 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.NumberedChannelGroup;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.output.FieldWriter;
 import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.writers.ChannelGroupChannelIdsWriter;
-
-import com.google.common.collect.ImmutableList;
 import org.joda.time.LocalDate;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,9 +26,12 @@ public class ChannelGroupChannelIdsAnnotation extends OutputAnnotation<ResolvedC
     public void write(ResolvedChannelGroup entity, FieldWriter writer, OutputContext ctxt)
             throws IOException {
         boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
-        ImmutableList<ChannelGroupMembership> channels = ImmutableList.copyOf(
-                entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)
+        ImmutableList<ChannelGroupMembership> availableChannels = ImmutableList.copyOf(
+                entity.getChannelGroup() instanceof NumberedChannelGroup ?
+                        ((NumberedChannelGroup) entity.getChannelGroup())
+                                .getChannelsAvailable(LocalDate.now(), lcnSharing)
+                        : entity.getChannelGroup().getChannelsAvailable(LocalDate.now())
         );
-        writer.writeList(channelIdsWriter, channels, ctxt);
+        writer.writeList(channelIdsWriter, availableChannels, ctxt);
     }
 }

--- a/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
+++ b/atlas-api/src/main/java/org/atlasapi/output/annotation/ChannelGroupChannelsAnnotation.java
@@ -1,12 +1,14 @@
 package org.atlasapi.output.annotation;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.atlasapi.annotation.Annotation;
 import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.NumberedChannelGroup;
 import org.atlasapi.channel.ResolvedChannel;
 import org.atlasapi.channel.ResolvedChannelGroup;
 import org.atlasapi.criteria.attribute.Attributes;
@@ -16,14 +18,13 @@ import org.atlasapi.output.OutputContext;
 import org.atlasapi.output.ResolvedChannelWithChannelGroupMembership;
 import org.atlasapi.query.common.exceptions.MissingResolvedDataException;
 import org.atlasapi.query.v4.channelgroup.ChannelGroupChannelWriter;
-
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import org.joda.time.LocalDate;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -69,8 +70,12 @@ public class ChannelGroupChannelsAnnotation extends OutputAnnotation<ResolvedCha
             }
         } else {
             boolean lcnSharing = ctxt.getActiveAnnotations().contains(Annotation.LCN_SHARING);
-            for (ChannelGroupMembership channelGroupMembership :
-                    entity.getChannelGroup().getChannelsAvailable(LocalDate.now(), lcnSharing)) {
+            Set<? extends ChannelGroupMembership> availableChannels =
+                    entity.getChannelGroup() instanceof NumberedChannelGroup ?
+                            ((NumberedChannelGroup) entity.getChannelGroup())
+                                    .getChannelsAvailable(LocalDate.now(), lcnSharing) :
+                            entity.getChannelGroup().getChannelsAvailable(LocalDate.now());
+            for (ChannelGroupMembership channelGroupMembership : availableChannels) {
                 builder.put(channelGroupMembership.getChannel().getId(), channelGroupMembership);
             }
         }

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -770,7 +770,7 @@ public class QueryWebModule {
                                 EnumCoercer.create(Sources.fromKey())
                         ),
                         QueryAtomParser.create(
-                                Attributes.REFRESH_CACHE,
+                                Attributes.CHANNEL_GROUP_REFRESH_CACHE,
                                 StringCoercer.create()
                         ),
                         QueryAtomParser.create(

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -813,6 +813,10 @@ public class QueryWebModule {
                                 EnumCoercer.create(Sources.fromKey())
                         ),
                         QueryAtomParser.create(
+                                Attributes.SOURCE,
+                                EnumCoercer.create(Sources.fromKey())
+                        ),
+                        QueryAtomParser.create(
                                 Attributes.BROADCASTER,
                                 EnumCoercer.create(Sources.fromKey())
                         ),

--- a/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -770,7 +770,7 @@ public class QueryWebModule {
                                 EnumCoercer.create(Sources.fromKey())
                         ),
                         QueryAtomParser.create(
-                                Attributes.CHANNEL_GROUP_REFRESH_CACHE,
+                                Attributes.REFRESH_CACHE,
                                 StringCoercer.create()
                         ),
                         QueryAtomParser.create(

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -141,7 +141,6 @@ public class ChannelQueryExecutor implements QueryExecutor<ResolvedChannel> {
                                 attributeValue.toString().toUpperCase()
                         )
                 );
-                ordering = ordering(attributeValue.toString());
             } else if (Attributes.ORDER_BY.externalName().equals(attributeName)) {
                 ordering = ordering(attributeValue.toString());
             } else if (Attributes.ADVERTISED_ON.externalName().equals(attributeName)) {

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -146,13 +146,6 @@ public class ChannelQueryExecutor implements QueryExecutor<ResolvedChannel> {
                 ordering = ordering(attributeValue.toString());
             } else if (Attributes.ADVERTISED_ON.externalName().equals(attributeName)) {
                 channelQueryBuilder.withAdvertisedOn(DateTime.now(DateTimeZone.UTC));
-            } else {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Incorrect query string parameter: %s",
-                                attributeQuery.getAttributeName()
-                        )
-                );
             }
         }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channel/ChannelQueryExecutor.java
@@ -97,10 +97,22 @@ public class ChannelQueryExecutor implements QueryExecutor<ResolvedChannel> {
                                 );
                             }
 
+                            Channel channel = input.getResources().first().get();
+
+                            if (!query.getContext()
+                                    .getApplication()
+                                    .getConfiguration()
+                                    .isReadEnabled(channel.getSource())
+                            ) {
+                                throw new UncheckedQueryExecutionException(
+                                        new NotFoundException(query.getOnlyId())
+                                );
+                            }
+
                             ResolvedChannel resolvedChannel =
                                     resolveAnnotationData(
                                             query.getContext(),
-                                            input.getResources().first().get()
+                                            channel
                                     );
 
                             return QueryResult.singleResult(

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -299,7 +299,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         return QueryResult.listResult(
                 channelGroupsResults,
                 query.getContext(),
-                channelGroupsResults.size()
+                filteredChannelGroups.size()
         );
     }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -99,6 +99,16 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                                     .first()
                                     .get();
 
+                            if (!query.getContext()
+                                    .getApplication()
+                                    .getConfiguration()
+                                    .isReadEnabled(channelGroup.getSource())
+                            ) {
+                                throw new UncheckedQueryExecutionException(
+                                        new NotFoundException(query.getOnlyId())
+                                );
+                            }
+
                             NumberedChannelGroup.ChannelOrdering channelOrdering =
                                     NumberedChannelGroup.ChannelOrdering.CHANNEL_NUMBER;
                             Set<Id> dttIds = null;

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -619,24 +619,4 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         return !(channelGroupMembership instanceof ChannelNumbering);
     }
 
-    private static class FilteredChannelGroupsAndOrdering {
-        private final Iterable<ChannelGroup<?>> channelGroups;
-        private final NumberedChannelGroup.ChannelOrdering channelOrdering;
-
-        public FilteredChannelGroupsAndOrdering(
-                Iterable<ChannelGroup<?>> channelGroups,
-                NumberedChannelGroup.ChannelOrdering channelOrdering
-        ) {
-            this.channelGroups = channelGroups;
-            this.channelOrdering = channelOrdering;
-        }
-
-        public Iterable<ChannelGroup<?>> getChannelGroups() {
-            return channelGroups;
-        }
-
-        public NumberedChannelGroup.ChannelOrdering getChannelOrdering() {
-            return channelOrdering;
-        }
-    }
 }

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -84,7 +84,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                                 ImmutableSet.of(query.getOnlyId()),
                                 Boolean.parseBoolean(
                                         query.getContext().getRequest().getParameter(
-                                                Attributes.REFRESH_CACHE.externalName()
+                                                Attributes.CHANNEL_GROUP_REFRESH_CACHE.externalName()
                                         )
                                 )
                         ),
@@ -239,7 +239,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
             } else if (Attributes.CHANNEL_GROUP_TYPE.externalName().equals(attributeName)) {
                 complexQuery = true;
                 channelGroupQueryBuilder.withTypes((List<String>) attributeValue);
-            } else if (Attributes.REFRESH_CACHE.externalName().equals(attributeName)) {
+            } else if (Attributes.CHANNEL_GROUP_REFRESH_CACHE.externalName().equals(attributeName)) {
                 refreshCache = Boolean.parseBoolean(attributeValue.toString());
             } else if (attributeName.equals(Attributes.CHANNEL_GROUP_DTT_CHANNELS.externalName())) {
                 Set<Id> newDttIds = ImmutableSet.copyOf((List<Id>) attributeValue);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -256,13 +256,6 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                                     NumberedChannelGroup.ChannelOrdering.names() + ")"
                     );
                 }
-            } else {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Incorrect query string parameter: %s",
-                                attributeQuery.getAttributeName()
-                        )
-                );
             }
         }
 

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutor.java
@@ -214,7 +214,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
     ) throws QueryExecutionException {
 
         ChannelGroupQuery.Builder channelGroupQueryBuilder = ChannelGroupQuery.builder();
-        boolean simpleIdsQuery = true;
+        boolean complexQuery = false; // Anything that doesn't require just querying for ids
         boolean refreshCache = false;
         Set<Id> channelGroupIds = null;
         NumberedChannelGroup.ChannelOrdering channelOrdering = NumberedChannelGroup.ChannelOrdering.CHANNEL_NUMBER;
@@ -234,10 +234,10 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
                                 .collect(MoreCollectors.toImmutableSet())
                 );
             } else if (Attributes.SOURCE.externalName().equals(attributeName)) {
-                simpleIdsQuery = false;
+                complexQuery = true;
                 channelGroupQueryBuilder.withPublishers((List<Publisher>) attributeValue);
             } else if (Attributes.CHANNEL_GROUP_TYPE.externalName().equals(attributeName)) {
-                simpleIdsQuery = false;
+                complexQuery = true;
                 channelGroupQueryBuilder.withTypes((List<String>) attributeValue);
             } else if (Attributes.REFRESH_CACHE.externalName().equals(attributeName)) {
                 refreshCache = Boolean.parseBoolean(attributeValue.toString());
@@ -262,7 +262,7 @@ public class ChannelGroupQueryExecutor implements QueryExecutor<ResolvedChannelG
         ChannelGroupQuery channelGroupQuery = channelGroupQueryBuilder.build();
         ListenableFuture<Resolved<ChannelGroup<?>>> resolvedChannelGroupsFuture;
 
-        if (channelGroupIds != null && simpleIdsQuery) {
+        if (channelGroupIds != null && !complexQuery) {
             resolvedChannelGroupsFuture = channelGroupResolver.resolveIds(channelGroupIds, refreshCache);
         } else {
             resolvedChannelGroupsFuture = channelGroupResolver.resolveChannelGroups(channelGroupQuery);

--- a/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/NoOpChannelGroupResolver.java
+++ b/atlas-api/src/main/java/org/atlasapi/query/v4/schedule/NoOpChannelGroupResolver.java
@@ -1,22 +1,27 @@
 package org.atlasapi.query.v4.schedule;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
-
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
+import org.atlasapi.media.channel.ChannelGroupQuery;
 
 public class NoOpChannelGroupResolver implements ChannelGroupResolver {
 
     @Override
-    public ListenableFuture<Resolved<ChannelGroup<?>>> allChannels() {
+    public ListenableFuture<Resolved<ChannelGroup<?>>> allChannelGroups() {
         return Futures.immediateFuture(Resolved.empty());
     }
 
     @Override
     public ListenableFuture<Resolved<ChannelGroup<?>>> resolveIds(Iterable<Id> ids) {
+        return Futures.immediateFuture(Resolved.empty());
+    }
+
+    @Override
+    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveChannelGroups(ChannelGroupQuery channelGroupQuery) {
         return Futures.immediateFuture(Resolved.empty());
     }
 }

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channel/ChannelQueryExecutorTest.java
@@ -1,7 +1,14 @@
 package org.atlasapi.query.v4.channel;
 
-import javax.servlet.http.HttpServletRequest;
-
+import com.google.api.client.util.Sets;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
+import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupMembership;
@@ -25,17 +32,6 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.query.common.Query;
 import org.atlasapi.query.common.QueryResult;
 import org.atlasapi.query.common.context.QueryContext;
-
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
-import com.metabroadcast.common.query.Selection;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.api.client.util.Sets;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.Futures;
 import org.bouncycastle.util.Iterable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +39,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -65,14 +63,6 @@ public class ChannelQueryExecutorTest {
     @InjectMocks
     private ChannelQueryExecutor objectUnderTest;
 
-    @Mock
-    private Application application = mock(Application.class);
-
-    private ApplicationConfiguration appConf = ApplicationConfiguration.builder()
-            .withNoPrecedence(ImmutableList.of())
-            .withEnabledWriteSources(ImmutableList.of())
-            .build();
-
     @Test
     public void testExecuteSingle() throws Exception {
         Id channelId = Id.valueOf(1L);
@@ -80,10 +70,14 @@ public class ChannelQueryExecutorTest {
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannel> channelQuery = mock(Query.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
+        Application application = mock(Application.class);
+        ApplicationConfiguration configuration = mock(ApplicationConfiguration.class);
         when(request.getParameter("annotations")).thenReturn("banana");
         when(context.getRequest()).thenReturn(request);
+        when(configuration.isReadEnabled(any(Publisher.class))).thenReturn(true);
+        when(configuration.isPrecedenceEnabled()).thenReturn(false);
+        when(application.getConfiguration()).thenReturn(configuration);
         when(context.getApplication()).thenReturn(application);
-        when(application.getConfiguration()).thenReturn(appConf);
         when(channelQuery.isListQuery()).thenReturn(false);
         when(channelQuery.getOnlyId()).thenReturn(channelId);
         when(channelQuery.getContext()).thenReturn(context);
@@ -150,14 +144,18 @@ public class ChannelQueryExecutorTest {
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannel> channelQuery = mock(Query.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
+        Application application = mock(Application.class);
+        ApplicationConfiguration configuration = mock(ApplicationConfiguration.class);
 
         Id channelId = Id.valueOf(1L);
         Id parentId = Id.valueOf(2L);
 
         when(request.getParameter("annotations")).thenReturn("parent");
+        when(configuration.isReadEnabled(any(Publisher.class))).thenReturn(true);
+        when(configuration.isPrecedenceEnabled()).thenReturn(false);
+        when(application.getConfiguration()).thenReturn(configuration);
         when(context.getRequest()).thenReturn(request);
         when(context.getApplication()).thenReturn(application);
-        when(application.getConfiguration()).thenReturn(appConf);
 
         when(parentRef.getId()).thenReturn(parentId);
         when(result.getParent()).thenReturn(parentRef);

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -3,7 +3,6 @@ package org.atlasapi.query.v4.channelgroup;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.metabroadcast.applications.client.model.internal.Application;
@@ -24,6 +23,7 @@ import org.atlasapi.criteria.AttributeQuery;
 import org.atlasapi.criteria.attribute.Attribute;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.media.channel.ChannelGroupQuery;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.query.common.Query;
 import org.atlasapi.query.common.QueryResult;
@@ -101,11 +101,9 @@ public class ChannelGroupQueryExecutorTest {
     public void testExecuteMulti() throws Exception {
         ChannelGroup result = mock(ChannelGroup.class);
         ChannelGroup result2 = mock(ChannelGroup.class);
-        ChannelGroup result3 = mock(ChannelGroup.class);
 
         when(result.getType()).thenReturn("platform");
-        when(result2.getType()).thenReturn("region");
-        when(result3.getType()).thenReturn("platform");
+        when(result2.getType()).thenReturn("platform");
 
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
@@ -139,10 +137,14 @@ public class ChannelGroupQueryExecutorTest {
 
         when(application.getTitle()).thenReturn("nana");
 
-        when(channelGroupResolver.allChannels())
+        when(channelGroupResolver.resolveChannelGroups(
+                ChannelGroupQuery.builder()
+                        .withTypes(ImmutableSet.of("platform"))
+                        .build()
+        ))
                 .thenReturn(
                         Futures.immediateFuture(
-                                Resolved.valueOf(ImmutableSet.of(result, result2, result3))
+                                Resolved.valueOf(ImmutableSet.of(result, result2))
                         )
                 );
 
@@ -154,7 +156,7 @@ public class ChannelGroupQueryExecutorTest {
                 .stream()
                 .map(ResolvedChannelGroup::getChannelGroup)
                 .collect(Collectors.toList()),
-                containsInAnyOrder(result, result3));
+                containsInAnyOrder(result, result2));
     }
 
     @Test
@@ -229,8 +231,7 @@ public class ChannelGroupQueryExecutorTest {
     @Test
     public void testMultipleChannelGroupsAreFullyResolvedByAnnotations() throws Exception {
         Platform testChannelGroup = mock(Platform.class);
-        ChannelGroup testChannelGroup2 = mock(ChannelGroup.class);
-        Platform testChannelGroup3 = mock(Platform.class);
+        Platform testChannelGroup2 = mock(Platform.class);
         Channel channel = mock(Channel.class);
         Channel channel2 = mock(Channel.class);
         ChannelGroup regionChannelGroup = mock(ChannelGroup.class);
@@ -247,7 +248,7 @@ public class ChannelGroupQueryExecutorTest {
         when(testChannelGroupRef.getId()).thenReturn(channelGroupId);
         testChannelGroupRefSet.add(testChannelGroupRef);
         when(testChannelGroup.getRegions()).thenReturn(testChannelGroupRefSet);
-        when(testChannelGroup3.getRegions()).thenReturn(testChannelGroupRefSet);
+        when(testChannelGroup2.getRegions()).thenReturn(testChannelGroupRefSet);
 
 
         when(channel.getId()).thenReturn(channelId);
@@ -261,11 +262,11 @@ public class ChannelGroupQueryExecutorTest {
 
         when(channelNumbering.getChannel()).thenReturn(channelRef);
         when(channelNumbering2.getChannel()).thenReturn(channelRef2);
-        Iterable<ChannelNumbering> channels = Lists.newArrayList(channelNumbering, channelNumbering2);
+        Set<ChannelNumbering> channels = ImmutableSet.of(channelNumbering, channelNumbering2);
 
         when(testChannelGroup.getChannelsAvailable(any(LocalDate.class)))
             .thenReturn(channels);
-        when(testChannelGroup3.getChannelsAvailable(any(LocalDate.class)))
+        when(testChannelGroup2.getChannelsAvailable(any(LocalDate.class)))
             .thenReturn(channels);
         when(testChannelGroup.getChannelsAvailable(
                 any(LocalDate.class),
@@ -273,7 +274,7 @@ public class ChannelGroupQueryExecutorTest {
                 anyBoolean())
         )
                 .thenReturn(channels);
-        when(testChannelGroup3.getChannelsAvailable(
+        when(testChannelGroup2.getChannelsAvailable(
                 any(LocalDate.class),
                 any(NumberedChannelGroup.ChannelOrdering.class),
                 anyBoolean())
@@ -281,8 +282,7 @@ public class ChannelGroupQueryExecutorTest {
                 .thenReturn(channels);
 
         when(testChannelGroup.getType()).thenReturn("platform");
-        when(testChannelGroup2.getType()).thenReturn("region");
-        when(testChannelGroup3.getType()).thenReturn("platform");
+        when(testChannelGroup2.getType()).thenReturn("platform");
 
         QueryContext context = mock(QueryContext.class);
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
@@ -315,10 +315,14 @@ public class ChannelGroupQueryExecutorTest {
 
         when(channelQuery.getOperands()).thenReturn(attributeQueries);
 
-        when(channelGroupResolver.allChannels())
+        when(channelGroupResolver.resolveChannelGroups(
+                ChannelGroupQuery.builder()
+                        .withTypes(ImmutableSet.of("platform"))
+                        .build()
+        ))
                 .thenReturn(
                         Futures.immediateFuture(
-                                Resolved.valueOf(ImmutableSet.of(testChannelGroup, testChannelGroup2, testChannelGroup3))
+                                Resolved.valueOf(ImmutableSet.of(testChannelGroup, testChannelGroup2))
                         )
                 );
 

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/channelgroup/ChannelGroupQueryExecutorTest.java
@@ -71,9 +71,12 @@ public class ChannelGroupQueryExecutorTest {
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
         Application application = mock(Application.class);
+        ApplicationConfiguration configuration = mock(ApplicationConfiguration.class);
 
         when(request.getParameter("annotations")).thenReturn("banana");
 
+        when(configuration.isReadEnabled(any(Publisher.class))).thenReturn(true);
+        when(application.getConfiguration()).thenReturn(configuration);
         when(context.getRequest()).thenReturn(request);
         when(context.getApplication()).thenReturn(application);
         when(context.getApplication().getTitle()).thenReturn("");
@@ -170,11 +173,15 @@ public class ChannelGroupQueryExecutorTest {
         Query<ResolvedChannelGroup> channelQuery = mock(Query.class);
         ChannelGroupRef regionChannelGroupRef = mock(ChannelGroupRef.class);
         Application application = mock(Application.class);
+        ApplicationConfiguration configuration = mock(ApplicationConfiguration.class);
+
         Set<ChannelGroupRef> regionChannelGroupRefSet = new HashSet<>();
         Id channelGroupId = Id.valueOf(1L);
         Id regionChannelGroupId = Id.valueOf(2L);
 
         when(request.getParameter("annotations")).thenReturn("regions");
+        when(configuration.isReadEnabled(any(Publisher.class))).thenReturn(true);
+        when(application.getConfiguration()).thenReturn(configuration);
         when(context.getRequest()).thenReturn(request);
         when(context.getApplication()).thenReturn(application);
         when(context.getApplication().getTitle()).thenReturn("");

--- a/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolverTest.java
+++ b/atlas-api/src/test/java/org/atlasapi/query/v4/schedule/OutputChannelGroupResolverTest.java
@@ -129,8 +129,6 @@ public class OutputChannelGroupResolverTest {
                 .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
         when(delegateResolver.resolveIds(ids, true))
                 .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
-        when(delegateResolver.resolveIds(ids, null))
-                .thenReturn(Futures.immediateFuture(Resolved.valueOf(channelGroupList)));
     }
 
     private void assertChannelGroupEquals(ChannelGroup<?> expected, ChannelGroup<?> actual) {

--- a/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
@@ -53,7 +53,7 @@ public class ChannelGroup<T extends ChannelGroupMembership> extends Identified i
 
 
     public ChannelGroup<T> copyWithChannels(Iterable<T> channels) {
-        return new ChannelGroup<>(
+        ChannelGroup<T> copy = new ChannelGroup<>(
                 getId(),
                 getCanonicalUri(),
                 this.publisher,
@@ -61,6 +61,8 @@ public class ChannelGroup<T extends ChannelGroupMembership> extends Identified i
                 this.availableCountries,
                 this.titles
         );
+        copy.setAliases(getAliases());
+        return copy;
     }
 
     @Override

--- a/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroup.java
@@ -17,17 +17,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ChannelGroup<T extends ChannelGroupMembership> extends Identified implements Sourced {
 
-    private final Publisher publisher;
-    private Set<T> channels;
-    private final ImmutableSet<Country> availableCountries;
-    private final ImmutableSet<TemporalField<String>> titles;
+    protected final Publisher publisher;
+    protected final ImmutableSet<T> channels;
+    protected final ImmutableSet<Country> availableCountries;
+    protected final ImmutableSet<TemporalField<String>> titles;
 
     public ChannelGroup(
             Id id,
             Publisher publisher,
-            Set<T> channels,
-            Set<Country> availableCountries,
-            Set<TemporalField<String>> titles
+            Iterable<T> channels,
+            Iterable<Country> availableCountries,
+            Iterable<TemporalField<String>> titles
     ) {
         super(id);
         this.channels = ImmutableSet.copyOf(channels);
@@ -40,9 +40,9 @@ public class ChannelGroup<T extends ChannelGroupMembership> extends Identified i
             Id id,
             String canonicalUri,
             Publisher publisher,
-            Set<T> channels,
-            Set<Country> availableCountries,
-            Set<TemporalField<String>> titles
+            Iterable<T> channels,
+            Iterable<Country> availableCountries,
+            Iterable<TemporalField<String>> titles
     ) {
         super(Identified.builder().withId(id).withCanonicalUri(canonicalUri));
         this.channels = ImmutableSet.copyOf(channels);
@@ -51,25 +51,29 @@ public class ChannelGroup<T extends ChannelGroupMembership> extends Identified i
         this.publisher = checkNotNull(publisher);
     }
 
+
+    public ChannelGroup<T> copyWithChannels(Iterable<T> channels) {
+        return new ChannelGroup<>(
+                getId(),
+                getCanonicalUri(),
+                this.publisher,
+                channels,
+                this.availableCountries,
+                this.titles
+        );
+    }
+
     @Override
     @FieldName("source")
     public Publisher getSource() {
         return publisher;
     }
 
-    public Iterable<T> getChannels() {
+    public Set<T> getChannels() {
         return channels;
     }
 
-    public void setChannels(Set<T> channels) {
-        this.channels = channels;
-    }
-
-    public Iterable<T> getChannelsAvailable(LocalDate date) {
-        return getChannelsAvailable(date, false);
-    }
-
-    public Iterable<T> getChannelsAvailable(LocalDate date, boolean lcnSharing) {
+    public Set<T> getChannelsAvailable(LocalDate date) {
         return channels.stream()
                 .filter(ch -> ch.isAvailable(date))
                 .collect(MoreCollectors.toImmutableSet());

--- a/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroupResolver.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/ChannelGroupResolver.java
@@ -1,11 +1,13 @@
 package org.atlasapi.channel;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import org.atlasapi.entity.IdResolver;
 import org.atlasapi.entity.util.Resolved;
-
-import com.google.common.util.concurrent.ListenableFuture;
+import org.atlasapi.media.channel.ChannelGroupQuery;
 
 public interface ChannelGroupResolver extends IdResolver<ChannelGroup<?>> {
 
-    ListenableFuture<Resolved<ChannelGroup<?>>> allChannels();
+    ListenableFuture<Resolved<ChannelGroup<?>>> allChannelGroups();
+
+    ListenableFuture<Resolved<ChannelGroup<?>>> resolveChannelGroups(ChannelGroupQuery channelGroupQuery);
 }

--- a/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/NumberedChannelGroup.java
@@ -128,14 +128,16 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
             ChannelOrdering ordering,
             boolean lcnSharing
     ) {
+        Set<ChannelNumbering> availableChannels = super.getChannelsAvailable(date);
+
         // normally within a channel group, we expect/want only channel per channel number AKA lcn.
         // with lcnSharing = true (via annotation), we allow more than one to be served.
         if (lcnSharing) {
             switch (ordering) {
                 case SPECIFIED:
-                    return super.getChannelsAvailable(date);
+                    return availableChannels;
                 case CHANNEL_NUMBER:
-                    return super.getChannelsAvailable(date).stream()
+                    return availableChannels.stream()
                             .sorted(CHANNEL_NUMBERING_ORDERING)
                             .collect(MoreCollectors.toImmutableSet());
                 default:
@@ -143,8 +145,7 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
             }
         }
 
-
-        Set<ChannelNumbering> deduplicatedChannelNumberingsWithChannelNumber = super.getChannelsAvailable(date).stream()
+        Set<ChannelNumbering> deduplicatedChannelNumberingsWithChannelNumber = availableChannels.stream()
                 .filter(channelNumbering -> channelNumbering.getChannelNumber().isPresent())
                 .collect(Collectors.groupingBy(channelNumbering -> channelNumbering.getChannelNumber().get()))
                 .values()
@@ -154,7 +155,7 @@ public abstract class NumberedChannelGroup extends ChannelGroup<ChannelNumbering
                 )
                 .collect(MoreCollectors.toImmutableSet());
 
-        Stream<ChannelNumbering> deduplicatedChannelNumberings = super.getChannelsAvailable(date).stream()
+        Stream<ChannelNumbering> deduplicatedChannelNumberings = availableChannels.stream()
                 .filter(channelNumbering -> !channelNumbering.getChannelNumber().isPresent()
                         // this is using reference equality to work
                         || deduplicatedChannelNumberingsWithChannelNumber.contains(channelNumbering)

--- a/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
@@ -22,10 +22,10 @@ public class Platform extends NumberedChannelGroup {
     public Platform(
             Id id,
             Publisher publisher,
-            Set<ChannelNumbering> channels,
-            Set<Country> availableCountries,
-            Set<TemporalField<String>> titles,
-            Set<ChannelGroupRef> regions,
+            Iterable<ChannelNumbering> channels,
+            Iterable<Country> availableCountries,
+            Iterable<TemporalField<String>> titles,
+            Iterable<ChannelGroupRef> regions,
             ChannelGroupRef channelNumbersFrom
     ) {
         super(id, publisher, channels, availableCountries, titles, channelNumbersFrom);
@@ -36,14 +36,28 @@ public class Platform extends NumberedChannelGroup {
             Id id,
             String canonicalUri,
             Publisher publisher,
-            Set<ChannelNumbering> channels,
-            Set<Country> availableCountries,
-            Set<TemporalField<String>> titles,
-            Set<ChannelGroupRef> regions,
+            Iterable<ChannelNumbering> channels,
+            Iterable<Country> availableCountries,
+            Iterable<TemporalField<String>> titles,
+            Iterable<ChannelGroupRef> regions,
             ChannelGroupRef channelNumbersFrom
     ) {
         super(id, canonicalUri, publisher, channels, availableCountries, titles, channelNumbersFrom);
         this.regions = ImmutableSet.copyOf(regions);
+    }
+
+    @Override
+    public ChannelGroup<ChannelNumbering> copyWithChannels(Iterable<ChannelNumbering> channels) {
+        return new Platform(
+                getId(),
+                getCanonicalUri(),
+                this.publisher,
+                channels,
+                this.availableCountries,
+                this.titles,
+                this.regions,
+                this.channelNumbersFrom
+        );
     }
 
     public Set<ChannelGroupRef> getRegions() {

--- a/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Platform.java
@@ -48,7 +48,7 @@ public class Platform extends NumberedChannelGroup {
 
     @Override
     public ChannelGroup<ChannelNumbering> copyWithChannels(Iterable<ChannelNumbering> channels) {
-        return new Platform(
+        Platform copy = new Platform(
                 getId(),
                 getCanonicalUri(),
                 this.publisher,
@@ -58,6 +58,8 @@ public class Platform extends NumberedChannelGroup {
                 this.regions,
                 this.channelNumbersFrom
         );
+        copy.setAliases(getAliases());
+        return copy;
     }
 
     public Set<ChannelGroupRef> getRegions() {

--- a/atlas-core/src/main/java/org/atlasapi/channel/Region.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Region.java
@@ -22,14 +22,28 @@ public class Region extends NumberedChannelGroup {
             Id id,
             String canonicalUri,
             Publisher publisher,
-            Set<ChannelNumbering> channels,
-            Set<Country> availableCountries,
-            Set<TemporalField<String>> titles,
+            Iterable<ChannelNumbering> channels,
+            Iterable<Country> availableCountries,
+            Iterable<TemporalField<String>> titles,
             ChannelGroupRef platform,
             ChannelGroupRef channelNumbersFrom
     ) {
         super(id, canonicalUri, publisher, channels, availableCountries, titles, channelNumbersFrom);
         this.platform = platform;
+    }
+
+    @Override
+    public ChannelGroup<ChannelNumbering> copyWithChannels(Iterable<ChannelNumbering> channels) {
+        return new Region(
+                getId(),
+                getCanonicalUri(),
+                this.publisher,
+                channels,
+                this.availableCountries,
+                this.titles,
+                this.platform,
+                this.channelNumbersFrom
+        );
     }
 
     public Optional<ChannelGroupRef> getPlatform() {

--- a/atlas-core/src/main/java/org/atlasapi/channel/Region.java
+++ b/atlas-core/src/main/java/org/atlasapi/channel/Region.java
@@ -34,7 +34,7 @@ public class Region extends NumberedChannelGroup {
 
     @Override
     public ChannelGroup<ChannelNumbering> copyWithChannels(Iterable<ChannelNumbering> channels) {
-        return new Region(
+        Region copy = new Region(
                 getId(),
                 getCanonicalUri(),
                 this.publisher,
@@ -44,6 +44,8 @@ public class Region extends NumberedChannelGroup {
                 this.platform,
                 this.channelNumbersFrom
         );
+        copy.setAliases(getAliases());
+        return copy;
     }
 
     public Optional<ChannelGroupRef> getPlatform() {

--- a/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/BroadcastAggregator.java
@@ -1,31 +1,5 @@
 package org.atlasapi.content;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import javax.annotation.Nullable;
-
-import org.atlasapi.channel.Channel;
-import org.atlasapi.channel.ChannelGroupMembership;
-import org.atlasapi.channel.ChannelRef;
-import org.atlasapi.channel.ChannelResolver;
-import org.atlasapi.channel.Platform;
-import org.atlasapi.channel.ResolvedChannel;
-import org.atlasapi.entity.Id;
-import org.atlasapi.entity.ResourceRef;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -39,11 +13,34 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.channel.Channel;
+import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.ChannelRef;
+import org.atlasapi.channel.ChannelResolver;
+import org.atlasapi.channel.Platform;
+import org.atlasapi.channel.ResolvedChannel;
+import org.atlasapi.entity.Id;
+import org.atlasapi.entity.ResourceRef;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeComparator;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class BroadcastAggregator {
 
@@ -350,12 +347,12 @@ public class BroadcastAggregator {
 
         List<Id> platformsIds = Lists.newArrayList();
         platformsOptional.ifPresent(platforms -> platforms.forEach(
-                platform -> platformsIds.addAll(StreamSupport.stream(
-                        platform.getChannels().spliterator(),
-                        false
+                platform -> platformsIds.addAll(
+                        platform.getChannels()
+                                .stream()
+                                .map(channelNumbering -> channelNumbering.getChannel().getId())
+                                .collect(MoreCollectors.toImmutableList())
                 )
-                        .map(channelNumbering -> channelNumbering.getChannel().getId())
-                        .collect(MoreCollectors.toImmutableList()))
         ));
 
         return parent.getVariations().stream()

--- a/atlas-core/src/main/java/org/atlasapi/content/ChannelsBroadcastFilter.java
+++ b/atlas-core/src/main/java/org/atlasapi/content/ChannelsBroadcastFilter.java
@@ -1,18 +1,19 @@
 package org.atlasapi.content;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import org.atlasapi.channel.ChannelGroup;
-import org.atlasapi.entity.Id;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.channel.ChannelGroup;
+import org.atlasapi.channel.ChannelGroupMembership;
+import org.atlasapi.channel.NumberedChannelGroup;
+import org.atlasapi.entity.Id;
 import org.joda.time.LocalDate;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class ChannelsBroadcastFilter {
 
@@ -32,10 +33,11 @@ public class ChannelsBroadcastFilter {
             return ImmutableList.of();
         }
 
-        ImmutableList<Id> channelIds = StreamSupport.stream(
-                channelGroup.getChannelsAvailable(LocalDate.now(), lcnSharing).spliterator(),
-                false
-        )
+        Set<? extends ChannelGroupMembership> availableChannels = channelGroup instanceof NumberedChannelGroup
+                ? ((NumberedChannelGroup) channelGroup).getChannelsAvailable(LocalDate.now(), lcnSharing)
+                : channelGroup.getChannelsAvailable(LocalDate.now());
+
+        ImmutableList<Id> channelIds = availableChannels.stream()
                 .map(channel -> channel.getChannel().getId())
                 .distinct()
                 .collect(MoreCollectors.toImmutableList());

--- a/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
+++ b/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
@@ -165,46 +165,36 @@ public class Attributes {
             Identified.class
     );
 
-    // For Channels
-    public static final String BROADCASTER_PARAM = "broadcaster";
-    public static final String AVAILABLE_FROM_PARAM = "available_from";
-    public static final String MEDIA_TYPE_PARAM = "media_type";
-    public static final String ORDER_BY_PARAM = "order_by";
-    public static final String ADVERTISED_FROM_PARAM = "advertised";
-    public static final String ALIASES_NAMESPACE_PARAM = "aliases.namespace";
-    public static final String ALIASES_VALUE_PARAM = "aliases.value";
-    public static final String REFRESH_CACHE_PARAM = "refresh_cache";
-
     public static final Attribute<Boolean> ADVERTISED_ON = BooleanAttribute.single(
-            ADVERTISED_FROM_PARAM,
+            "advertised",
             Identified.class
     );
     public static final Attribute<Publisher> BROADCASTER = EnumAttribute.list(
-            BROADCASTER_PARAM,
+            "broadcaster",
             Publisher.class,
             Identified.class
     );
     public static final Attribute<Publisher> AVAILABLE_FROM = EnumAttribute.list(
-            AVAILABLE_FROM_PARAM,
+            "available_from",
             Publisher.class,
             Identified.class
     );
     public static final Attribute<MediaType> MEDIA_TYPE = EnumAttribute.single(
-            MEDIA_TYPE_PARAM,
+            "media_type",
             MediaType.class,
             Identified.class
     );
     public static final Attribute<String> ORDER_BY_CHANNEL = StringAttribute.single(
-            ORDER_BY_PARAM,
+            "order_by",
             Channel.class
     );
 
     public static final Attribute<String> REFRESH_CACHE = StringAttribute.single(
-            REFRESH_CACHE_PARAM,
+            "refresh_cache",
             Channel.class
     );
     public static final Attribute<String> CHANNEL_GROUP_REFRESH_CACHE = StringAttribute.single(
-            REFRESH_CACHE_PARAM,
+            "refresh_cache",
             ChannelGroup.class
     );
 

--- a/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
+++ b/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
@@ -193,10 +193,6 @@ public class Attributes {
             "refresh_cache",
             Channel.class
     );
-    public static final Attribute<String> CHANNEL_GROUP_REFRESH_CACHE = StringAttribute.single(
-            "refresh_cache",
-            ChannelGroup.class
-    );
 
     // For filtering
     public static final Attribute<String> CONTENT_TITLE_PREFIX = StringAttribute.single(

--- a/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
+++ b/atlas-core/src/main/java/org/atlasapi/criteria/attribute/Attributes.java
@@ -194,6 +194,11 @@ public class Attributes {
             Channel.class
     );
 
+    public static final Attribute<String> CHANNEL_GROUP_REFRESH_CACHE = StringAttribute.single(
+            "refresh_cache",
+            ChannelGroup.class
+    );
+
     // For filtering
     public static final Attribute<String> CONTENT_TITLE_PREFIX = StringAttribute.single(
             "title",

--- a/atlas-core/src/main/java/org/atlasapi/entity/IdResolver.java
+++ b/atlas-core/src/main/java/org/atlasapi/entity/IdResolver.java
@@ -1,14 +1,13 @@
 package org.atlasapi.entity;
 
-import org.atlasapi.entity.util.Resolved;
-
 import com.google.common.util.concurrent.ListenableFuture;
+import org.atlasapi.entity.util.Resolved;
 
 public interface IdResolver<I extends Identifiable> {
 
     ListenableFuture<Resolved<I>> resolveIds(Iterable<Id> ids);
 
-    default ListenableFuture<Resolved<I>> resolveIds(Iterable<Id> ids, Boolean refreshCache) {
+    default ListenableFuture<Resolved<I>> resolveIds(Iterable<Id> ids, boolean refreshCache) {
         return resolveIds(ids);
     }
 

--- a/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
+++ b/atlas-core/src/test/java/org/atlasapi/content/BroadcastAggregatorTest.java
@@ -360,7 +360,7 @@ public class BroadcastAggregatorTest {
         ChannelRef channelRef = new ChannelRef(Id.valueOf(444L), Publisher.METABROADCAST);
 
         when(channelNumbering.getChannel()).thenReturn(channelRef);
-        when(platform.getChannels()).thenReturn(ImmutableList.of(channelNumbering));
+        when(platform.getChannels()).thenReturn(ImmutableSet.of(channelNumbering));
 
         List<ChannelVariantRef> excludedRefs = broadcastAggregator.resolveExcludedVariantRefs(
                 variantRefParent,

--- a/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelGroupResolver.java
+++ b/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelGroupResolver.java
@@ -1,17 +1,16 @@
 package org.atlasapi.system.legacy;
 
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.atlasapi.channel.ChannelGroup;
 import org.atlasapi.channel.ChannelGroupResolver;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
+import org.atlasapi.media.channel.ChannelGroupQuery;
 
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
+import java.util.Objects;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,7 +28,7 @@ public class LegacyChannelGroupResolver implements ChannelGroupResolver {
     }
 
     @Override
-    public ListenableFuture<Resolved<ChannelGroup<?>>> allChannels() {
+    public ListenableFuture<Resolved<ChannelGroup<?>>> allChannelGroups() {
         Iterable<org.atlasapi.media.channel.ChannelGroup> resolved = legacyResolver.channelGroups();
         Iterable<ChannelGroup<?>> transformed = transformer.transform(resolved);
         return Futures.immediateFuture(Resolved.valueOf(transformed));
@@ -45,8 +44,8 @@ public class LegacyChannelGroupResolver implements ChannelGroupResolver {
     }
 
     @Override
-    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveIds(Iterable<Id> ids, Boolean refreshCache) {
-        if (refreshCache != null && refreshCache) {
+    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveIds(Iterable<Id> ids, boolean refreshCache) {
+        if (refreshCache) {
             StreamSupport.stream(ids.spliterator(), false)
                     .map(Id.toLongValue()::apply)
                     .filter(Objects::nonNull)
@@ -54,5 +53,14 @@ public class LegacyChannelGroupResolver implements ChannelGroupResolver {
         }
 
         return resolveIds(ids);
+    }
+
+    @Override
+    public ListenableFuture<Resolved<ChannelGroup<?>>> resolveChannelGroups(ChannelGroupQuery channelGroupQuery) {
+        Iterable<org.atlasapi.media.channel.ChannelGroup> resolvedChannels = legacyResolver.channelGroupsFor(
+                channelGroupQuery
+        );
+        Iterable<ChannelGroup<?>> transformed = transformer.transform(resolvedChannels);
+        return Futures.immediateFuture(Resolved.valueOf(transformed));
     }
 }

--- a/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelResolver.java
+++ b/atlas-legacy/src/main/java/org/atlasapi/system/legacy/LegacyChannelResolver.java
@@ -1,16 +1,13 @@
 package org.atlasapi.system.legacy;
 
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.atlasapi.channel.Channel;
 import org.atlasapi.channel.ChannelResolver;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.util.Resolved;
 import org.atlasapi.media.channel.ChannelQuery;
-
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-
-import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +34,8 @@ public class LegacyChannelResolver implements ChannelResolver {
     }
 
     @Override
-    public ListenableFuture<Resolved<Channel>> resolveIds(Iterable<Id> ids, @Nullable Boolean refreshCache) {
-        if (refreshCache != null && refreshCache) {
+    public ListenableFuture<Resolved<Channel>> resolveIds(Iterable<Id> ids, boolean refreshCache) {
+        if (refreshCache) {
             legacyResolver.refreshCache();
         }
         return resolveIds(ids);


### PR DESCRIPTION
* Improve resolving efficiency of channel group endpoint by adding filtering within the resolve step instead of resolving all groups and then filtering

* Removed a setter on the channel group class and replaced with a copy method to avoid possible side-effects when filtering channels in the channel group endpoint due to caching

* Fixed a possible bug with selections on channel groups when the selection would happen before a further filtering step

* Return correct results count in channel group endpoint

* Throw exceptions when requesting single id in channel and channel group endpoints if no read access

* Expose resource not found error in channel and channel group endpoints to match content endpoint behaviour

* Removed nonsensical lcnSharing boolean from a method on ChannelGroup

* Added source query param to channels endpoint

* Minor code cleanup