### PR TITLE
Make force migration endpoint also force equiv updates

### DIFF
--- a/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphStore.java
+++ b/atlas-core/src/main/java/org/atlasapi/equivalence/EquivalenceGraphStore.java
@@ -1,16 +1,14 @@
 package org.atlasapi.equivalence;
 
-import java.util.Set;
-
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.metabroadcast.common.collect.OptionalMap;
 import org.atlasapi.entity.Id;
 import org.atlasapi.entity.ResourceRef;
 import org.atlasapi.entity.util.WriteException;
 import org.atlasapi.media.entity.Publisher;
 
-import com.metabroadcast.common.collect.OptionalMap;
-
-import com.google.common.base.Optional;
-import com.google.common.util.concurrent.ListenableFuture;
+import java.util.Set;
 
 /**
  * <p> Records equivalences between resources. </p>
@@ -43,6 +41,12 @@ public interface EquivalenceGraphStore {
      */
     Optional<EquivalenceGraphUpdate> updateEquivalences(ResourceRef subject,
             Set<ResourceRef> assertedAdjacents, Set<Publisher> sources) throws WriteException;
+
+    Optional<EquivalenceGraphUpdate> forceUpdateEquivalences(
+            ResourceRef subject,
+            Set<ResourceRef> assertedAdjacents,
+            Set<Publisher> sources
+    ) throws WriteException;
 
     ListenableFuture<OptionalMap<Id, EquivalenceGraph>> resolveIds(Iterable<Id> ids);
 

--- a/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
+++ b/atlas-processing/src/main/java/org/atlasapi/system/bootstrap/ContentBootstrapListener.java
@@ -1,12 +1,14 @@
 package org.atlasapi.system.bootstrap;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-
-import javax.annotation.Nullable;
-
+import com.google.api.client.util.Lists;
+import com.google.api.client.util.Maps;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.metabroadcast.common.collect.OptionalMap;
 import org.atlasapi.content.Brand;
 import org.atlasapi.content.Container;
 import org.atlasapi.content.Content;
@@ -28,19 +30,14 @@ import org.atlasapi.segment.SegmentEvent;
 import org.atlasapi.system.bootstrap.workers.DirectAndExplicitEquivalenceMigrator;
 import org.atlasapi.system.legacy.LegacySegmentMigrator;
 import org.atlasapi.system.legacy.UnresolvedLegacySegmentException;
-
-import com.metabroadcast.common.collect.OptionalMap;
-
-import com.google.api.client.util.Lists;
-import com.google.api.client.util.Maps;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -238,8 +235,7 @@ public class ContentBootstrapListener
             stringBuilder.append(writeResult.written() ? "DONE, " : "UNCHANGED, ");
 
             stringBuilder.append("Equivalence Graph: ");
-            Optional<EquivalenceGraphUpdate> graphUpdate =
-                    equivalenceMigrator.migrateEquivalence(content.toRef());
+            Optional<EquivalenceGraphUpdate> graphUpdate = updateEquivalenceGraph(content);
             stringBuilder.append(graphUpdate.isPresent() ? "DONE, " : "UNCHANGED, ");
 
             equivalentContentStore.updateContent(content.getId());
@@ -261,6 +257,14 @@ public class ContentBootstrapListener
             return contentWriter.forceWriteContent(content);
         } else {
             return contentWriter.writeContent(content);
+        }
+    }
+
+    private Optional<EquivalenceGraphUpdate> updateEquivalenceGraph(Content content) {
+        if (forceWrite) {
+            return equivalenceMigrator.forceMigrateEquivalence(content.toRef());
+        } else {
+            return equivalenceMigrator.migrateEquivalence(content.toRef());
         }
     }
 


### PR DESCRIPTION
In addition to forcing content updates.

It has been observed that outgoing equiv links do not always end up as incoming equiv links on the corresponding piece of content when equivs are migrated. This endpoint allows us to fix such cases as we discover them until the root cause is solved.